### PR TITLE
test(e2e): two-layer E2E testing strategy (OpenAPI round-trip + WireMock)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -85,6 +85,27 @@ python ./tools/tests.py --short --e2e
 
 Requires Docker. Spins up a WireMock container that serves stubs derived from
 the committed OpenAPI spec at `tests/_openapi/fixtures/nextlabs-openapi.json`.
+The full E2E suite runs in about 25 seconds on top of the ~18 second unit run.
+
+### Troubleshooting
+
+- **`docker: command not found` or Docker socket unavailable:** E2E tests are
+  automatically skipped when Docker is not reachable. Inside the dev container
+  make sure the Docker-in-Docker feature is enabled (see *Docker from inside
+  the dev container* above).
+- **Tests hang at WireMock startup / connection refused:** when running from
+  inside a container the host-mapped port is not routable. The fixtures
+  resolve the WireMock container's internal IP via `docker inspect` and talk
+  to it on port 8080 directly — verify Docker network reachability with
+  `docker network ls` and `docker inspect <container>`.
+- **Corporate proxy breaks requests to WireMock:** the conftest clears
+  `HTTP(S)_PROXY` before each test because httpx's `NO_PROXY` does not
+  understand CIDR ranges. If you see unexpected proxy traffic, confirm the
+  clearing logic in `tests/e2e/conftest.py` still fires.
+- **`nextlabs: command not found` in CLI tests:** the subprocess fixtures
+  inherit the full `os.environ` so the installed entry point is found via
+  user site-packages. If you override `PATH`/`HOME` in a custom fixture you
+  must keep them pointed at the same Python environment.
 
 ### Regenerating the OpenAPI fixture
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,3 +76,25 @@ For non-Docker deployments:
 ```bash
 ./tools/setup_bare_metal.sh
 ```
+
+## E2E Tests
+
+```bash
+python ./tools/tests.py --short --e2e
+```
+
+Requires Docker. Spins up a WireMock container that serves stubs derived from
+the committed OpenAPI spec at `tests/_openapi/fixtures/nextlabs-openapi.json`.
+
+### Regenerating the OpenAPI fixture
+
+The vendor spec is committed so the test suite stays hermetic. To refresh:
+
+```bash
+python tools/fetch_openapi_spec.py
+```
+
+This writes the latest spec to
+`tests/_openapi/fixtures/nextlabs-openapi.json`. Review the diff, run the test
+suite (including `--e2e`), fix any new round-trip or model-registry failures,
+then commit. The helper refuses to run in CI.

--- a/tests/_openapi/__init__.py
+++ b/tests/_openapi/__init__.py
@@ -1,0 +1,1 @@
+"""Test-only helpers for loading and walking the vendor OpenAPI spec."""

--- a/tests/_openapi/allowlist.py
+++ b/tests/_openapi/allowlist.py
@@ -1,0 +1,16 @@
+"""Vendor examples that are genuinely malformed and cannot be parsed.
+
+Each entry must carry a comment naming the spec path and the reason. Keep
+this list short; a growing list indicates the normalizer or the registry
+needs attention rather than a waiver.
+"""
+
+from __future__ import annotations
+
+# Format: (path, method, status)
+KNOWN_UNPARSEABLE: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        # Populated during Task 6 after running the round-trip suite and
+        # triaging each failure. Empty on purpose.
+    },
+)

--- a/tests/_openapi/allowlist.py
+++ b/tests/_openapi/allowlist.py
@@ -1,16 +1,238 @@
-"""Vendor examples that are genuinely malformed and cannot be parsed.
+"""Allowlist of ``(path, method, status)`` triples that cannot round-trip.
 
-Each entry must carry a comment naming the spec path and the reason. Keep
-this list short; a growing list indicates the normalizer or the registry
-needs attention rather than a waiver.
+Each triple is tagged with a reason so regressions in the round-trip
+suite stay honest: when the SDK gains a model or the spec fixture is
+refreshed with valid JSON, the corresponding entry must be removed.
+
+Categories
+----------
+
+* ``INVALID_JSON_EXAMPLES`` — the vendor spec's example body is not
+  parseable JSON (unquoted strings, trailing commas, etc.). Nothing the
+  SDK can do here; the fix is upstream or in the fixture. These stay
+  xfailed until the spec is corrected.
+* ``MISSING_MODEL`` — the SDK does not (yet) expose a dedicated Pydantic
+  response model for this endpoint. The round-trip suite cannot assert
+  a contract on it. Removing the entry is the signal that a model has
+  been added; wire it up in :mod:`tests._openapi.model_registry` at the
+  same time.
 """
 
 from __future__ import annotations
 
-# Format: (path, method, status)
-KNOWN_UNPARSEABLE: frozenset[tuple[str, str, str]] = frozenset(
-    {
-        # Populated during Task 6 after running the round-trip suite and
-        # triaging each failure. Empty on purpose.
-    },
+INVALID_JSON_EXAMPLES: frozenset[tuple[str, str, str]] = frozenset(
+    (
+        ("/console/api/v1/component/mgmt/bulkDelete", "delete", "200"),
+        ("/console/api/v1/component/mgmt/deploy", "post", "200"),
+        ("/console/api/v1/component/mgmt/findDependencies", "post", "200"),
+        ("/console/api/v1/component/mgmt/remove/{id}", "delete", "200"),
+        ("/console/api/v1/component/mgmt/unDeploy", "post", "200"),
+        ("/console/api/v1/component/search/remove/{id}", "delete", "200"),
+        ("/console/api/v1/config/dataType/list", "get", "200"),
+        ("/console/api/v1/config/tags/remove/{id}", "delete", "200"),
+        ("/console/api/v1/policy/mgmt/bulkDelete", "delete", "200"),
+        (
+            "/console/api/v1/policy/mgmt/bulkDeleteXacmlPolicy",
+            "delete",
+            "200",
+        ),
+        ("/console/api/v1/policy/mgmt/deploy", "post", "200"),
+        (
+            "/console/api/v1/policy/mgmt/obligation/daeValidate",
+            "post",
+            "200",
+        ),
+        ("/console/api/v1/policy/mgmt/remove/{id}", "delete", "200"),
+        ("/console/api/v1/policy/mgmt/unDeploy", "post", "200"),
+        ("/console/api/v1/policy/search/remove/{id}", "delete", "200"),
+        ("/console/api/v1/policyModel/mgmt/active/{id}", "get", "200"),
+        ("/console/api/v1/policyModel/mgmt/bulkDelete", "delete", "200"),
+        (
+            "/console/api/v1/policyModel/mgmt/extraSubjectAttribs/{type}",
+            "get",
+            "200",
+        ),
+        ("/console/api/v1/policyModel/mgmt/remove/{id}", "delete", "200"),
+        ("/console/api/v1/policyModel/mgmt/{id}", "get", "200"),
+        ("/console/api/v1/policyModel/search/remove/{id}", "delete", "200"),
+        ("/console/scim/v2/Bulk", "post", "200"),
+    ),
+)
+
+
+MISSING_MODEL: frozenset[tuple[str, str, str]] = frozenset(
+    (
+        ("/console/api/v1/component/mgmt/add", "post", "200"),
+        ("/console/api/v1/component/mgmt/addSubComponent", "post", "200"),
+        ("/console/api/v1/component/mgmt/modify", "put", "200"),
+        ("/console/api/v1/component/search", "post", "200"),
+        ("/console/api/v1/component/search/add", "post", "200"),
+        ("/console/api/v1/component/search/listNames/{group}", "get", "200"),
+        (
+            "/console/api/v1/component/search/listNames/{group}/{type}",
+            "get",
+            "200",
+        ),
+        ("/console/api/v1/component/search/saved/{id}", "get", "200"),
+        ("/console/api/v1/component/search/savedlist", "get", "200"),
+        ("/console/api/v1/component/search/savedlist/{name}", "get", "200"),
+        ("/console/api/v1/config/dataType/list/{dataType}", "get", "200"),
+        ("/console/api/v1/config/dataType/types", "get", "200"),
+        ("/console/api/v1/config/tags/add/{tagType}", "post", "200"),
+        ("/console/api/v1/policy/mgmt/add", "post", "200"),
+        ("/console/api/v1/policy/mgmt/addSubPolicy", "post", "200"),
+        ("/console/api/v1/policy/mgmt/export", "post", "200"),
+        ("/console/api/v1/policy/mgmt/exportAll", "get", "200"),
+        ("/console/api/v1/policy/mgmt/exportOptions", "get", "200"),
+        ("/console/api/v1/policy/mgmt/generatePDF", "post", "200"),
+        ("/console/api/v1/policy/mgmt/generateXACML", "post", "200"),
+        ("/console/api/v1/policy/mgmt/import", "post", "200"),
+        ("/console/api/v1/policy/mgmt/importXacmlPolicy", "post", "200"),
+        ("/console/api/v1/policy/mgmt/modify", "put", "200"),
+        ("/console/api/v1/policy/mgmt/retrieveAllPolicies", "get", "200"),
+        ("/console/api/v1/policy/search", "post", "200"),
+        ("/console/api/v1/policy/search/add", "post", "200"),
+        ("/console/api/v1/policy/search/saved/{id}", "get", "200"),
+        ("/console/api/v1/policy/search/savedlist", "get", "200"),
+        ("/console/api/v1/policy/search/savedlist/{name}", "get", "200"),
+        ("/console/api/v1/policy/search/{search}", "post", "200"),
+        ("/console/api/v1/policyModel/mgmt/add", "post", "200"),
+        ("/console/api/v1/policyModel/mgmt/clone", "post", "200"),
+        ("/console/api/v1/policyModel/mgmt/modify", "put", "200"),
+        ("/console/api/v1/policyModel/search", "post", "200"),
+        ("/console/api/v1/policyModel/search/add", "post", "200"),
+        ("/console/api/v1/policyModel/search/saved/{id}", "get", "200"),
+        (
+            "/console/api/v1/policyModel/search/savedlist/{type}",
+            "get",
+            "200",
+        ),
+        (
+            "/console/api/v1/policyModel/search/savedlist/{type}/{name}",
+            "get",
+            "200",
+        ),
+        ("/console/scim/v2/Groups", "get", "200"),
+        ("/console/scim/v2/Groups", "post", "201"),
+        ("/console/scim/v2/Groups/{groupId}", "get", "200"),
+        ("/console/scim/v2/Groups/{groupId}", "put", "200"),
+        ("/console/scim/v2/Users", "get", "200"),
+        ("/console/scim/v2/Users", "post", "201"),
+        ("/console/scim/v2/Users/{userId}", "get", "200"),
+        ("/console/scim/v2/Users/{userId}", "patch", "200"),
+        ("/console/scim/v2/Users/{userId}", "put", "200"),
+        ("/nextlabs-reporter/api/activity-logs/search", "get", "200"),
+        (
+            "/nextlabs-reporter/api/system-configuration/getUIConfigs",
+            "get",
+            "200",
+        ),
+        ("/nextlabs-reporter/api/v1/auditLogs/export", "post", "400"),
+        ("/nextlabs-reporter/api/v1/auditLogs/export", "post", "500"),
+        ("/nextlabs-reporter/api/v1/auditLogs/search", "post", "200"),
+        ("/nextlabs-reporter/api/v1/auditLogs/users", "get", "200"),
+        (
+            "/nextlabs-reporter/api/v1/dashboard/activityByPolicies/{fromDate}/{toDate}/{policyDecision}",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/dashboard/activityByResources/{fromDate}/{toDate}/{policyDecision}",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/dashboard/activityByUsers/{fromDate}/{toDate}/{policyDecision}",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/dashboard/alertByMonitorTags/{fromDate}/{toDate}",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/dashboard/latestAlerts/{fromDate}/{toDate}",
+            "get",
+            "200",
+        ),
+        ("/nextlabs-reporter/api/v1/policy-activity-reports", "get", "200"),
+        ("/nextlabs-reporter/api/v1/policy-activity-reports", "post", "200"),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/delete",
+            "post",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/generate/enforcements",
+            "post",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/generate/widgets",
+            "post",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/mappings",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/policies",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/resource-actions",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/share/application-users",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/share/user-groups",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/users",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}",
+            "put",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}/enforcements",
+            "get",
+            "200",
+        ),
+        (
+            "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}/widgets",
+            "get",
+            "200",
+        ),
+        ("/nextlabs-reporter/api/v1/report-activity-logs", "post", "200"),
+        (
+            "/nextlabs-reporter/api/v1/report-activity-logs/{rowId}",
+            "get",
+            "200",
+        ),
+    ),
+)
+
+
+KNOWN_UNPARSEABLE: frozenset[tuple[str, str, str]] = (
+    INVALID_JSON_EXAMPLES | MISSING_MODEL
 )

--- a/tests/_openapi/examples.py
+++ b/tests/_openapi/examples.py
@@ -1,0 +1,86 @@
+"""Walk the OpenAPI spec and yield response-body examples as ExampleCase records."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from tests._openapi.spec import load_spec
+
+
+@dataclass(frozen=True)
+class ExampleCase:
+    """One vendor-supplied response example.
+
+    Attributes:
+        path: OpenAPI path template (unmodified).
+        method: Lowercase HTTP method.
+        status: HTTP status code as string (matches OpenAPI key format).
+        content_type: Response content-type key from the spec.
+        body: Raw example string exactly as the vendor wrote it. The
+            consumer is responsible for calling ``substitute`` before
+            parsing.
+    """
+
+    path: str
+    method: str
+    status: str
+    content_type: str
+    body: str
+
+
+def collect_example_cases() -> Iterator[ExampleCase]:
+    """Yield one ExampleCase per response-body example found in the spec."""
+    spec = load_spec()
+    for path, operations in spec.get("paths", {}).items():
+        yield from _walk_operations(path, operations)
+
+
+def _walk_operations(
+    path: str,
+    operations: Any,
+) -> Iterator[ExampleCase]:
+    if not isinstance(operations, dict):
+        return
+    for method, op in operations.items():
+        if not isinstance(op, dict):
+            continue
+        yield from _walk_responses(path, method, op.get("responses", {}))
+
+
+def _walk_responses(
+    path: str,
+    method: str,
+    responses: dict[str, Any],
+) -> Iterator[ExampleCase]:
+    for status, resp in responses.items():
+        for content_type, media in (resp or {}).get("content", {}).items():
+            body = _extract_body(media.get("example"))
+            if body is not None:
+                yield ExampleCase(
+                    path=path,
+                    method=method,
+                    status=status,
+                    content_type=content_type,
+                    body=body,
+                )
+
+
+def _extract_body(example: Any) -> str | None:
+    """Return the example as a string, serializing dict/list examples to JSON.
+
+    NextLabs' spec mixes conventions: ``*/*`` responses carry hand-written
+    string blobs (sometimes with embedded ``{id}`` placeholders that make
+    them invalid JSON on their own), while ``application/json`` responses
+    carry structured dict examples. We preserve both so downstream layers
+    see every documented example.
+    """
+    if example is None:
+        return None
+    if isinstance(example, str):
+        return example
+    if isinstance(example, (dict, list)):
+        return json.dumps(example)
+    return None

--- a/tests/_openapi/fixtures/nextlabs-openapi.json
+++ b/tests/_openapi/fixtures/nextlabs-openapi.json
@@ -1,0 +1,13764 @@
+{
+   "openapi":"3.0.1",
+   "info":{
+      "title":"NextLabs API Reference",
+      "description":"<style>.cc-swagger-example {}</style><h3>API Authentication</h3><p>CloudAz supports OpenID Connect (OIDC)-based authentication for API requests. The following are the general steps to authenticate.</p><ol><li><strong>Request an ID token.</strong><p>Clients can request an ID token by making the following HTTP POST request to the access token URL: https://&lt;Base URL&gt;/cas/oidc/accessToken.</p><p>The following table lists the request parameters.</p><table><thead><tr><td><strong>POST request body parameter<strong></td><td><strong>Description<strong></td></tr></thead><tbody><tr><td>grant_type</td><td>The grant_type value must be password.</td></tr><tr><td>username</td><td>The CloudAz console user name.</td></tr><tr><td>password</td><td>The CloudAz password.</td></tr><tr><td>client_id</td><td>The value of the registered OIDC service (client). You may use the client_id of the CloudAz OIDC service, which is ControlCenterOIDCClient by default. If you have a custom OIDC service configured, please use the appropriate client_id provided by your OIDC service provider.</td></tbody></table><p>Request headers and body parameter sample</p><pre  style=\"font-size: 12px;margin: 0;padding: 10px;white-space: pre-wrap;word-wrap: break-word;word-break: break-all;word-break: break-word;-webkit-hyphens: auto;-ms-hyphens: auto;hyphens: auto;border-radius: 4px;background: #41444e;overflow-wrap: break-word;font-family: Source Code Pro,monospace;font-weight: 600;color: #fff;\">POST /cas/oidc/accessToken HTTP/1.1<br/>Content-Type: application/x-www-form-urlencoded<br/>Accept: */*<br/>Accept-Encoding: gzip, deflate, br<br/>Connection: keep-alive<br/>Content-Length: 98<br/><br/>grant_type=password&username=nextlabsuser&password=strongpassword!&client_id=ControlCenterOIDCClient</pre><p>Response headers and body sample</p><pre style=\"font-size: 12px;margin: 0;padding: 10px;white-space: pre-wrap;word-wrap: break-word;word-break: break-all;word-break: break-word;-webkit-hyphens: auto;-ms-hyphens: auto;hyphens: auto;border-radius: 4px;background: #41444e;overflow-wrap: break-word;font-family: Source Code Pro,monospace;font-weight: 600;color: #fff;\">HTTP/1.1 200 OK<br/>Cache-Control: no-cache, no-store, max-age=0, must-revalidate<br/>Pragma: no-cache<br/>Expires: 0<br/>Strict-Transport-Security: max-age=15768000 ; includeSubDomains<br/>X-Content-Type-Options: nosniff<br/>X-Frame-Options: DENY<br/>X-XSS-Protection: 1; mode=block<br/>WWW-Authenticate: Basic realm=\"authentication required\"<br/>Content-Type: application/json;charset=UTF-8<br/>Content-Length: 1797<br/>Keep-Alive: timeout=60<br/>Connection: keep-alive<br/><br/>{<br>\"access_token\": \"AT-10-yEZyMs-FL0aodqsKDereRZ5jnhSo0mkr.....\",<br>\"token_type\": \"bearer\",<br>\"expires_in\": 1200,<br>\"refresh_token\": \"RT-10-6-QO99z9fzLaPOR0yUrHZdW-jk5FFrCa\",<br>\"id_token\": \"eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwia2l...\",<br>\"refresh_token\": \"RT-3-89AVtKqbSuyAKYx3rM6I2TwyNywSF5J5..\",<br>\"token_type\": \"bearer\",<br>\"expires_in\": 1200,<br>\"scope\": \"\"<br>}<br></pre></li><li><p>Send the value of the id_token in the Authorization HTTP header. The following is an example raw request of a protected resource using this method.</p><p>Request headers sample</p><pre  style=\"font-size: 12px;margin: 0;padding: 10px;white-space: pre-wrap;word-wrap: break-word;word-break: break-all;word-break: break-word;-webkit-hyphens: auto;-ms-hyphens: auto;hyphens: auto;border-radius: 4px;background: #41444e;overflow-wrap: break-word;font-family: Source Code Pro,monospace;font-weight: 600;color: #fff;\">GET /console/api/v1/policy/mgmt/82 HTTP/1.1<br/>Authorization: Bearer eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwia2l...<br/>Accept: */*<br/>Accept-Encoding: gzip, deflate, br<br/>Connection: keep-alive</pre></li></ol><h4>API Workflow guide to create attribute-based policies</h4><ol><li><strong>Create 3 new tags</strong><p>Tags are optionals but efficiently in utilizing for the search related endpoints.</p><p>Create 3 tags with different types. Detailed in <a href=\"#operations-tag-\\32 \\._Tag_Management\">[Tag Management] POST/console/api/v1/config/tags/add/{tagType}-Creates a new Tag of the given tag type.</a></p><p>a. \"key\": \"helpdesk\" (POLICY_MODEL_TAG type). <p>b. \"key\": \"helpdesk_component\" (COMPONENT_TAG type). <p>c. \"key\": \"helpdesk_policy\" (POLICY_TAG type).</p></li><li><strong>Create a component type (policy model)</strong><p>Component types (policy models) represent data attributes which are references utilized within the component.</p><p>Create 1 resource component type (policy model). Detailed in <a href=\"#operations-tag-\\33 \\._Component_Type_Management\">[Component Type Management] POST/console/api/v1/policyModel/mgmt/add-Creates a new component type (policy model)</a></p><p>a. User (Fixed subject policy model).</p><p>b. Support Tickets (Resource policy model).</p></li><li><strong>Create new components with the component type (policy model).</strong><p>Components are used as utilization for the data attributes from Component types (policy models).</p><p>Create 1 subject component, 2 resource components, 3 action components. Detailed in <a href=\"#operations-tag-\\35 \\._Component_Management\">[Component Management] POST/console/api/v1/component/mgmt/add-Creates a new component.</a></p><p>a. IT Department (Subject component).</p><p>b. Security Vulnerabilities (Resource component).</p><p>c. Tickets in User's Product Area (resource component).</p><p>d. Assign Support Tickets (Action component).</p><p>e. Edit Support Tickets (Action component).</p><p>f. View Support Tickets (Action component).</p></li><li><strong>Create new policies with components</strong><p>Policies are used as rules that uses the attributes from the components to decide whether to grant or deny access to the resources.</p><p>Create 3 policies. Detailed in <a href=\"#operations-tag-\\37 \\._Policy_Management\">[Policy Management] POST/console/api/v1/policy/mgmt/add-Creates a new policy.</a></p><p>a. Allow Users in IT to View All Support Tickets (Allow policy).</p><p>b. Allow Users in IT to Edit and Reassign Tickets in their Product Area (Allow policy).</p><p>c. Deny access to Security Vulnerabilities if not Created By or Assigned To the User (Deny policy).</p></li></ol><h4>Workflow dependency diagram</h4><p>A List of attribute-based policies</p><p>|</p><p>|----> Allow Users in IT to View All Support Tickets (Allow Policy)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|----> IT Department (Subject Component)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> User Component Type (Subject Policy Model)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|----> View Support Tickets (Action Component)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp; &emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p>|</p><p>|----> Allow Users in IT to Edit and Reassign Tickets in their Product Area (Allow Policy)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Tickets in User's Product Area (Resource Component)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Edit Support Tickets (Action Component)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Assign Support Tickets (Action Component)</p><p>|&emsp;&emsp;&emsp;&emsp;&emsp; &emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p>|</p><p>|----> Deny access to Security Vulnerabilities if not Created By or Assigned To the User (Deny Policy)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|----> Security Vulnerabilities (Resource Component)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|----> View Support Tickets (Action Component)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|----> Edit Support Tickets (Action Component)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|&emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp;|----> Assign Support Tickets (Action Component)</p><p> &emsp;&emsp;&emsp;&emsp;&emsp; &emsp;&emsp;&emsp;&emsp;&emsp;|----> Support Tickets Component Type (Resource Policy Model)</p><h4>Table of API Operations</h4><table><thead><tr><td><strong>No.<strong></td><td><strong>Operation Tags<strong></td><td><strong>Description<strong></td></tr></thead><tbody><tr><td>1.</td><td><a href=\"#operations-tag-\\31 \\._Operator_Configuration\">[Operator Configuration]</a></td><td>Retrieving operators configurations related endpoints.</td></tr><tr><td>2.</td><td><a href=\"#operations-tag-\\32 \\._Tag_Management\">[Tag Management]</a></td><td>Managing tag configurations related endpoints.</td></tr><tr><td>3.</td><td><a href=\"#operations-tag-\\33 \\._Component_Type_Management\">[Component Type Management]</a></td><td>Managing component type (policy model) related endpoints.</td></tr><tr><td>4.</td><td><a href=\"#operations-tag-\\34 \\._Component_Type_Search\">[Component Type Search]</a></td><td>Searching component type (policy model) related endpoints.</td></tr><tr><td>5.</td><td><a href=\"#operations-tag-\\36 \\._Component_Search\">[Component Search]</a></td><td>Managing component related endpoints.</td></tr><tr><td>6.</td><td><a href=\"#operations-tag-\\35 \\._Component_Management\">[Component Management]</a></td><td>Searching component, managing saved search related endpoints.</td></tr><tr><td>7.</td><td><a href=\"#operations-tag-\\37 \\._Policy_Management\">[Policy Management]</a></td><td>Managing policy related endpoints.</td></tr><tr><td>8.</td><td><a href=\"#operations-tag-\\38 \\._Policy_Search\">[Policy Search]</a></td><td>Searching policy, managing saved search related endpoints.</td></tr></tbody></table><h4>Try-it-out feature guide</h4><p>To use the 'Try it out' feature, please ensure you are authorized by clicking the \"Authorize\" button below, inputting your access token with prefix of \"Bearer\" e.g. value= Bearer AT-10-yEZyMs-FL0aodqsKDereRZ5jnhSo0mkr...</p><p>Once you've set up the authorization, you may utilize the \"Try it out\" feature available for each operation.</p>",
+      "contact":{
+         
+      },
+      "license":{
+         
+      },
+      "version":"1.0"
+   },
+   "tags":[
+      {
+         "name":"Operator Configuration",
+         "description":"Retrieving operators configurations related endpoints"
+      },
+      {
+         "name":"Tag Management",
+         "description":"Managing tag configurations related endpoints"
+      },
+      {
+         "name":"Component Type Management",
+         "description":"Managing component type (policy model) related endpoints"
+      },
+      {
+         "name":"Component Type Search",
+         "description":"Searching component type (policy model) related endpoints"
+      },
+      {
+         "name":"Component Management",
+         "description":"Managing component related endpoints"
+      },
+      {
+         "name":"Component Search",
+         "description":"Searching component, managing saved search related endpoints"
+      },
+      {
+         "name":"Policy Management",
+         "description":"Managing policy related endpoints"
+      },
+      {
+         "name":"Policy Search",
+         "description":"Searching policy, managing saved search related endpoints"
+      },
+      {
+         "name":"SCIM Bulk Controller",
+         "description":"Scim Bulk Controller"
+      },
+      {
+         "name":"SCIM Group Controller",
+         "description":"Scim Group Controller"
+      },
+      {
+         "name":"SCIM User Controller",
+         "description":"Scim User Controller"
+      },
+      {
+         "name":"Entity Audit Log",
+         "description":"REST APIs for entity audit logs"
+      },
+      {
+         "name":"Policy Activity Report",
+         "description":"REST APIs for policy activity reports"
+      },
+      {
+         "name":"Reporter System Configuration",
+         "description":"REST APIs for Reporter system configuration"
+      },
+      {
+         "name":"Audit Log",
+         "description":"REST APIs for Reporter audit logs"
+      },
+      {
+         "name":"Report Activity Log",
+         "description":"REST APIs for policy activity logs"
+      },
+      {
+         "name":"Reporter Dashboard",
+         "description":"REST APIs for Reporter dashboard widgets"
+      }
+   ],
+   "paths":{
+      "/console/api/v1/component/mgmt/active/{id}":{
+         "get":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Retrieve the detail of an active component based on the given ID",
+            "description":"\n1. The active component ID must exist before trying to retrieve.\nTo create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n\n2. An active component shouldn't have the status field that is marked as DELETED\n",
+            "operationId":"get_Active_Component_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the component to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abComponentDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"folderId\": null,\n    \"name\": \"Security Vulnerabilities\",\n    \"description\": \"Support Tickets that are categorized as security vulnerabilities.\",\n    \"tags\": [\n      {\n        \"id\": {id},\n        \"key\": \"helpdesk_component\",\n        \"label\": \"Helpdesk_Component\",\n        \"type\": \"COMPONENT_TAG\",\n        \"status\": \"ACTIVE\"\n      }\n    ],\n    \"type\": \"RESOURCE\",\n    \"category\": \"COMPONENT\",\n    \"policyModel\": {\n      \"id\": {id}\n    },\n    \"actions\": [],\n    \"conditions\": [\n      {\n        \"attribute\": \"category\",\n        \"operator\": \"=\",\n        \"value\": \"security\",\n        \"rhsType\": \"CONSTANT\",\n        \"rhsvalue\": \"security\"\n      }\n    ],\n    \"memberConditions\": [],\n    \"subComponents\": [],\n    \"status\": \"DRAFT\",\n    \"parentId\": null,\n    \"parentName\": null,\n    \"deploymentTime\": 0,\n    \"deployed\": false,\n    \"actionType\": null,\n    \"revisionCount\": 0,\n    \"ownerId\": 0,\n    \"ownerDisplayName\": \"Administrator\",\n    \"createdDate\": 1713171640267,\n    \"modifiedById\": 0,\n    \"modifiedBy\": \"Administrator\",\n    \"lastUpdatedDate\": 1713171640252,\n    \"skipValidate\": false,\n    \"reIndexAllNow\": true,\n    \"hidden\": false,\n    \"authorities\": [\n      {\n        \"authority\": \"VIEW_COMPONENT\"\n      },\n      {\n        \"authority\": \"EDIT_COMPONENT\"\n      },\n      {\n        \"authority\": \"DELETE_COMPONENT\"\n      },\n      {\n        \"authority\": \"DEPLOY_COMPONENT\"\n      },\n      {\n        \"authority\": \"MOVE_COMPONENT\"\n      },\n      {\n        \"authority\": \"CREATE_COMPONENT\"\n      }\n    ],\n    \"deploymentRequest\": {\n      \"id\": 200,\n      \"type\": \"POLICY\",\n      \"push\": false,\n      \"deploymentTime\": 1713172120387,\n      \"deployDependencies\": true\n    },\n    \"folderPath\": null,\n    \"preCreated\": false,\n    \"version\": 1,\n    \"pageNo\": 0,\n    \"pageSize\": 20,\n    \"hasInactiveSubComponets\": false,\n    \"deploymentPending\": false\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/mgmt/add":{
+         "post":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Creates a new component.",
+            "description":"\n1. A component have mandatory name field.\n\n2. The type field is type of components which are restricted to SUBJECT, RESOURCE, and ACTION.\n\n3. The subject components should be associated with a subject policy model specified in the policyModel field.\n\n4. The resource and action components should be associated to the resource policy model specified in the policyModel field. For more info about resource policy model, please refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add-Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n5. The policyModel field (e.g. Support tickets policy model is resource type for the Security Vulnerabilities component). The policyModel can be retrieved from other endpoint, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search-Searches for a list of component types based on a given search criteria](#/4.%20Component%20Type%20Search/search_PolicyModel).\n\n6. The tags field are labels that identify or classify objects, which can be refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n",
+            "operationId":"create_Component",
+            "requestBody":{
+               "description":"<a href=\"#model-ComponentDTOReq\">ComponentDTOReq</a>: A new RESOURCE (Tickets in User's Product Area) component to be saved.\n\n1. Execute [[Tag Management]-GET/console/api/v1/config/tags/list/COMPONENT_TAG] and populate the tag {id} in the payload accordingly.\n\n2. Execute [[Component Type Search] POST/console/api/v1/policyModel/search] and populate the policy model {id} in the payload accordingly.\n\n3. To utilize the \"try it out\" feature, please copy the payloads provided and execute them in the designated most bottom payload input field.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":null,
+                           "name":"Tickets in User's Product Area",
+                           "description":"Support Tickets that match the Product Area assignment of the user",
+                           "tags":[
+                              {
+                                 "id":"{id}",
+                                 "key":"helpdesk",
+                                 "label":"Helpdesk",
+                                 "type":"COMPONENT_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "type":"RESOURCE",
+                           "conditions":[
+                              {
+                                 "attribute":"prod_name",
+                                 "operator":"=",
+                                 "value":"${user.assigned_prod_area}"
+                              }
+                           ],
+                           "memberConditions":[
+                              
+                           ],
+                           "actions":[
+                              
+                           ],
+                           "subComponents":[
+                              
+                           ],
+                           "version":null,
+                           "folderId":null,
+                           "policyModel":{
+                              "id":"{id}",
+                              "name":"Support Tickets",
+                              "shortName":"support_tickets"
+                           },
+                           "status":"DRAFT",
+                           "skipValidate":true
+                        }
+                     }
+                  }
+               },
+               "required":false
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"componentDTO     "
+         }
+      },
+      "/console/api/v1/component/mgmt/addSubComponent":{
+         "post":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Creates a new sub-component.",
+            "description":"\n1. A sub-component have mandatory parent component id and name fields.\n\n2. The type field is type of components which are restricted to SUBJECT, RESOURCE, and ACTION.\n\n3. The subject components should be associated with a subject policy model specified in the policyModel field.\n\n4. The resource and action components should be associated to the resource policy model specified in the policyModel field. For more info about resource policy model, please refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add-Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n5. The policyModel field (e.g. Support tickets policy model is resource type for the Security Vulnerabilities component). The policyModel can be retrieved from other endpoint, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search-Searches for a list of component types based on a given search criteria](#/4.%20Component%20Type%20Search/search_PolicyModel).\n\n6. The tags field are labels that identify or classify objects, which can be refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n",
+            "operationId":"add_Sub_Component",
+            "requestBody":{
+               "description":"<a href=\"#model-ComponentDTOReq\">ComponentDTOReq</a>: A new sub-component to be saved.\n\n1. Execute [[Tag Management]-GET/console/api/v1/config/tags/list/COMPONENT_TAG] and populate the tag {id} in the payload accordingly.\n\n2. Execute [[Component Type Search] POST/console/api/v1/policyModel/search] and populate the policy model {id} in the payload accordingly.\n\n3. Populate the parent id {id} in the payload.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":null,
+                           "name":"Sub ticket",
+                           "description":"Sub ticket from support tickets",
+                           "tags":[
+                              {
+                                 "id":"{id}",
+                                 "key":"helpdesk",
+                                 "label":"Helpdesk",
+                                 "type":"COMPONENT_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "type":"RESOURCE",
+                           "conditions":[
+                              
+                           ],
+                           "memberConditions":[
+                              
+                           ],
+                           "actions":[
+                              
+                           ],
+                           "subComponents":[
+                              
+                           ],
+                           "version":null,
+                           "folderId":null,
+                           "policyModel":{
+                              "id":"{id}",
+                              "name":"Support Tickets",
+                              "shortName":"support_tickets"
+                           },
+                           "status":"DRAFT",
+                           "parentId":"{id}",
+                           "skipValidate":true
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"componentDTO"
+         }
+      },
+      "/console/api/v1/component/mgmt/bulkDelete":{
+         "delete":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Removes a list of component based on the list of IDs",
+            "description":"\n1. The component ID must exist before trying to remove.To create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n",
+            "operationId":"removeByIdUsingDELETE",
+            "requestBody":{
+               "description":"The list of component's ID to be deleted",
+               "content":{
+                  "*/*":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/component/mgmt/deploy":{
+         "post":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Deploys a list of components based on the given list of component IDs",
+            "description":"\n1. Prior to deployment, ensure that the component IDs you intend to deploy already exists.\n\n2. The component ID must exist before trying to deploy. To create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n\n3. Before proceeding with deployment, please validate the dependencies of the components by referring to the [[Component Management] POST/console/api/v1/component/mgmt/findDependencies-Find the dependencies for the components](#/4.%20Component%20Management/find_Component_Dependencies).\n\n4. Any component dependencies listed in the response of /findDependencies should be populated the ids in the deployment request.\n5. After a successful deployment, the deploymentTime field is populated and the deployed field is set to true.\n",
+            "operationId":"deploy_Component",
+            "requestBody":{
+               "description":"<a href=\"#model-DeploymentRequestDTO\">List of DeploymentRequestDTO</a>: A List of deployment request to be deployed.\n\n1. Execute [[Component Search] POST/console/api/v1/component/search](#/6.%20Component%20Search/search_Component) and populate the component {id} that to be deployed, in the payload accordingly.\n\n2. Execute [[Component Management] POST/console/api/v1/component/mgmt/findDependencies](#/4.%20Component%20Management/find_Component_Dependencies) and add more component deployment request DTO if dependencies are found, in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":[
+                           {
+                              "id":"{id}",
+                              "type":"COMPONENT",
+                              "push":true,
+                              "deploymentTime":-1
+                           },
+                           {
+                              "id":"{id}",
+                              "type":"COMPONENT",
+                              "push":true,
+                              "deploymentTime":-1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abDeploymentResponseDTO\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1006\",\n    \"message\": \"Data deployed successfully\",\n    \"data\": [\n        {\n            \"id\": {id},\n            \"pushResults\": [\n                {\n                    \"dpsUrl\": \"https://cc-prod-01:8443/dps\",\n                    \"success\": true,\n                    \"message\": Push Successful\n                }\n            ]\n        }\n    ],\n    \"pageNo\": 1,\n    \"pageSize\": 1,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 1,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"deploymentRequests"
+         }
+      },
+      "/console/api/v1/component/mgmt/findDependencies":{
+         "post":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Find the dependencies for the components based on given list of component IDs",
+            "description":"\n1. The component ID must exist before trying to find dependencies.\nTo create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n",
+            "operationId":"find_Component_Dependencies",
+            "requestBody":{
+               "description":"The list of component's ID to find its dependencies",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n  \"statusCode\": \"1008\",\n  \"message\": \"Data validated successfully\",\n  \"data\": [\n    {\n      \"id\": {id}},\n      \"type\": \"COMPONENT\",\n      \"group\": \"RESOURCE\",\n      \"name\": \"Security Vulnerabilities\",\n      \"folderPath\": null,\n      \"optional\": false,\n      \"provided\": true,\n      \"sub\": false\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 10,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 0,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/component/mgmt/modify":{
+         "put":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Modifies existing component.",
+            "description":"\n1. An existing component have mandatory existing id and name fields.\n\n2. The type field is type of components which are restricted to SUBJECT, RESOURCE, and ACTION.\n\n3. The subject components should be associated with a subject policy model specified in the policyModel field.\n\n4. The resource and action components should be associated to the resource policy model specified in the policyModel field. For more info about resource policy model, please refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add-Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n5. The policyModel field (e.g. Support tickets policy model is resource type for the Security Vulnerabilities component). The policyModel can be retrieved from other endpoint, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search-Searches for a list of component types based on a given search criteria](#/4.%20Component%20Type%20Search/search_PolicyModel).\n\n6. The tags field are labels that identify or classify objects, which can be refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n",
+            "operationId":"modify_Component",
+            "requestBody":{
+               "description":"<a href=\"#model-ComponentDTOReq\">ComponentDTOReq</a>: A existing component to be updated.\n\n1. Execute [[Tag Management]-GET/console/api/v1/config/tags/list/COMPONENT_TAG] and populate the tag {id} in the payload accordingly.\n\n2. Execute [[Component Type Search] POST/console/api/v1/policyModel/search] and populate the policy model {id} in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":"{id}",
+                           "name":"Security Vulnerabilities",
+                           "description":"Support Tickets that are categorized as security vulnerabilities.",
+                           "tags":[
+                              {
+                                 "id":"{id}",
+                                 "key":"helpdesk_component",
+                                 "label":"Helpdesk_Component",
+                                 "type":"COMPONENT_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "type":"RESOURCE",
+                           "conditions":[
+                              {
+                                 "attribute":"category",
+                                 "operator":"=",
+                                 "value":"security"
+                              }
+                           ],
+                           "memberConditions":[
+                              
+                           ],
+                           "actions":[
+                              
+                           ],
+                           "subComponents":[
+                              
+                           ],
+                           "version":null,
+                           "folderId":null,
+                           "policyModel":{
+                              "id":"{id}",
+                              "name":"Support Tickets",
+                              "shortName":"support_tickets"
+                           },
+                           "status":"DRAFT",
+                           "skipValidate":true
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data modified successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1001\",\n    \"message\": \"Data modified successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"componentDTO"
+         }
+      },
+      "/console/api/v1/component/mgmt/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Removes a component based on the given ID",
+            "description":"\n1. The component ID must exist before trying to remove.\nTo create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n",
+            "operationId":"remove_Component_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"id",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/mgmt/unDeploy":{
+         "post":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Deploys a list of components based on the given list of component IDs",
+            "description":"\n1. Prior to un-deployment, ensure that the component IDs you intend to un-deploy already exists.\n\n2. The component ID must exist before trying to un-deploy.\nTo create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n\n3. After a successful un-deployment, the deployed field is set to false.\n",
+            "operationId":"componentUnDeployUsingPOST",
+            "requestBody":{
+               "description":"The list of component's ID to be undeployed",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data un-deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1007\",\n    \"message\": \"Data un-deployed successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/component/mgmt/{id}":{
+         "get":{
+            "tags":[
+               "Component Management"
+            ],
+            "summary":"Retrieve the detail of a component based on the given ID",
+            "description":"\n1. The component ID must exist before trying to retrieve.\nTo create a new component, please refer to the documentation, [[Component Management] POST/console/api/v1/Component/mgmt/add-Creates a new component](#/4.%20Component%20Management/create_Component).\n",
+            "operationId":"get_Component_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the component to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abComponentDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"folderId\": null,\n    \"name\": \"Security Vulnerabilities\",\n    \"description\": \"Support Tickets that are categorized as security vulnerabilities.\",\n    \"tags\": [\n      {\n        \"id\": {id},\n        \"key\": \"helpdesk_component\",\n        \"label\": \"Helpdesk_Component\",\n        \"type\": \"COMPONENT_TAG\",\n        \"status\": \"ACTIVE\"\n      }\n    ],\n    \"type\": \"RESOURCE\",\n    \"category\": \"COMPONENT\",\n    \"policyModel\": {\n      \"id\": {id}\n    },\n    \"actions\": [],\n    \"conditions\": [\n      {\n        \"attribute\": \"category\",\n        \"operator\": \"=\",\n        \"value\": \"security\",\n        \"rhsType\": \"CONSTANT\",\n        \"rhsvalue\": \"security\"\n      }\n    ],\n    \"memberConditions\": [],\n    \"subComponents\": [],\n    \"status\": \"DRAFT\",\n    \"parentId\": null,\n    \"parentName\": null,\n    \"deploymentTime\": 0,\n    \"deployed\": false,\n    \"actionType\": null,\n    \"revisionCount\": 0,\n    \"ownerId\": 0,\n    \"ownerDisplayName\": \"Administrator\",\n    \"createdDate\": 1713171640267,\n    \"modifiedById\": 0,\n    \"modifiedBy\": \"Administrator\",\n    \"lastUpdatedDate\": 1713171640252,\n    \"skipValidate\": false,\n    \"reIndexAllNow\": true,\n    \"hidden\": false,\n    \"authorities\": [\n      {\n        \"authority\": \"VIEW_COMPONENT\"\n      },\n      {\n        \"authority\": \"EDIT_COMPONENT\"\n      },\n      {\n        \"authority\": \"DELETE_COMPONENT\"\n      },\n      {\n        \"authority\": \"DEPLOY_COMPONENT\"\n      },\n      {\n        \"authority\": \"MOVE_COMPONENT\"\n      },\n      {\n        \"authority\": \"CREATE_COMPONENT\"\n      }\n    ],\n    \"deploymentRequest\": {\n      \"id\": 200,\n      \"type\": \"POLICY\",\n      \"push\": false,\n      \"deploymentTime\": 1713172120387,\n      \"deployDependencies\": true\n    },\n    \"folderPath\": null,\n    \"preCreated\": false,\n    \"version\": 1,\n    \"pageNo\": 0,\n    \"pageSize\": 20,\n    \"hasInactiveSubComponets\": false,\n    \"deploymentPending\": false\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search":{
+         "post":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Searches for a list of components based on a given search criteria",
+            "description":"\n1. The search criteria in criteria.fields.field is used to search by group, modelType, status, tags, date, text, empty, hasIncludedIn. The model information can be referred in the documentation <a href=\"#model-ComponentLite\">ComponentLite</a>.\n\n2. The search by group (criteria.fields.field=group), the allowable values are SUBJECT, RESOURCE, ACTION. e.g. \"value\": [\"RESOURCE\"]\n\n3. The search by status (criteria.fields.field=status), the allowable values are DRAFT, APPROVED, OBSOLETE. (APPROVED = DEPLOYED, OBSOLETE = DEACTIVATED). e.g. \"value\": [\"APPROVED\"].\n\n4. The search by type (criteria.fields.field=modelType), the values is based on the policy model name created. e.g. \"value\": [\"Support Tickets\"]\n\n5. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status, please refer to documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType), e.g. \"value\": [\"helpdesk_component\"].\n\n6. The search by text (criteria.fields.field=text), the text represents a specific term used to search for the name and description of the component effectively. e.g.\"value\": \"security\"\n\n7. The search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date).\n \n8. The search by empty (criteria.fields.field=empty), the value is either true (search only for empty component) or false (search all components).\n\n9. The search by hasIncludedIn criteria.fields.field=hasIncludedIn), the value is either true (search including sub components) or false (search excluding sub components).\n",
+            "operationId":"search_Component",
+            "requestBody":{
+               "description":"<a href=\"#model-SearchCriteriaDTO\">SearchCriteriaDTO</a>: A search criteria to search for components.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"status",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "APPROVED"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"group",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"RESOURCE"
+                                    }
+                                 },
+                                 {
+                                    "field":"modelType",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "Support Tickets"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk_component"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712569342133,
+                                       "toDate":1713174142133
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"security"
+                                    }
+                                 },
+                                 {
+                                    "field":"empty",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"false"
+                                    }
+                                 },
+                                 {
+                                    "field":"hasIncludedIn",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"true"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "order":"DESC"
+                                 }
+                              ],
+                              "pageNo":0,
+                              "pageSize":20
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abComponentLite\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"folderId\": -1,\n      \"folderPath\": null,\n      \"name\": \"Security Vulnerabilities\",\n      \"lowercase_name\": \"security vulnerabilities\",\n      \"fullName\": \"RESOURCE/Security Vulnerabilities\",\n      \"description\": \"Support Tickets that are categorized as security vulnerabilities.\",\n      \"status\": \"APPROVED\",\n      \"modelId\": {id},\n      \"modelType\": \"Support Tickets\",\n      \"group\": \"RESOURCE\",\n      \"lastUpdatedDate\": 1713173211329,\n      \"createdDate\": 1713171640267,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": \"Administrator\",\n      \"modifiedById\": 0,\n      \"modifiedBy\": \"Administrator\",\n      \"hasIncludedIn\": false,\n      \"hasSubComponents\": false,\n      \"predicateData\": {\n        \"operator\": null,\n        \"referenceIds\": [],\n        \"attributes\": [\n          {\n            \"lhs\": \"category\",\n            \"operator\": \"=\",\n            \"rhs\": \"security\"\n          }\n        ],\n        \"actions\": []\n      },\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk_component\",\n          \"label\": \"Helpdesk_Component\",\n          \"type\": \"COMPONENT_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"includedInComponents\": [],\n      \"subComponents\": [],\n      \"deploymentTime\": 1713173211332,\n      \"deployed\": true,\n      \"actionType\": \"DE\",\n      \"revisionCount\": 1,\n      \"empty\": false,\n      \"version\": 2,\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_COMPONENT\"\n        },\n        {\n          \"authority\": \"EDIT_COMPONENT\"\n        },\n        {\n          \"authority\": \"DELETE_COMPONENT\"\n        },\n        {\n          \"authority\": \"DEPLOY_COMPONENT\"\n        },\n        {\n          \"authority\": \"MOVE_COMPONENT\"\n        },\n        {\n          \"authority\": \"CREATE_COMPONENT\"\n        }\n      ],\n      \"preCreated\": false,\n      \"referedInPolicies\": false,\n      \"deploymentPending\": false\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/component/search/add":{
+         "post":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Saves a new component search criteria.",
+            "description":"\n1. A new saved component search criteria requires mandatory name, description, and type fields.\n\n2. The type field must be chosen from a predefined set of options, including POLICY, COMPONENT, POLICY_MODEL_RESOURCE, POLICY_MODEL_SUBJECT, LOCATION, and PROPERTY.\n\n3. The search criteria in criteria.fields.field is used to search by group, modelType, status, tags, date, text, empty, hasIncludedIn. The model information can be referred in the documentation <a href=\"#model-ComponentLite\">ComponentLite</a>.\n\n4. The search by group (criteria.fields.field=group), the allowable values are SUBJECT, RESOURCE, ACTION. e.g. \"value\": [\"RESOURCE\"]\n\n5. The search by status (criteria.fields.field=status), the allowable values are DRAFT, APPROVED, OBSOLETE. (APPROVED = DEPLOYED, OBSOLETE = DEACTIVATED). e.g. \"value\": [\"APPROVED\"].\n\n6. The search by type (criteria.fields.field=modelType), the values is based on the policy model name created. e.g. \"value\": [\"Support Tickets\"]\n\n7. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status, please refer to documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType). e.g. \"value\": [\"helpdesk_component\"].\n\n8. The search by text (criteria.fields.field=text), the text represents a specific term used to search for the name and description of the component effectively. e.g.\"value\": \"security\"\n\n9. The search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date).\n \n10. The search by empty (criteria.fields.field=empty), the value is either true (search only for empty component) or false (search all components).\n\n11. The search by hasIncludedIn criteria.fields.field=hasIncludedIn), the value is either true (search including sub components) or false (search excluding sub components).\n",
+            "operationId":"save_Component_Search",
+            "requestBody":{
+               "description":"<a href=\"#model-SavedSearchDTO\">SavedSearchDTO</a>: A new search criteria to be saved.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "name":"Saved search for component Security Vulnerabilities",
+                           "desc":"saved search description",
+                           "type":"COMPONENT",
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"status",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "APPROVED"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"group",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"RESOURCE"
+                                    }
+                                 },
+                                 {
+                                    "field":"modelType",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "Support Tickets"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk_component"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712569342133,
+                                       "toDate":1713174142133
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"security"
+                                    }
+                                 },
+                                 {
+                                    "field":"empty",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"false"
+                                    }
+                                 },
+                                 {
+                                    "field":"hasIncludedIn",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"true"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "order":"DESC"
+                                 }
+                              ],
+                              "pageNo":0,
+                              "pageSize":20
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/component/search/listNames/{group}":{
+         "get":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Retrieve a list of components based on the given group type.",
+            "description":"\n1. The group type can be RESOURCE, ACTION OR SUBJECT\n",
+            "operationId":"findNamesByGroupTypeUsingGET",
+            "parameters":[
+               {
+                  "name":"group",
+                  "in":"path",
+                  "description":"The group type of components to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abLiteDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Security Vulnerabilities\",\n      \"empty\": false,\n      \"status\": \"APPROVED\",\n      \"data\": {\n        \"policy_model_id\": {id},\n        \"policy_model_name\": \"Support Tickets\"\n      }\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 10,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search/listNames/{group}/{type}":{
+         "get":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Retrieve a list of components based on the given group type and component type.",
+            "description":"\n1. The {group} type can be RESOURCE, ACTION OR SUBJECT.\n\n2. For group subject type, the allowable values for component {type} are USER, HOST, APPLICATION.\n\n3. For group resource/action types, the value of component {type} is based on the policy model name created. e.g. Support Tickets.\n",
+            "operationId":"findNamesByGroupAndTypeUsingGET",
+            "parameters":[
+               {
+                  "name":"group",
+                  "in":"path",
+                  "description":"The group type of components to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               },
+               {
+                  "name":"type",
+                  "in":"path",
+                  "description":"The component type (policy model type) of components to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abLiteDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Security Vulnerabilities\",\n      \"empty\": false,\n      \"status\": \"APPROVED\",\n      \"data\": {\n        \"policy_model_id\": {id},\n        \"policy_model_name\": \"Support Tickets\"\n      }\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 10,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Deletes the saved search based on the given component ID",
+            "description":"\n1. The saved search ID must exist before trying to delete.\nTo create saved search, refer to the documentation, [[Component Search] POST/console/api/v1/component/search/add-Saves a new component search criteria.](#/6.%20Component%20Search/save_Component_Search)\n",
+            "operationId":"removeCriteriaUsingDELETE",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to be deleted.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search/saved/{id}":{
+         "get":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Retrieve the saved search based on the given component ID",
+            "description":"\n1. The saved search ID must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Component Search] POST/console/api/v1/component/search/add-Saves a new component search criteria.](#/6.%20Component%20Search/save_Component_Search)\n",
+            "operationId":"getByIdUsingGET",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to be searched\n",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"name\": \"Saved search for component Security Vulnerabilities\",\n    \"desc\": \"saved search description\",\n    \"criteria\": {\n      \"fields\": [\n        {\n          \"field\": \"group\",\n          \"type\": \"SINGLE_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": \"RESOURCE\"\n          }\n        },\n        {\n          \"field\": \"modelType\",\n          \"type\": \"MULTI\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": [\n              \"Support Tickets\"\n            ]\n          }\n        },\n        {\n          \"field\": \"tags\",\n          \"type\": \"NESTED_MULTI\",\n          \"nestedField\": \"tags.key\",\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": [\n              \"helpdesk\"\n            ]\n          }\n        }\n      ],\n      \"sortFields\": [],\n      \"columns\": [],\n      \"facetField\": null,\n      \"properties\": null,\n      \"pageNo\": 0,\n      \"pageSize\": 10,\n      \"enableFullList\": false\n    },\n    \"status\": \"ACTIVE\",\n    \"sharedMode\": \"PUBLIC\",\n    \"userIds\": [],\n    \"type\": \"COMPONENT\"\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search/savedlist":{
+         "get":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Retrieve all the saved search",
+            "description":"\n1. The saved search must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Component Search] POST/console/api/v1/component/search/add-Saves a new component search criteria.](#/6.%20Component%20Search/save_Component_Search)\n",
+            "operationId":"findByAllUsingGET",
+            "parameters":[
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Saved search for component Security Vulnerabilities\",\n      \"desc\": \"saved search description\",\n      \"criteria\": {\n        \"fields\": [\n          {\n            \"field\": \"group\",\n            \"type\": \"SINGLE_EXACT_MATCH\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": null,\n              \"value\": \"RESOURCE\"\n            }\n          },\n          {\n            \"field\": \"modelType\",\n            \"type\": \"MULTI\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": null,\n              \"value\": [\n                \"Support Tickets\"\n              ]\n            }\n          },\n          {\n            \"field\": \"tags\",\n            \"type\": \"NESTED_MULTI\",\n            \"nestedField\": \"tags.key\",\n            \"value\": {\n              \"type\": null,\n              \"value\": [\n                \"helpdesk\"\n              ]\n            }\n          }\n        ],\n        \"sortFields\": [],\n        \"columns\": [],\n        \"facetField\": null,\n        \"properties\": null,\n        \"pageNo\": 0,\n        \"pageSize\": 10,\n        \"enableFullList\": false\n      },\n      \"status\": \"ACTIVE\",\n      \"sharedMode\": \"PUBLIC\",\n      \"userIds\": [],\n      \"type\": \"COMPONENT\"\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 10,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/component/search/savedlist/{name}":{
+         "get":{
+            "tags":[
+               "Component Search"
+            ],
+            "summary":"Retrieve the saved search based on the given name or description",
+            "description":"\n1. The saved search must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Component Search] POST/console/api/v1/component/search/add-Saves a new component search criteria.](#/6.%20Component%20Search/save_Component_Search)\n",
+            "operationId":"findByTextUsingGET",
+            "parameters":[
+               {
+                  "name":"name",
+                  "in":"path",
+                  "description":"The name of the saved search criteria to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"name\": \"Saved search for component Security Vulnerabilities\",\n    \"desc\": \"saved search description\",\n    \"criteria\": {\n      \"fields\": [\n        {\n          \"field\": \"group\",\n          \"type\": \"SINGLE_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": \"RESOURCE\"\n          }\n        },\n        {\n          \"field\": \"modelType\",\n          \"type\": \"MULTI\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": [\n              \"Support Tickets\"\n            ]\n          }\n        },\n        {\n          \"field\": \"tags\",\n          \"type\": \"NESTED_MULTI\",\n          \"nestedField\": \"tags.key\",\n          \"value\": {\n            \"type\": \"String\",\n            \"type\": null,\n            \"value\": [\n              \"helpdesk\"\n            ]\n          }\n        }\n      ],\n      \"sortFields\": [],\n      \"columns\": [],\n      \"facetField\": null,\n      \"properties\": null,\n      \"pageNo\": 0,\n      \"pageSize\": 10,\n      \"enableFullList\": false\n    },\n    \"status\": \"ACTIVE\",\n    \"sharedMode\": \"PUBLIC\",\n    \"userIds\": [],\n    \"type\": \"COMPONENT\"\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/dataType/list":{
+         "get":{
+            "tags":[
+               "Operator Configuration"
+            ],
+            "summary":"Retrieve all the operators",
+            "description":"\n1. Return a list of all the operators of all data types.\n",
+            "operationId":"find_All_Operator",
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": [\n        {\n            \"id\": 1,\n            \"key\": \"<\",\n            \"label\": \"before\",\n            \"dataType\": \"DATE\"\n        },\n        {\n            \"id\": 2,\n            \"key\": \">=\",\n            \"label\": \"on or after\",\n            \"dataType\": \"DATE\"\n        },\n        {\n            \"id\": 3,\n            \"key\": \"within_last\",\n            \"label\": \"within last\",\n            \"dataType\": \"TIME_INTERVAL\"\n        },\n        {\n            \"id\": 4,\n            \"key\": \"=\",\n            \"label\": \"is\",\n            \"dataType\": \"STRING\"\n        },\n        {\n            \"id\": 5,\n            \"key\": \"!=\",\n            \"label\": \"is not\",\n            \"dataType\": \"STRING\"\n        },\n        {...}\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 15,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 15,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/dataType/list/{dataType}":{
+         "get":{
+            "tags":[
+               "Operator Configuration"
+            ],
+            "summary":"Retrieve the operators based on given type",
+            "description":"\n1. The allowable values for the dataType are DATE, TIME_INTERVAL, NUMBER, STRING, and MULTIVAL.\n",
+            "operationId":"find_All_Operator_ByType",
+            "parameters":[
+               {
+                  "name":"dataType",
+                  "in":"path",
+                  "description":"The data type of the operator config",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": [\n        {\n            \"id\": 4,\n            \"key\": \"=\",\n            \"label\": \"is\",\n            \"dataType\": \"STRING\"\n        },\n        {\n            \"id\": 5,\n            \"key\": \"!=\",\n            \"label\": \"is not\",\n            \"dataType\": \"STRING\"\n        }\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 2,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 2,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/dataType/types":{
+         "get":{
+            "tags":[
+               "Operator Configuration"
+            ],
+            "summary":"Retrieve all the data types of operator config",
+            "description":"1. Returns a list of all the operator config's data types and information.",
+            "operationId":"load_All_DataType",
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": [\n        \"DATE\",\n        \"MULTIVAL\",\n        \"NUMBER\",\n        \"STRING\",\n        \"TIME_INTERVAL\"\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 5,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 5,\n    \"additionalAttributes\": {\n        \"daeValidationOptions\": [\n            \"No\",\n            \"Yes\"\n        ],\n        \"enableDAEValidation\": true\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/tags/add/{tagType}":{
+         "post":{
+            "tags":[
+               "Tag Management"
+            ],
+            "summary":"Creates a new Tag of the given tag type",
+            "description":"\n1. There are three types of tags: POLICY_MODEL_TAG, COMPONENT_TAG, and POLICY_TAG, whereby each is corresponding to their own respective category.\n",
+            "operationId":"add_Tag",
+            "parameters":[
+               {
+                  "name":"tagType",
+                  "in":"path",
+                  "description":"A new tag type should be saved in accordance with the tag model. Allowable values are POLICY_MODEL_TAG, COMPONENT_TAG, and POLICY_TAG.",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  },
+                  "example":"COMPONENT_TAG"
+               }
+            ],
+            "requestBody":{
+               "description":"<a href=\"#model-TagDTO\">TagDTO</a>: A new tag model (POLICY_TAG) to be saved.\n1. To utilize the \"try it out\" feature, please copy the payloads provided and execute them in the designated most bottom payload input field.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "key":"helpdesk_policy",
+                           "label":"Helpdesk_Policy",
+                           "type":"POLICY_TAG",
+                           "status":"ACTIVE"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"tagDTO  "
+         }
+      },
+      "/console/api/v1/config/tags/list/{type}":{
+         "get":{
+            "tags":[
+               "Tag Management"
+            ],
+            "summary":"Retrieve a list of tag based on tag type",
+            "description":"\n1. There are three types of tags: POLICY_MODEL_TAG, COMPONENT_TAG, and POLICY_TAG, whereby each is corresponding to their own respective category.\n",
+            "operationId":"find_Tag_ByType",
+            "parameters":[
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               },
+               {
+                  "name":"showHidden",
+                  "in":"query",
+                  "description":"The flag to display hidden type",
+                  "schema":{
+                     "type":"boolean",
+                     "default":false
+                  }
+               },
+               {
+                  "name":"type",
+                  "in":"path",
+                  "description":"The type of the tags",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": [\n        {\n            \"id\": 4,\n            \"key\": \"helpdesk\",\n            \"label\": \"Helpdesk\",\n            \"type\": \"COMPONENT_TAG\",\n            \"status\": \"ACTIVE\"\n        }\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 10,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 1,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/tags/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Tag Management"
+            ],
+            "summary":"Removes a Tag based on the given ID",
+            "description":"\n1. The tag ID must exist before trying to delete.\nTo create a new tag, refer to the documentation, [[Tag Management] POST/console/api/v1/config/tags/add/{tagType}-creates a new Tag of the given tag type.](#/2.%20Tag%20Management/add_Tag)\n",
+            "operationId":"remove_Tag_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the tag to be removed",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/config/tags/{id}":{
+         "get":{
+            "tags":[
+               "Tag Management"
+            ],
+            "summary":"Retrieve the detail of a tag based on the given ID",
+            "description":"\n1. The tag ID must exist before trying to retrieve.\nTo create a new tag, refer to the documentation, [[Tag Management] POST/console/api/v1/config/tags/add/{tagType}-creates a new Tag of the given tag type.](#/2.%20Tag%20Management/add_Tag)\n",
+            "operationId":"get_Tag_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the tag to be retrieved",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": {\n        \"id\": 4,\n        \"key\": \"helpdesk\",\n        \"label\": \"Helpdesk\",\n        \"type\": \"POLICY_MODEL_TAG\",\n        \"status\": \"ACTIVE\"\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/active/{id}":{
+         "get":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Retrieve the detail of an active policy based on the given ID",
+            "description":"\n1. The active policy ID must exist before trying to retrieve\nTo create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n\n2. An active policy mean the status is not marked as DELETED.\n",
+            "operationId":"activePolicyByIdUsingGET",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"id",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abPolicyDTO\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": {\n        \"id\": {id},\n        \"folderId\": null,\n        \"name\": \"Allow Users in IT to View All Support Tickets\",\n        \"fullName\": \"ROOT_134/Allow Users in IT to View All Support Tickets\",\n        \"description\": \"Allow Users in the IT Department to View All Support Tickets\",\n        \"status\": \"DRAFT\",\n        \"category\": \"POLICY\",\n        \"effectType\": \"allow\",\n        \"tags\": [\n            {\n                \"id\": {id},\n                \"key\": \"helpdesk_policy\",\n                \"label\": \"Helpdesk_Policy\",\n                \"type\": \"POLICY_TAG\",\n                \"status\": \"ACTIVE\"\n            }\n        ],\n        \"parentId\": null,\n        \"parentName\": null,\n        \"hasParent\": false,\n        \"hasSubPolicies\": false,\n        \"subjectComponents\": [\n            {\n                \"operator\": \"IN\",\n                \"components\": [\n                    {\n                        \"id\": {id},\n                        \"folderId\": null,\n                        \"name\": null,\n                        \"description\": null,\n                        \"tags\": [],\n                        \"type\": null,\n                        \"category\": null,\n                        \"policyModel\": null,\n                        \"actions\": [],\n                        \"conditions\": [],\n                        \"memberConditions\": [],\n                        \"subComponents\": [],\n                        \"status\": null,\n                        \"parentId\": null,\n                        \"parentName\": null,\n                        \"deploymentTime\": 0,\n                        \"deployed\": false,\n                        \"actionType\": null,\n                        \"revisionCount\": 0,\n                        \"ownerId\": 0,\n                        \"ownerDisplayName\": null,\n                        \"createdDate\": 0,\n                        \"modifiedById\": 0,\n                        \"modifiedBy\": null,\n                        \"lastUpdatedDate\": 0,\n                        \"skipValidate\": false,\n                        \"reIndexAllNow\": true,\n                        \"hidden\": false,\n                        \"authorities\": [],\n                        \"deploymentRequest\": {\n                            \"id\": {id},\n                            \"type\": \"POLICY\",\n                            \"push\": false,\n                            \"deploymentTime\": 1712633239397,\n                            \"deployDependencies\": true\n                        },\n                        \"folderPath\": null,\n                        \"preCreated\": false,\n                        \"version\": 0,\n                        \"pageNo\": 0,\n                        \"pageSize\": 20,\n                        \"hasInactiveSubComponets\": false,\n                        \"deploymentPending\": false\n                    }\n                ]\n            }\n        ],\n        \"hasToSubjectComponents\": false,\n        \"toSubjectComponents\": [],\n        \"actionComponents\": [\n            {\n                \"operator\": \"IN\",\n                \"components\": [\n                    {\n                        \"id\": {id},\n                        \"folderId\": null,\n                        \"name\": null,\n                        \"description\": null,\n                        \"tags\": [],\n                        \"type\": null,\n                        \"category\": null,\n                        \"policyModel\": null,\n                        \"actions\": [],\n                        \"conditions\": [],\n                        \"memberConditions\": [],\n                        \"subComponents\": [],\n                        \"status\": null,\n                        \"parentId\": null,\n                        \"parentName\": null,\n                        \"deploymentTime\": 0,\n                        \"deployed\": false,\n                        \"actionType\": null,\n                        \"revisionCount\": 0,\n                        \"ownerId\": 0,\n                        \"ownerDisplayName\": null,\n                        \"createdDate\": 0,\n                        \"modifiedById\": 0,\n                        \"modifiedBy\": null,\n                        \"lastUpdatedDate\": 0,\n                        \"skipValidate\": false,\n                        \"reIndexAllNow\": true,\n                        \"hidden\": false,\n                        \"authorities\": [],\n                        \"deploymentRequest\": {\n                            \"id\": 126,\n                            \"type\": \"POLICY\",\n                            \"push\": false,\n                            \"deploymentTime\": 1712633239400,\n                            \"deployDependencies\": true\n                        },\n                        \"folderPath\": null,\n                        \"preCreated\": false,\n                        \"version\": 0,\n                        \"pageNo\": 0,\n                        \"pageSize\": 20,\n                        \"hasInactiveSubComponets\": false,\n                        \"deploymentPending\": false\n                    }\n                ]\n            }\n        ],\n        \"fromResourceComponents\": [],\n        \"hasToResourceComponents\": false,\n        \"toResourceComponents\": [],\n        \"environmentConfig\": {\n            \"remoteAccess\": -1,\n            \"timeSinceLastHBSecs\": -1\n        },\n        \"scheduleConfig\": null,\n        \"expression\": \"\",\n        \"allowObligations\": [\n            {\n                \"id\": null,\n                \"policyModelId\": 0,\n                \"name\": \"log\",\n                \"params\": {}\n            }\n        ],\n        \"denyObligations\": [\n            {\n                \"id\": null,\n                \"policyModelId\": 0,\n                \"name\": \"log\",\n                \"params\": {}\n            }\n        ],\n        \"subPolicy\": false,\n        \"subPolicyRefs\": [],\n        \"attributes\": [\n            \"TRUE_ALLOW\"\n        ],\n        \"deploymentTime\": 0,\n        \"deployed\": false,\n        \"actionType\": null,\n        \"revisionCount\": 0,\n        \"ownerId\": 0,\n        \"ownerDisplayName\": \"Administrator\",\n        \"createdDate\": 1712132912288,\n        \"modifiedById\": 0,\n        \"modifiedBy\": \"Administrator\",\n        \"lastUpdatedDate\": 1712132912288,\n        \"skipValidate\": false,\n        \"reIndexNow\": true,\n        \"skipAddingTrueAllowAttribute\": false,\n        \"version\": 1,\n        \"authorities\": [\n            {\n                \"authority\": \"VIEW_POLICY\"\n            },\n            {\n                \"authority\": \"EDIT_POLICY\"\n            },\n            {\n                \"authority\": \"DELETE_POLICY\"\n            },\n            {\n                \"authority\": \"DEPLOY_POLICY\"\n            },\n            {\n                \"authority\": \"MOVE_POLICY\"\n            },\n            {\n                \"authority\": \"CREATE_POLICY\"\n            },\n            {\n                \"authority\": \"PARTIAL_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"FULL_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"EXPORT_POLICY\"\n            }\n        ],\n        \"manualDeploy\": false,\n        \"deploymentTargets\": [],\n        \"deploymentRequest\": {\n            \"id\": {id},\n            \"type\": \"POLICY\",\n            \"push\": false,\n            \"deploymentTime\": 1712633239408,\n            \"deployDependencies\": true\n        },\n        \"folderPath\": null,\n        \"activeWorkflowRequest\": null,\n        \"componentIds\": null,\n        \"hidden\": false,\n        \"deploymentPending\": false,\n        \"type\": null\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/add":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Creates a new policy.",
+            "description":"\n1. A policy have mandatory name field.\n\n2. The effectType field is authorization decision for the policy, which can be either \"Allow\" or \"Deny\".\n\n3. The tags field are labels that identify or classify objects, please refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType).\n\n4. The subjectComponents field should be populated with subject components e.g. IT department, which can be retrieved from another endpoint, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type SUBJECT.\n\n5. The fromResourceComponents field should be populated with resource components e.g. Security Vulnerabilities, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type RESOURCE.\n\n6. The actionComponents field should be populated with action components e.g. VIEW,EDIT,ASSIGN Support Tickets, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type ACTION.\n",
+            "operationId":"create_Policy",
+            "requestBody":{
+               "description":"<a href=\"#model-PolicyDTOReq\">PolicyDTOReq</a>: A new policy (Deny access to Security Vulnerabilities if not Created By or Assigned To the User) to be saved.\n1. Execute [[Tag Management]-GET/console/api/v1/config/tags/list/POLICY_TAG](#/2.%20Tag%20Management/find_Tag_ByType) and populate the tag {id} of helpdesk_policy in the payload accordingly.\n\n2. Execute [[Component Search] POST/console/api/v1/component/search/savedlist/ACTION](#/6.%20Component%20Search/search_Component) and populate the policy model {id} of VIEW,EDIT,ASSIGN Support Tickets in the payload accordingly.\n\n3. Execute [[Component Search] POST/console/api/v1/component/search/savedlist/RESOURCE](#/6.%20Component%20Search/search_Component) and populate the policy model {id} of Security Vulnerabilities in the payload accordingly.\n\n4. To utilize the \"try it out\" feature, please copy the payloads provided and execute them in the designated most bottom payload input field.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":null,
+                           "folderId":null,
+                           "name":"Deny access to Security Vulnerabilities if not Created By or Assigned To the User",
+                           "effectType":"deny",
+                           "description":"Deny access to Support Tickets categorized as Security Vulnerabilities if not Created By or Assigned To the User",
+                           "expression":"(resource.support_tickets.created_by != user.user_id AND resource.support_tickets.assigned_to != user.user_id)",
+                           "tags":[
+                              {
+                                 "id":"{{helpdesk_policy_id}}"
+                              }
+                           ],
+                           "version":null,
+                           "subjectComponents":[
+                              
+                           ],
+                           "actionComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"{{ASSIGN_Action_ID}}"
+                                    },
+                                    {
+                                       "id":"{{EDIT_Action_ID}}"
+                                    },
+                                    {
+                                       "id":"{{VIEW_Action_ID}}"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "fromResourceComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"{{Resource_Security_Vulnerabilities_ID}}"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "environmentConfig":{
+                              "remoteAccess":-1,
+                              "timeSinceLastHBSecs":-1
+                           },
+                           "allowObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              }
+                           ],
+                           "denyObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              },
+                              {
+                                 "policyModelId":"1107",
+                                 "name":"notify_violation",
+                                 "params":{
+                                    "ticket_id":"$from.ticket_id",
+                                    "assigned_to":"$from.assigned_to",
+                                    "message":"Policy Violation: Security Vulnerability ${ticket_id} can only be accessed by the owner ${assigned_to}"
+                                 }
+                              }
+                           ],
+                           "manualDeploy":false,
+                           "deploymentTargets":[
+                              
+                           ],
+                           "status":"DRAFT",
+                           "parentId":null,
+                           "skipValidate":true
+                        }
+                     }
+                  }
+               },
+               "required":false
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyDTO  "
+         }
+      },
+      "/console/api/v1/policy/mgmt/addSubPolicy":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Creates a new sub policy.",
+            "description":"\n1. A sub policy have mandatory parent policy id and name fields.\n\n2. The effectType field is authorization decision for the policy, which can be either \"Allow\" or \"Deny\".\n\n3. The tags field are labels that identify or classify objects, please refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType).\n\n4. The subjectComponents field should be populated with subject components e.g. IT department, which can be retrieved from another endpoint, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type SUBJECT.\n\n5. The fromResourceComponents field should be populated with resource components e.g. Security Vulnerabilities, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type RESOURCE.\n\n6. The actionComponents field should be populated with action components e.g. VIEW,EDIT,ASSIGN Support Tickets, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type ACTION.\n",
+            "operationId":"addSubPolicyUsingPOST",
+            "requestBody":{
+               "description":"<a href=\"#model-PolicyDTOReq\">PolicyDTOReq</a>: A new sub policy to be saved.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":null,
+                           "parentId":"{id}",
+                           "folderId":null,
+                           "name":"Sub policy of Allow Users in IT to View All Support Tickets",
+                           "effectType":"allow",
+                           "description":"Sub policy of Allow Users in the IT Department to View All Support Tickets",
+                           "expression":"",
+                           "tags":[
+                              {
+                                 "id":"{{helpdesk_policy_id}}"
+                              }
+                           ],
+                           "version":null,
+                           "subjectComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"{{IT_Department_id}}"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "fromResourceComponents":[
+                              
+                           ],
+                           "actionComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"{{VIEW_Action_ID}}"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "environmentConfig":{
+                              "remoteAccess":-1,
+                              "timeSinceLastHBSecs":-1
+                           },
+                           "allowObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              }
+                           ],
+                           "denyObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              }
+                           ],
+                           "manualDeploy":false,
+                           "deploymentTargets":[
+                              
+                           ],
+                           "status":"DRAFT",
+                           "skipValidate":true
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyDTO"
+         }
+      },
+      "/console/api/v1/policy/mgmt/bulkDelete":{
+         "delete":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Removes a list of policies based on a list of policy IDS",
+            "description":"\n1. The policy ID must exist before trying to retrieve.\nTo create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n",
+            "operationId":"removeByIdUsingDELETE_2",
+            "requestBody":{
+               "description":"The list of policy IDs to be deleted",
+               "content":{
+                  "*/*":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/policy/mgmt/bulkDeleteXacmlPolicy":{
+         "delete":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Removes a list of policies.",
+            "description":"\n1. Given a list of policy ID, this API removes the policies and returns a success message.\n",
+            "operationId":"removeXacmlPolicyByIdUsingDELETE",
+            "requestBody":{
+               "description":"The list of policy IDs to be exported as XCAML",
+               "content":{
+                  "*/*":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/policy/mgmt/deploy":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Deploys a list of policies.",
+            "description":"\n1. Prior to deployment, ensure that the Policy IDs you intend to deploy already exists.\n\n2. The policy ID must exist before trying to retrieve. To create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n\n3. Before proceeding with deployment,  please validate the dependencies of the policies by referring to the [[Policy Management] POST/console/api/v1/policy/mgmt/findDependencies-Find the dependencies for the policies](#/7.%20Policy%20Management/find_Policy_Dependencies)\n\n4. Any component dependencies listed in the response of /findDependencies should be populated the ids in the deployment request.\n5. After a successful deployment, The deploymentTime field is populated and the deployed field is set to true, detailed in [[Policy Management] GET/console/api/v1/policy/mgmt/{id}-retrieve the detail of a policy](#/7.%20Policy%20Management/get_Policy_ById).\n",
+            "operationId":"policyDeployUsingPOST",
+            "requestBody":{
+               "description":"<a href=\"#model-DeploymentRequestDTO\">List of DeploymentRequestDTO</a>: A List of deployment request to be deployed.\n\n1. Execute [[Policy Search] POST/console/api/v1/policy/search](#/8.%20Policy%20Search/search_Policy) and populate the policy {id} in the payload accordingly.\n\n2. Execute [[Policy Management] POST/console/api/v1/policy/mgmt/findDependencies](#/7.%20Policy%20Management/find_Policy_Dependencies) and add more component/policy deployment request DTO if dependencies are found, in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":[
+                           {
+                              "id":"{{Component_id}}",
+                              "type":"COMPONENT",
+                              "push":true,
+                              "deploymentTime":-1
+                           },
+                           {
+                              "id":"{{Policy_id}}",
+                              "type":"POLICY",
+                              "push":true,
+                              "deploymentTime":-1
+                           }
+                        ]
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abDeploymentResponseDTO\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1006\",\n    \"message\": \"Data deployed successfully\",\n    \"data\": [\n        {\n            \"id\": {id},\n            \"pushResults\": [\n                {\n                    \"dpsUrl\": \"https://cc-prod-01:8443/dps\",\n                    \"success\": true,\n                    \"message\": Push Successful\n                }\n            ]\n        }\n    ],\n    \"pageNo\": 1,\n    \"pageSize\": 1,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 1,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"deploymentRequests"
+         }
+      },
+      "/console/api/v1/policy/mgmt/export":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Export the given list of policies.",
+            "description":"\n1. The selected export mode must be allowed in the Control Centre configuration.\n\n2. The available export modes can be refer from the documentation, [[Policy Management] GET/console/api/v1/policy/mgmt/exportOptions-get policy export options.](#/7.%20Policy%20Management/get_Policy_ExportOptions)\n\n3. The {policy_id} is required for exporting.\n",
+            "operationId":"policyExportUsingPOST",
+            "parameters":[
+               {
+                  "name":"exportMode",
+                  "in":"query",
+                  "description":"Export Mode",
+                  "schema":{
+                     "type":"string",
+                     "default":"PLAIN"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"<a href=\"#model-exportEntityDTO\">List of exportEntityDTO</a>: A List of policy entities to be exported.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":[
+                           {
+                              "entityType":"POLICY",
+                              "id":"{policy_id}"
+                           },
+                           {
+                              "entityType":"POLICY",
+                              "id":"{policy_id}"
+                           }
+                        ]
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"File exported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1009\",\n    \"message\": \"File exported successfully\",\n    \"data\": \"Policy_Export_XXXXXXXXXXXXXXX.<filetype>\"\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"exportEntityDTOS"
+         }
+      },
+      "/console/api/v1/policy/mgmt/exportAll":{
+         "get":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Export all the policies.",
+            "description":"\n1. The selected export mode must be allowed in the Control Centre configuration.\n\n2. The available export modes can be refer from the documentation, [[Policy Management] GET/console/api/v1/policy/mgmt/exportOptions-get policy export options.](#/7.%20Policy%20Management/get_Policy_ExportOptions)\n",
+            "operationId":"policyExportAllUsingGET",
+            "parameters":[
+               {
+                  "name":"exportMode",
+                  "in":"query",
+                  "description":"Export Mode",
+                  "schema":{
+                     "type":"string",
+                     "default":"PLAIN"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"File exported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1009\",\n    \"message\": \"File exported successfully\",\n    \"data\": \"Policy_Export_XXXXXXXXXXXXXXX.<filetype>\"\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/exportOptions":{
+         "get":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Get policy export options.",
+            "description":"\n1. Export options can be configured using the Control Centre console. By default: \"sandeEnabled\": true,\"plainTextEnabled\": true\n",
+            "operationId":"get_Policy_ExportOptions",
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1004\",\n    \"message\": \"Data loaded successfully\",\n    \"data\": {\n        \"sandeEnabled\": true,\n        \"plainTextEnabled\": true\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/findDependencies":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Find the dependencies for the policies based on given list of policy IDs",
+            "description":"\n1. The policy ID must exist before trying to find dependencies. To create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n",
+            "operationId":"find_Policy_Dependencies",
+            "requestBody":{
+               "description":"The list of policy's ID to find its dependencies",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1008\",\n    \"message\": \"Data validated successfully\",\n    \"data\": [\n        {\n            \"id\": {id},\n            \"type\": \"COMPONENT\",\n            \"group\": \"SUBJECT\",\n            \"name\": \"IT Department\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": false,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"COMPONENT\",\n            \"group\": \"ACTION\",\n            \"name\": \"Assign\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": false,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"POLICY\",\n            \"group\": null,\n            \"name\": \"Allow Users in IT to Edit and Reassign Tickets in their Product Area\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": true,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"POLICY\",\n            \"group\": null,\n            \"name\": \"Allow Users in IT to View All Support Tickets\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": true,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"COMPONENT\",\n            \"group\": \"ACTION\",\n            \"name\": \"View\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": false,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"COMPONENT\",\n            \"group\": \"ACTION\",\n            \"name\": \"Edit\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": false,\n            \"sub\": false\n        },\n        {\n            \"id\": {id},\n            \"type\": \"COMPONENT\",\n            \"group\": \"RESOURCE\",\n            \"name\": \"Tickets in User's Product Area\",\n            \"folderPath\": null,\n            \"optional\": false,\n            \"provided\": false,\n            \"sub\": false\n        }\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 10,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 0,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/policy/mgmt/generatePDF":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Generate the PDF policies based on the given IDs.",
+            "description":"\n1. Returns a success message along with list exported policy file URL and contents, when the policies has been successfully exported.\n\n2. The {policy_id} is required for generating PDF.\n",
+            "operationId":"policyPDFExportUsingPOST",
+            "requestBody":{
+               "description":"A list of <a href=\"#model-ExportEntityDTO\">ExportEntityDTO</a>: A List of policy entities to be exported.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":[
+                           {
+                              "entityType":"POLICY",
+                              "id":"{Policy_id}"
+                           },
+                           {
+                              "entityType":"POLICY",
+                              "id":"{Policy_id}"
+                           }
+                        ]
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"File exported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abstring\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1009\",\n    \"message\": \"File exported successfully\",\n    \"data\": \"Policy_Export_XXXXXXXXXXXXXXX.<filetype>\"\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"exportEntityDTOS"
+         }
+      },
+      "/console/api/v1/policy/mgmt/generateXACML":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Generate the xacml policies based on the given IDs.",
+            "description":"\n1. Returns a success message along with list exported policy file URL and contents, when the policies has been successfully exported.\n\n2. The {policy_id} is required for generating XACML.\n",
+            "operationId":"policyXacmlExportUsingPOST",
+            "requestBody":{
+               "description":"A list of <a href=\"#model-ExportEntityDTO\">ExportEntityDTO</a>: A List of policy entities to be exported.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":[
+                           {
+                              "entityType":"POLICY",
+                              "id":"{{Policy_id}}"
+                           },
+                           {
+                              "entityType":"POLICY",
+                              "id":"{{Policy_id}}"
+                           }
+                        ]
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"File exported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abstring\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1009\",\n    \"message\": \"File exported successfully\",\n    \"data\": \"Policy_Export_XXXXXXXXXXXXXXX.<filetype>\"\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"exportEntityDTOS"
+         }
+      },
+      "/console/api/v1/policy/mgmt/import":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Import policies provided in the attachment file",
+            "description":"\n1. If the import file is encrypted, file extension should be ebin.\n\n2. For plain text file import, file extension should be bin.\n",
+            "operationId":"importPoliciesUsingPOST",
+            "parameters":[
+               {
+                  "name":"cleanup",
+                  "in":"query",
+                  "description":"Option to clean up non-importing entity. Default value is false.",
+                  "required":true,
+                  "schema":{
+                     "type":"boolean"
+                  }
+               },
+               {
+                  "name":"importMechanism",
+                  "in":"query",
+                  "description":"Import mechanism. Value should be either PARTIAL or FULL. Default value is PARTIAL.",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"A list of MutipartFile to import",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"array",
+                        "example":"policyFiles: (binary)",
+                        "items":{
+                           "type":"file",
+                           "format":"binary"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"File imported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1010\",\n    \"message\": \"File imported successfully\",\n    \"data\": {\n        \"total_components\": 6,\n        \"total_policies\": 3,\n        \"total_policy_models\": 2,\n        \"non_blocking_error\": false\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyFiles"
+         }
+      },
+      "/console/api/v1/policy/mgmt/importXacmlPolicy":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Import a new Xacml policy.",
+            "description":"\n1. Returns a success message along with the new policy's ID, when the policy has been successfully saved.\n",
+            "operationId":"importXacmlPolicyUsingPOST",
+            "requestBody":{
+               "description":"A MutipartFile in XML format",
+               "content":{
+                  "multipart/form-data":{
+                     "schema":{
+                        "type":"string",
+                        "format":"binary",
+                        "example":"xacmlFile: (binary)"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"File imported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1010\",\n    \"message\": \"File imported successfully\",\n    \"data\": {\n        \"total_components\": 6,\n        \"total_policies\": 3,\n        \"total_policy_models\": 2,\n        \"non_blocking_error\": false\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"xacmlFile"
+         }
+      },
+      "/console/api/v1/policy/mgmt/modify":{
+         "put":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Modifies existing policy.",
+            "description":"\n1. An existing policy requires existing policy {id} and a mandatory name field.\n\n2. The effectType field is authorization decision for the policy, which can be either \"Allow\" or \"Deny\".\n\n3. The tags field are labels that identify or classify objects, please refer to the documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType).\n\n4. The subjectComponents field should be populated with subject components e.g. IT department, which can be retrieved from another endpoint, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type SUBJECT.\n\n5. The fromResourceComponents field should be populated with resource components e.g. Security Vulnerabilities, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type RESOURCE.\n\n6. The actionComponents field should be populated with action components e.g. VIEW,EDIT,ASSIGN Support Tickets, which can be retrieved from another endpoint, please refer to the documentation, [[Component Search] POST/console/api/v1/component/search/savedlist/{type}](#/6.%20Component%20Search/search_Component), retrieve a list of components based on group type ACTION.\n",
+            "operationId":"modifyPolicyUsingPUT",
+            "requestBody":{
+               "description":"<a href=\"#model-PolicyDTOReq\">PolicyDTOReq</a>: A existing policy (Allow Users in IT to View All Support Tickets) to be saved.\n\n1. Execute [[Tag Management]-GET/console/api/v1/config/tags/list/POLICY_TAG](#/2.%20Tag%20Management/find_Tag_ByType) and populate the tag {id} of helpdesk_policy in the payload accordingly.\n\n2. Execute [[Component Search] POST/console/api/v1/component/search/savedlist/SUBJECT](#/6.%20Component%20Search/search_Component) and populate the policy model {id} of IT department in the payload accordingly.\n\n3. Execute [[Component Search] POST/console/api/v1/component/search/savedlist/ACTION](#/6.%20Component%20Search/search_Component) and populate the policy model {id} of VIEW Support Tickets in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":"{\n    \"id\": {id},\n    \"folderId\": null,\n    \"name\": \"Allow Users in IT to View All Support Tickets\",\n    \"effectType\": \"allow\",\n    \"description\": \"Allow Users in the IT Department to View All Support Tickets\",\n    \"expression\": \"\",\n    \"tags\": [{\n        \"id\": {{helpdesk_policy_id}}\n    }],\n    \"version\": null,\n    \"subjectComponents\": [{\n        \"operator\": \"IN\",\n        \"components\": [{\n            \"id\": {{IT_Department_id}}\n        }]\n    }],\n    \"fromResourceComponents\": [],\n    \"actionComponents\": [{\n        \"operator\": \"IN\",\n        \"components\": [{\n            \"id\": {{VIEW_Action_ID}}\n        }]\n    }],\n    \"environmentConfig\": {\n        \"remoteAccess\": -1,\n        \"timeSinceLastHBSecs\": -1\n    },\n    \"allowObligations\": [{\n        \"policyModelId\": \"0\",\n        \"name\": \"log\",\n        \"params\": {}\n    }],\n    \"denyObligations\": [{\n        \"policyModelId\": \"0\",\n        \"name\": \"log\",\n        \"params\": {}\n    }],\n    \"manualDeploy\": false,\n    \"deploymentTargets\": [],\n    \"status\": \"DRAFT\",\n    \"parentId\": null,\n    \"skipValidate\": true\n}"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data modified successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1001\",\n    \"message\": \"Data modified successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyDTO"
+         }
+      },
+      "/console/api/v1/policy/mgmt/obligation/daeValidate":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"validate obligation values",
+            "description":"\n1. Please enable the obligation validation in the system configuration setting.\n\n2. To validate the obligations, please set the validation flag to true/yes in component type obligation.\n",
+            "operationId":"validateObligationValuesUsingPOST",
+            "requestBody":{
+               "description":"<a href=\"#model-PolicyDTODAE\">PolicyDTODAE</a>: A policy obligation model to be validated.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":"sample-id",
+                           "folderId":2,
+                           "name":"Allow Users in IT to View All Support Tickets",
+                           "effectType":"allow",
+                           "description":"Allow Users in the IT Department to View All Support Tickets",
+                           "expression":"",
+                           "tags":[
+                              {
+                                 "id":"sample-tag-id",
+                                 "key":"helpdesk",
+                                 "label":"Helpdesk",
+                                 "type":"POLICY_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "version":21,
+                           "subjectComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"subject-comp-id"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "actionComponents":[
+                              {
+                                 "operator":"IN",
+                                 "components":[
+                                    {
+                                       "id":"action-comp-id"
+                                    }
+                                 ]
+                              }
+                           ],
+                           "fromResourceComponents":[
+                              
+                           ],
+                           "environmentConfig":{
+                              "remoteAccess":-1,
+                              "timeSinceLastHBSecs":-1
+                           },
+                           "allowObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              },
+                              {
+                                 "policyModelId":"0",
+                                 "name":"notify",
+                                 "params":{
+                                    "to":"sample@nextlabs.com",
+                                    "message":"message sample"
+                                 }
+                              },
+                              {
+                                 "policyModelId":"35",
+                                 "name":"notify_violation",
+                                 "params":{
+                                    "ticket_id":"${from.ticket_id}",
+                                    "message":"message 1",
+                                    "assigned_to":"${from.assigned_to}"
+                                 }
+                              }
+                           ],
+                           "denyObligations":[
+                              {
+                                 "policyModelId":"0",
+                                 "name":"log",
+                                 "params":{
+                                    
+                                 }
+                              }
+                           ],
+                           "manualDeploy":false,
+                           "deploymentTargets":[
+                              
+                           ],
+                           "status":"DRAFT",
+                           "parentId":null
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"DAE validation performed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": 1008,\n    \"message\": \"Data validated successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyDTO"
+         }
+      },
+      "/console/api/v1/policy/mgmt/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Removes a policy based on the given ID",
+            "description":"\n1. The policy ID must exist before trying to delete.\nTo create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n",
+            "operationId":"removeByIdUsingDELETE_1",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the policy to be removed.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/retrieveAllPolicies":{
+         "get":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Export all policies.",
+            "description":"\n1. The selected export mode must be allowed in the Control Centre configuration.\n\n2. The allowable values for export mode are PLAIN, SANDE.\n",
+            "operationId":"retrieveAllPoliciesUsingGET",
+            "parameters":[
+               {
+                  "name":"exportMode",
+                  "in":"query",
+                  "description":"Export Mode",
+                  "schema":{
+                     "type":"string",
+                     "default":"PLAIN"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"File exported successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ByteArrayResource"
+                        },
+                        "example":"{\n    \"statusCode\": \"1009\",\n    \"message\": \"File exported successfully\",\n    \"data\": \"Policy_Export_XXXXXXXXXXXXXXX.<filetype>\"\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/mgmt/unDeploy":{
+         "post":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Undeploys a list of policies.",
+            "description":"\n1. The policy ID must exist before trying to un-deploy.\nTo create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n",
+            "operationId":"policyunDeployUsingPOST",
+            "requestBody":{
+               "description":"The list of policy's ID to be undeployed",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data un-deployed successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1007\",\n    \"message\": \"Data un-deployed successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/policy/mgmt/{id}":{
+         "get":{
+            "tags":[
+               "Policy Management"
+            ],
+            "summary":"Retrieve the detail of a policy based on the given ID",
+            "description":"\n1. The policy ID must exist before trying to retrieve.\nTo create a new policy, please refer to the documentation, [[Policy Management] POST/console/api/v1/Policy/mgmt/add-Creates a new policy](#/7.%20Policy%20Management/create_Policy)\n",
+            "operationId":"get_Policy_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the policy to be retrieved.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abPolicyDTO\u00bb"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": {\n        \"id\": {id},\n        \"folderId\": null,\n        \"name\": \"Allow Users in IT to View All Support Tickets\",\n        \"fullName\": \"ROOT_134/Allow Users in IT to View All Support Tickets\",\n        \"description\": \"Allow Users in the IT Department to View All Support Tickets\",\n        \"status\": \"DRAFT\",\n        \"category\": \"POLICY\",\n        \"effectType\": \"allow\",\n        \"tags\": [\n            {\n                \"id\": {id},\n                \"key\": \"helpdesk_policy\",\n                \"label\": \"Helpdesk_Policy\",\n                \"type\": \"POLICY_TAG\",\n                \"status\": \"ACTIVE\"\n            }\n        ],\n        \"parentId\": null,\n        \"parentName\": null,\n        \"hasParent\": false,\n        \"hasSubPolicies\": false,\n        \"subjectComponents\": [\n            {\n                \"operator\": \"IN\",\n                \"components\": [\n                    {\n                        \"id\": {id},\n                        \"folderId\": null,\n                        \"name\": null,\n                        \"description\": null,\n                        \"tags\": [],\n                        \"type\": null,\n                        \"category\": null,\n                        \"policyModel\": null,\n                        \"actions\": [],\n                        \"conditions\": [],\n                        \"memberConditions\": [],\n                        \"subComponents\": [],\n                        \"status\": null,\n                        \"parentId\": null,\n                        \"parentName\": null,\n                        \"deploymentTime\": 0,\n                        \"deployed\": false,\n                        \"actionType\": null,\n                        \"revisionCount\": 0,\n                        \"ownerId\": 0,\n                        \"ownerDisplayName\": null,\n                        \"createdDate\": 0,\n                        \"modifiedById\": 0,\n                        \"modifiedBy\": null,\n                        \"lastUpdatedDate\": 0,\n                        \"skipValidate\": false,\n                        \"reIndexAllNow\": true,\n                        \"hidden\": false,\n                        \"authorities\": [],\n                        \"deploymentRequest\": {\n                            \"id\": {id},\n                            \"type\": \"POLICY\",\n                            \"push\": false,\n                            \"deploymentTime\": 1712633239397,\n                            \"deployDependencies\": true\n                        },\n                        \"folderPath\": null,\n                        \"preCreated\": false,\n                        \"version\": 0,\n                        \"pageNo\": 0,\n                        \"pageSize\": 20,\n                        \"hasInactiveSubComponets\": false,\n                        \"deploymentPending\": false\n                    }\n                ]\n            }\n        ],\n        \"hasToSubjectComponents\": false,\n        \"toSubjectComponents\": [],\n        \"actionComponents\": [\n            {\n                \"operator\": \"IN\",\n                \"components\": [\n                    {\n                        \"id\": {id},\n                        \"folderId\": null,\n                        \"name\": null,\n                        \"description\": null,\n                        \"tags\": [],\n                        \"type\": null,\n                        \"category\": null,\n                        \"policyModel\": null,\n                        \"actions\": [],\n                        \"conditions\": [],\n                        \"memberConditions\": [],\n                        \"subComponents\": [],\n                        \"status\": null,\n                        \"parentId\": null,\n                        \"parentName\": null,\n                        \"deploymentTime\": 0,\n                        \"deployed\": false,\n                        \"actionType\": null,\n                        \"revisionCount\": 0,\n                        \"ownerId\": 0,\n                        \"ownerDisplayName\": null,\n                        \"createdDate\": 0,\n                        \"modifiedById\": 0,\n                        \"modifiedBy\": null,\n                        \"lastUpdatedDate\": 0,\n                        \"skipValidate\": false,\n                        \"reIndexAllNow\": true,\n                        \"hidden\": false,\n                        \"authorities\": [],\n                        \"deploymentRequest\": {\n                            \"id\": 126,\n                            \"type\": \"POLICY\",\n                            \"push\": false,\n                            \"deploymentTime\": 1712633239400,\n                            \"deployDependencies\": true\n                        },\n                        \"folderPath\": null,\n                        \"preCreated\": false,\n                        \"version\": 0,\n                        \"pageNo\": 0,\n                        \"pageSize\": 20,\n                        \"hasInactiveSubComponets\": false,\n                        \"deploymentPending\": false\n                    }\n                ]\n            }\n        ],\n        \"fromResourceComponents\": [],\n        \"hasToResourceComponents\": false,\n        \"toResourceComponents\": [],\n        \"environmentConfig\": {\n            \"remoteAccess\": -1,\n            \"timeSinceLastHBSecs\": -1\n        },\n        \"scheduleConfig\": null,\n        \"expression\": \"\",\n        \"allowObligations\": [\n            {\n                \"id\": null,\n                \"policyModelId\": 0,\n                \"name\": \"log\",\n                \"params\": {}\n            }\n        ],\n        \"denyObligations\": [\n            {\n                \"id\": null,\n                \"policyModelId\": 0,\n                \"name\": \"log\",\n                \"params\": {}\n            }\n        ],\n        \"subPolicy\": false,\n        \"subPolicyRefs\": [],\n        \"attributes\": [\n            \"TRUE_ALLOW\"\n        ],\n        \"deploymentTime\": 0,\n        \"deployed\": false,\n        \"actionType\": null,\n        \"revisionCount\": 0,\n        \"ownerId\": 0,\n        \"ownerDisplayName\": \"Administrator\",\n        \"createdDate\": 1712132912288,\n        \"modifiedById\": 0,\n        \"modifiedBy\": \"Administrator\",\n        \"lastUpdatedDate\": 1712132912288,\n        \"skipValidate\": false,\n        \"reIndexNow\": true,\n        \"skipAddingTrueAllowAttribute\": false,\n        \"version\": 1,\n        \"authorities\": [\n            {\n                \"authority\": \"VIEW_POLICY\"\n            },\n            {\n                \"authority\": \"EDIT_POLICY\"\n            },\n            {\n                \"authority\": \"DELETE_POLICY\"\n            },\n            {\n                \"authority\": \"DEPLOY_POLICY\"\n            },\n            {\n                \"authority\": \"MOVE_POLICY\"\n            },\n            {\n                \"authority\": \"CREATE_POLICY\"\n            },\n            {\n                \"authority\": \"PARTIAL_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"FULL_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n            },\n            {\n                \"authority\": \"EXPORT_POLICY\"\n            }\n        ],\n        \"manualDeploy\": false,\n        \"deploymentTargets\": [],\n        \"deploymentRequest\": {\n            \"id\": {id},\n            \"type\": \"POLICY\",\n            \"push\": false,\n            \"deploymentTime\": 1712633239408,\n            \"deployDependencies\": true\n        },\n        \"folderPath\": null,\n        \"activeWorkflowRequest\": null,\n        \"componentIds\": null,\n        \"hidden\": false,\n        \"deploymentPending\": false,\n        \"type\": null\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/search":{
+         "post":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Searches for a list of policies based on a given search criteria.",
+            "description":"\n1. The search criteria in criteria.fields.field can be used examples such as search by status, tags, effectType, date, text, hasParent. More model information detailed in the <a href=\"#model-PolicyLite\">PolicyLite</a>.\n\n2. The search by status (criteria.fields.field=status), the allowable values are DRAFT, APPROVED, OBSOLETE. (APPROVED = DEPLOYED, OBSOLETE = DEACTIVATED),  e.g.\"value\": \"DRAFT\".\n\n3. The search by effectType (criteria.fields.field=effectType), the allowable values are authorization decisions, which can be either \"Allow\" or \"Deny\"  e.g.\"value\": \"Allow\".\n\n4. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status. This can be refer from documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType), e.g. \"value\": [\"helpdesk_policy\"].\n\n5. The search by text (criteria.fields.field=text),the text represents a specific term used to search for the name and description of policy effectively. e.g.\"value\": \"Tickets\".\n\n6. To search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date)\n\n7. The search by hasParent (criteria.fields.field=hasParent), the value is either true (search result including the sub policies) or false (search result excluding sub policies).\n",
+            "operationId":"search_Policy",
+            "parameters":[
+               {
+                  "name":"search",
+                  "in":"path",
+                  "description":"search",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"<a href=\"#model-SearchCriteriaDTO\">SearchCriteriaDTO</a>: A search criteria to search for policies.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"effectType",
+                                    "type":"MULTI_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "allow"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"status",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "DRAFT"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk_policy"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712634137720,
+                                       "toDate":1713238937720
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"tickets"
+                                    }
+                                 },
+                                 {
+                                    "field":"hasParent",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"false"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "order":"DESC"
+                                 }
+                              ],
+                              "pageNo":0,
+                              "pageSize":20
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abPolicyLite\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"folderId\": -1,\n      \"folderName\": null,\n      \"folderPath\": null,\n      \"name\": \"Allow Users in IT to Edit and Reassign Tickets in their Product Area\",\n      \"lowercase_name\": \"allow users in it to edit and reassign tickets in their product area\",\n      \"rootFolder\": \"ROOT_207\",\n      \"policyFullName\": \"ROOT_207/Allow Users in IT to Edit and Reassign Tickets in their Product Area\",\n      \"description\": \"Allow Users in the IT department to Edit and Reassign Support Tickets assigned to their Product Area\",\n      \"status\": \"DRAFT\",\n      \"effectType\": \"allow\",\n      \"lastUpdatedDate\": 1713238881754,\n      \"createdDate\": 1713193182933,\n      \"hasParent\": false,\n      \"hasSubPolicies\": false,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": \"Administrator\",\n      \"modifiedById\": 0,\n      \"modifiedBy\": \"Administrator\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk_policy\",\n          \"label\": \"Helpdesk_Policy\",\n          \"type\": \"POLICY_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"noOfTags\": 1,\n      \"parentPolicy\": null,\n      \"subPolicies\": [],\n      \"childNodes\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY\"\n        },\n        {\n          \"authority\": \"MOVE_POLICY\"\n        },\n        {\n          \"authority\": \"CREATE_POLICY\"\n        },\n        {\n          \"authority\": \"PARTIAL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"FULL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"EXPORT_POLICY\"\n        }\n      ],\n      \"manualDeploy\": false,\n      \"deploymentTime\": 0,\n      \"deployed\": false,\n      \"actionType\": \"N/A\",\n      \"activeWorkflowId\": null,\n      \"activeEntityWorkflowRequestStatus\": null,\n      \"activeWorkflowRequestLevelStatus\": null,\n      \"revisionCount\": 0,\n      \"version\": 2,\n      \"componentIds\": [\n        {id},\n        {id},\n        {id},\n        {id}\n      ],\n      \"obligationModelIds\": null,\n      \"hideMoreDetails\": false,\n      \"deploymentPending\": false\n    },\n    {\n      \"id\": {id},\n      \"folderId\": -1,\n      \"folderName\": null,\n      \"folderPath\": null,\n      \"name\": \"Allow Users in IT to View All Support Tickets\",\n      \"lowercase_name\": \"allow users in it to view all support tickets\",\n      \"rootFolder\": \"ROOT_208\",\n      \"policyFullName\": \"ROOT_208/Allow Users in IT to View All Support Tickets\",\n      \"description\": \"Allow Users in the IT Department to View All Support Tickets\",\n      \"status\": \"DRAFT\",\n      \"effectType\": \"allow\",\n      \"lastUpdatedDate\": 1713238866440,\n      \"createdDate\": 1713193225880,\n      \"hasParent\": false,\n      \"hasSubPolicies\": false,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": \"Administrator\",\n      \"modifiedById\": 0,\n      \"modifiedBy\": \"Administrator\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk_policy\",\n          \"label\": \"Helpdesk_Policy\",\n          \"type\": \"POLICY_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"noOfTags\": 1,\n      \"parentPolicy\": null,\n      \"subPolicies\": [],\n      \"childNodes\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY\"\n        },\n        {\n          \"authority\": \"MOVE_POLICY\"\n        },\n        {\n          \"authority\": \"CREATE_POLICY\"\n        },\n        {\n          \"authority\": \"PARTIAL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"FULL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"EXPORT_POLICY\"\n        }\n      ],\n      \"manualDeploy\": false,\n      \"deploymentTime\": 0,\n      \"deployed\": false,\n      \"actionType\": \"N/A\",\n      \"activeWorkflowId\": null,\n      \"activeEntityWorkflowRequestStatus\": null,\n      \"activeWorkflowRequestLevelStatus\": null,\n      \"revisionCount\": 0,\n      \"version\": 2,\n      \"componentIds\": [\n        {id},\n        {id}\n      ],\n      \"obligationModelIds\": null,\n      \"hideMoreDetails\": false,\n      \"deploymentPending\": false\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 2,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/policy/search/add":{
+         "post":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Saves a new policy search criteria.",
+            "description":"\n1. A new saved policy search criteria requires mandatory name, desc and type fields.\n\n2. The type field must be chosen from a predefined set of options, including POLICY, COMPONENT, POLICY_MODEL_RESOURCE, POLICY_MODEL_SUBJECT, LOCATION, and PROPERTY.\n\n3. The search criteria in criteria.fields.field can be used examples such as search by status, tags, effectType, date, text, hasParent. More model information detailed in the <a href=\"#model-PolicyLite\">PolicyLite</a>.\n\n4. The search by status (criteria.fields.field=status), the allowable values are DRAFT, APPROVED, OBSOLETE. (APPROVED = DEPLOYED, OBSOLETE = DEACTIVATED),  e.g.\"value\": \"DRAFT\".\n\n5. The search by effectType (criteria.fields.field=effectType), the allowable values are authorization decisions, which can be either \"Allow\" or \"Deny\"  e.g.\"value\": \"Allow\".\n\n6. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status. This can be refer from documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType), e.g. \"value\": [\"helpdesk_policy\"].\n\n7. The search by text (criteria.fields.field=text),the text represents a specific term used to search for the name and description of policy effectively. e.g.\"value\": \"Tickets\".\n\n8. To search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date)\n\n9. The search by hasParent (criteria.fields.field=hasParent), the value is either true (search result including the sub policies) or false (search result excluding sub policies).\n",
+            "operationId":"save_Policy_Search",
+            "requestBody":{
+               "description":"<a href=\"#model-SavedSearchDTO\">SavedSearchDTO</a>: A new search criteria to be saved.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "name":"Saved search for component Allow users action on support tickets",
+                           "desc":"Saved search for component Allow users action on support tickets description",
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"effectType",
+                                    "type":"MULTI_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "allow"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"status",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "DRAFT"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk_policy"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712634691925,
+                                       "toDate":1713239491925
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"Tickets"
+                                    }
+                                 },
+                                 {
+                                    "field":"hasParent",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"false"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/policy/search/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Deletes the saved search based on the given ID",
+            "description":"\n1. The saved search ID must exist before trying to delete.\nTo create saved search, refer to the documentation, [[Policy Search] POST/console/api/v1/policy/search/add-Saves a new policy search criteria](#/8.%20Policy%20Search/save_Policy_Search).\n",
+            "operationId":"removeCriteriaUsingDELETE_1",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to be deleted.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/search/saved/{id}":{
+         "get":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Retrieve the saved search based on the given ID",
+            "description":"\n1. The saved search ID must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Policy Search] POST/console/api/v1/policy/search/add-Saves a new policy search criteria](#/8.%20Policy%20Search/save_Policy_Search).\n",
+            "operationId":"getByIdUsingGET_1",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to be searched\n",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"name\": \"Saved search for component Allow users action on support tickets\",\n    \"desc\": \"Saved search for component Allow users action on support tickets description\",\n    \"criteria\": {\n      \"fields\": [\n        {\n          \"field\": \"effectType\",\n          \"type\": \"MULTI_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"allow\"]\n          }\n        },\n        {\n          \"field\": \"status\",\n          \"type\": \"MULTI\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"DRAFT\"]\n          }\n        },\n        {\n          \"field\": \"tags\",\n          \"type\": \"NESTED_MULTI\",\n          \"nestedField\": \"tags.key\",\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"helpdesk_policy\"]\n          }\n        },\n        {\n          \"field\": \"lastUpdatedDate\",\n          \"type\": \"DATE\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"Date\",\n            \"fromDate\": 1712634691925,\n            \"toDate\": 1713239491925,\n            \"dateOption\": \"PAST_7_DAYS\"\n          }\n        },\n        {\n          \"field\": \"text\",\n          \"type\": \"TEXT\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"Text\",\n            \"value\": \"Tickets\",\n            \"fields\": [\"name\",\"description\"]\n          }\n        },\n        {\n          \"field\": \"hasParent\",\n          \"type\": \"SINGLE_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": \"false\"\n          }\n        }\n      ],\n      \"sortFields\": [],\n      \"columns\": [],\n      \"facetField\": null,\n      \"properties\": null,\n      \"pageNo\": 0,\n      \"pageSize\": 10,\n      \"enableFullList\": false\n    },\n    \"status\": \"ACTIVE\",\n    \"sharedMode\": \"PUBLIC\",\n    \"userIds\": [],\n    \"type\": \"POLICY\"\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/search/savedlist":{
+         "get":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Retrieve all the saved search",
+            "description":"\n1. The saved search must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Policy Search] POST/console/api/v1/policy/search/add-Saves a new policy search criteria](#/8.%20Policy%20Search/save_Policy_Search).\n",
+            "operationId":"findByAllUsingGET_1",
+            "parameters":[
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": [\n    {\n      \"id\": 4,\n      \"name\": \"Sample saved search\",\n      \"desc\": \"Sample saved search description\",\n      \"criteria\": {\n        \"fields\": [\n          {\n            \"field\": \"status\",\n            \"type\": \"MULTI\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": \"String\",\n              \"type\": null,\n              \"value\": [\n                \"DRAFT\"\n              ]\n            }\n          },\n          {\n            \"field\": \"tags\",\n            \"type\": \"NESTED_MULTI\",\n            \"nestedField\": \"tags.key\",\n            \"value\": {\n              \"type\": \"String\",\n              \"type\": null,\n              \"value\": [\n                \"helpdesk\"\n              ]\n            }\n          },\n          {\n            \"field\": \"text\",\n            \"type\": \"TEXT\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": \"Text\",\n              \"type\": null,\n              \"value\": \"support tickets\",\n              \"fields\": [\n                \"name\",\n                \"description\"\n              ]\n            }\n          }\n        ],\n        \"sortFields\": [],\n        \"columns\": [],\n        \"facetField\": null,\n        \"properties\": null,\n        \"pageNo\": 0,\n        \"pageSize\": 10,\n        \"enableFullList\": false\n      },\n      \"status\": \"ACTIVE\",\n      \"sharedMode\": \"PUBLIC\",\n      \"userIds\": [],\n      \"type\": \"POLICY\"\n    },\n    {\n      \"id\": 5,\n      \"name\": \"Sample saved search 2\",\n      \"desc\": \"Sample saved search 2 description\",\n      \"criteria\": {\n        \"fields\": [\n          {\n            \"field\": \"status\",\n            \"type\": \"MULTI\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": \"String\",\n              \"type\": null,\n              \"value\": [\n                \"OBSOLETE\"\n              ]\n            }\n          },\n          {\n            \"field\": \"text\",\n            \"type\": \"TEXT\",\n            \"nestedField\": null,\n            \"value\": {\n              \"type\": \"Text\",\n              \"type\": null,\n              \"value\": \"support ticket\",\n              \"fields\": [\n                \"name\",\n                \"description\"\n              ]\n            }\n          }\n        ],\n        \"sortFields\": [],\n        \"columns\": [],\n        \"facetField\": null,\n        \"properties\": null,\n        \"pageNo\": 0,\n        \"pageSize\": 10,\n        \"enableFullList\": false\n      },\n      \"status\": \"ACTIVE\",\n      \"sharedMode\": \"PUBLIC\",\n      \"userIds\": [],\n      \"type\": \"POLICY\"\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 10,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 2,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/search/savedlist/{name}":{
+         "get":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Retrieve the saved search based on the given name or description.",
+            "description":"\n1. The saved search must exist before trying to retrieve.\nTo create saved search, refer to the documentation, [[Policy Search] POST/console/api/v1/policy/search/add-Saves a new policy search criteria](#/8.%20Policy%20Search/save_Policy_Search).\n",
+            "operationId":"findByTextUsingGET_1",
+            "parameters":[
+               {
+                  "name":"name",
+                  "in":"path",
+                  "description":"The name of the saved search criteria to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1003\",\n  \"message\": \"Data found successfully\",\n  \"data\": {\n    \"id\": {id},\n    \"name\": \"Saved search for component Allow users action on support tickets\",\n    \"desc\": \"Saved search for component Allow users action on support tickets description\",\n    \"criteria\": {\n      \"fields\": [\n        {\n          \"field\": \"effectType\",\n          \"type\": \"MULTI_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"allow\"]\n          }\n        },\n        {\n          \"field\": \"status\",\n          \"type\": \"MULTI\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"DRAFT\"]\n          }\n        },\n        {\n          \"field\": \"tags\",\n          \"type\": \"NESTED_MULTI\",\n          \"nestedField\": \"tags.key\",\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": [\"helpdesk_policy\"]\n          }\n        },\n        {\n          \"field\": \"lastUpdatedDate\",\n          \"type\": \"DATE\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"Date\",\n            \"fromDate\": 1712634691925,\n            \"toDate\": 1713239491925,\n            \"dateOption\": \"PAST_7_DAYS\"\n          }\n        },\n        {\n          \"field\": \"text\",\n          \"type\": \"TEXT\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"Text\",\n            \"value\": \"Tickets\",\n            \"fields\": [\"name\",\"description\"]\n          }\n        },\n        {\n          \"field\": \"hasParent\",\n          \"type\": \"SINGLE_EXACT_MATCH\",\n          \"nestedField\": null,\n          \"value\": {\n            \"type\": \"String\",\n            \"value\": \"false\"\n          }\n        }\n      ],\n      \"sortFields\": [],\n      \"columns\": [],\n      \"facetField\": null,\n      \"properties\": null,\n      \"pageNo\": 0,\n      \"pageSize\": 10,\n      \"enableFullList\": false\n    },\n    \"status\": \"ACTIVE\",\n    \"sharedMode\": \"PUBLIC\",\n    \"userIds\": [],\n    \"type\": \"POLICY\"\n  }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policy/search/{search}":{
+         "post":{
+            "tags":[
+               "Policy Search"
+            ],
+            "summary":"Searches for a list of policies based on a given search criteria.",
+            "description":"\n1. The search criteria in criteria.fields.field can be used examples such as search by status, tags, effectType, date, text, hasParent. More model information detailed in the <a href=\"#model-PolicyLite\">PolicyLite</a>.\n\n2. The search by status (criteria.fields.field=status), the allowable values are DRAFT, APPROVED, OBSOLETE. (APPROVED = DEPLOYED, OBSOLETE = DEACTIVATED),  e.g.\"value\": \"DRAFT\".\n\n3. The search by effectType (criteria.fields.field=effectType), the allowable values are authorization decisions, which can be either \"Allow\" or \"Deny\"  e.g.\"value\": \"Allow\".\n\n4. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status. This can be refer from documentation, [[Tag Management]-GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType), e.g. \"value\": [\"helpdesk_policy\"].\n\n5. The search by text (criteria.fields.field=text),the text represents a specific term used to search for the name and description of policy effectively. e.g.\"value\": \"Tickets\".\n\n6. To search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date)\n\n7. The search by hasParent (criteria.fields.field=hasParent), the value is either true (search result including the sub policies) or false (search result excluding sub policies).\n",
+            "operationId":"search_Policy_1",
+            "parameters":[
+               {
+                  "name":"search",
+                  "in":"path",
+                  "description":"search",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"<a href=\"#model-SearchCriteriaDTO\">SearchCriteriaDTO</a>: A search criteria to search for policies.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"effectType",
+                                    "type":"MULTI_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "allow"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"status",
+                                    "type":"MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "DRAFT"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk_policy"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712634137720,
+                                       "toDate":1713238937720
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"tickets"
+                                    }
+                                 },
+                                 {
+                                    "field":"hasParent",
+                                    "type":"SINGLE_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":"false"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "order":"DESC"
+                                 }
+                              ],
+                              "pageNo":0,
+                              "pageSize":20
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abPolicyLite\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"folderId\": -1,\n      \"folderName\": null,\n      \"folderPath\": null,\n      \"name\": \"Allow Users in IT to Edit and Reassign Tickets in their Product Area\",\n      \"lowercase_name\": \"allow users in it to edit and reassign tickets in their product area\",\n      \"rootFolder\": \"ROOT_207\",\n      \"policyFullName\": \"ROOT_207/Allow Users in IT to Edit and Reassign Tickets in their Product Area\",\n      \"description\": \"Allow Users in the IT department to Edit and Reassign Support Tickets assigned to their Product Area\",\n      \"status\": \"DRAFT\",\n      \"effectType\": \"allow\",\n      \"lastUpdatedDate\": 1713238881754,\n      \"createdDate\": 1713193182933,\n      \"hasParent\": false,\n      \"hasSubPolicies\": false,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": \"Administrator\",\n      \"modifiedById\": 0,\n      \"modifiedBy\": \"Administrator\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk_policy\",\n          \"label\": \"Helpdesk_Policy\",\n          \"type\": \"POLICY_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"noOfTags\": 1,\n      \"parentPolicy\": null,\n      \"subPolicies\": [],\n      \"childNodes\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY\"\n        },\n        {\n          \"authority\": \"MOVE_POLICY\"\n        },\n        {\n          \"authority\": \"CREATE_POLICY\"\n        },\n        {\n          \"authority\": \"PARTIAL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"FULL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"EXPORT_POLICY\"\n        }\n      ],\n      \"manualDeploy\": false,\n      \"deploymentTime\": 0,\n      \"deployed\": false,\n      \"actionType\": \"N/A\",\n      \"activeWorkflowId\": null,\n      \"activeEntityWorkflowRequestStatus\": null,\n      \"activeWorkflowRequestLevelStatus\": null,\n      \"revisionCount\": 0,\n      \"version\": 2,\n      \"componentIds\": [\n        {id},\n        {id},\n        {id},\n        {id}\n      ],\n      \"obligationModelIds\": null,\n      \"hideMoreDetails\": false,\n      \"deploymentPending\": false\n    },\n    {\n      \"id\": {id},\n      \"folderId\": -1,\n      \"folderName\": null,\n      \"folderPath\": null,\n      \"name\": \"Allow Users in IT to View All Support Tickets\",\n      \"lowercase_name\": \"allow users in it to view all support tickets\",\n      \"rootFolder\": \"ROOT_208\",\n      \"policyFullName\": \"ROOT_208/Allow Users in IT to View All Support Tickets\",\n      \"description\": \"Allow Users in the IT Department to View All Support Tickets\",\n      \"status\": \"DRAFT\",\n      \"effectType\": \"allow\",\n      \"lastUpdatedDate\": 1713238866440,\n      \"createdDate\": 1713193225880,\n      \"hasParent\": false,\n      \"hasSubPolicies\": false,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": \"Administrator\",\n      \"modifiedById\": 0,\n      \"modifiedBy\": \"Administrator\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk_policy\",\n          \"label\": \"Helpdesk_Policy\",\n          \"type\": \"POLICY_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"noOfTags\": 1,\n      \"parentPolicy\": null,\n      \"subPolicies\": [],\n      \"childNodes\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY\"\n        },\n        {\n          \"authority\": \"MOVE_POLICY\"\n        },\n        {\n          \"authority\": \"CREATE_POLICY\"\n        },\n        {\n          \"authority\": \"PARTIAL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"FULL_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"CLEAN_UP_IMPORT_POLICY\"\n        },\n        {\n          \"authority\": \"EXPORT_POLICY\"\n        }\n      ],\n      \"manualDeploy\": false,\n      \"deploymentTime\": 0,\n      \"deployed\": false,\n      \"actionType\": \"N/A\",\n      \"activeWorkflowId\": null,\n      \"activeEntityWorkflowRequestStatus\": null,\n      \"activeWorkflowRequestLevelStatus\": null,\n      \"revisionCount\": 0,\n      \"version\": 2,\n      \"componentIds\": [\n        {id},\n        {id}\n      ],\n      \"obligationModelIds\": null,\n      \"hideMoreDetails\": false,\n      \"deploymentPending\": false\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 2,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/active/{id}":{
+         "get":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Retrieve the detail of a component type (policy model) based on the given ID",
+            "description":"\n1. The active component type ID (policy model ID) must exist before trying to retrieve.\nTo create a new component type, refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add- Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n2. An active component type (policy model) shouldn't have the status field that is marked as DELETED.\n",
+            "operationId":"view_Active_PolicyModel",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the policy model to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abPolicyModelDTO\u00bb"
+                        },
+                        "example":"{\n    \"id\": {id},\n    \"name\": \"Support Tickets\",\n    \"shortName\": \"support_tickets\",\n    \"description\": \"Support Tickets Description\",\n    \"type\": \"RESOURCE\",\n    \"status\": \"ACTIVE\",\n    \"tags\": [],\n    \"attributes\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.100+00:00\",\n            \"lastUpdatedDate\": \"2024-03-13T08:03:48.100+00:00\",\n            \"version\": 4,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 16,\n            \"name\": \"Priority\",\n            \"shortName\": \"priority\",\n            \"dataType\": \"NUMBER\",\n            \"operatorConfigs\": [...],\n            \"regExPattern\": null,\n            \"policyModel\": null,\n            \"isReferenced\": null,\n            \"sortOrder\": 5\n        },\n        {...}\n    ],\n    \"actions\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.023+00:00\",\n            \"lastUpdatedDate\": \"2024-02-19T03:09:23.023+00:00\",\n            \"version\": 0,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 81,\n            \"name\": \"View\",\n            \"shortName\": \"VIEW_TKTS\",\n            \"shortCode\": \"cc\",\n            \"isReferenced\": null,\n            \"sortOrder\": 0\n        },\n        {...}\n    ],\n    \"obligations\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.120+00:00\",\n            \"lastUpdatedDate\": \"2024-03-13T08:03:48.350+00:00\",\n            \"version\": 4,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 6,\n            \"name\": \"Notify Customer\",\n            \"shortName\": \"notify_cust\",\n            \"runAt\": \"PEP\",\n            \"parameters\": [...],\n            \"isReferenced\": null,\n            \"sortOrder\": 0,\n            \"daeValidation\": \"No\"\n        },\n        {...}\n    \"authorities\": [\n            {\n                \"authority\": \"VIEW_POLICY_MODEL\"\n            },\n            {...}\n        ]\n     \"lastUpdatedDate\": 1710317028350,\n     \"createdDate\": 0,\n     \"ownerId\": 0,\n     \"ownerDisplayName\": null,\n     \"modifiedById\": 0,\n     \"modifiedBy\": null,\n     \"version\": 8\n     }"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/add":{
+         "post":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Creates a new component type (policy model)",
+            "description":"\n1. A component type (policy model) have mandatory name and short name fields.\n\n2. A subject component types are limited or fixed to USER, HOST, and APPLICATION for subject components.\n\n3. A resource component types can be added/customized for resource or action components. e.g. Support Tickets\n\n4. The tags field are labels that identify or classify objects, which can be refer to the documentation, [[Tag Management] GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n\n5. The attributes field are associated data, which have mandatory name, data type, and operator(s) fields. The allowable values for the data types are DATE, TIME_INTERVAL, NUMBER, STRING, and MULTIVAL. The Operator(s) field can be refer to the documentation, [[Operator Configuration] GET/console/api/v1/config/dataType/list-retrieve all the operators](#/1.%20Operator%20Configuration/find_All_Operator).\n\n6. The actions field represent operations that can be performed on resource types, such as opening, copying, printing, or sharing. Authorization requests involve accessing resources and performing actions. For e.g. \"Assign\", \"View\", \"Edit\" support tickets. The Action field have mandatory name and short name fields.\n\n7. The obligations field are sets of operations that must be executed by the Policy Enforcement Point (PEP) alongside an authorization decision, which can be either \"Allow\" or \"Deny\". The Obligations field have mandatory name and short name fields. Adding parameters to an obligation requires mandatory parameter name and short name.\n",
+            "operationId":"add_PolicyModel",
+            "requestBody":{
+               "description":"\n<a href=\"#model-PolicyModelDTOReq\">PolicyModelDTOReq</a>: A new policy model to be saved.\n\n1. Execute [[Tag Management] GET/console/api/v1/config/tags/list/POLICY_MODEL_TAG](#/2.%20Tag%20Management/find_Tag_ByType) and populate the tag {id} in the payload accordingly.\n\n2. Execute [[Operator Configuration] GET/console/api/v1/config/dataType/list](#/1.%20Operator%20Configuration/find_All_Operator) and populate all the operatorConfigs {id} in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":null,
+                           "name":"Support Tickets",
+                           "shortName":"support_tickets",
+                           "description":"Support Tickets Description",
+                           "type":"RESOURCE",
+                           "status":"ACTIVE",
+                           "tags":[
+                              {
+                                 "id":"{{id}}",
+                                 "key":"helpdesk",
+                                 "label":"helpdesk",
+                                 "type":"POLICY_MODEL_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "attributes":[
+                              {
+                                 "id":null,
+                                 "name":"Created By",
+                                 "shortName":"created_by",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":0
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Category",
+                                 "shortName":"category",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":2
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Assigned To",
+                                 "shortName":"assigned_to",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":4
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Priority",
+                                 "shortName":"priority",
+                                 "dataType":"NUMBER",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"<=",
+                                       "label":"<=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"<",
+                                       "label":"<",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":">",
+                                       "label":">",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":">=",
+                                       "label":">=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"!=",
+                                       "label":"!=",
+                                       "dataType":"NUMBER"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":5
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Ticket Id",
+                                 "shortName":"ticket_id",
+                                 "dataType":"NUMBER",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"<=",
+                                       "label":"<=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"<",
+                                       "label":"<",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":">",
+                                       "label":">",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":">=",
+                                       "label":">=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":7,
+                                       "key":"!=",
+                                       "label":"!=",
+                                       "dataType":"NUMBER"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":6
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Product Name",
+                                 "shortName":"prod_name",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{{id}}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":7
+                              }
+                           ],
+                           "actions":[
+                              {
+                                 "id":null,
+                                 "name":"Edit",
+                                 "shortName":"EDIT_TKTS",
+                                 "sortOrder":0
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Assign",
+                                 "shortName":"ASSIGN_TKTS",
+                                 "sortOrder":1
+                              },
+                              {
+                                 "id":null,
+                                 "name":"View",
+                                 "shortName":"VIEW_TKTS",
+                                 "sortOrder":2
+                              }
+                           ],
+                           "obligations":[
+                              {
+                                 "id":null,
+                                 "name":"Policy Violation Notification",
+                                 "shortName":"notify_violation",
+                                 "runAt":"PEP",
+                                 "parameters":[
+                                    {
+                                       "id":null,
+                                       "name":"Ticket Id",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":"${from.ticket_id}",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":0,
+                                       "shortName":"ticket_id"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Assigned To",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":"${from.assigned_to}",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":1,
+                                       "shortName":"assigned_to"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Violation Message",
+                                       "type":"TEXT_MULTIPLE_ROW",
+                                       "defaultValue":"<Enter the reason why access is denied>",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":2,
+                                       "shortName":"message"
+                                    }
+                                 ],
+                                 "sortOrder":0,
+                                 "daeValidation":"No"
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Notify Customer",
+                                 "shortName":"notify_cust",
+                                 "runAt":"PEP",
+                                 "parameters":[
+                                    {
+                                       "id":null,
+                                       "name":"Customer Notification",
+                                       "type":"TEXT_MULTIPLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":0,
+                                       "shortName":"message"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Ticket Id",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":1,
+                                       "shortName":"ticket_id"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Assigned To",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":2,
+                                       "shortName":"assigned_to"
+                                    }
+                                 ],
+                                 "sortOrder":1,
+                                 "daeValidation":"No"
+                              }
+                           ],
+                           "version":0
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyModelDTO"
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/bulkDelete":{
+         "delete":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Removes a list of component types (policy models) based on the list of IDs",
+            "description":"\n1. The component type IDs (policy model IDs) must exist before trying to delete.\nTo create a new component type, refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add- Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n2. If the policy model is being referenced by component(s), it can't be removed. Please unlink them from the components before removing.",
+            "operationId":"bulk_Delete_PolicyModel",
+            "requestBody":{
+               "description":"The list of policy model's ID to be deleted",
+               "content":{
+                  "*/*":{
+                     "schema":{
+                        "type":"array",
+                        "example":[
+                           "${id}",
+                           "${id}"
+                        ],
+                        "items":{
+                           "type":"integer",
+                           "format":"int64"
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"ids"
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/clone":{
+         "post":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Clone an existing component type (policy model) based on the given id",
+            "description":"\n1. The component type ID (policy model ID) must exist before trying to clone.\nTo create a new component type, refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add- Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n",
+            "operationId":"clone_PolicyModel",
+            "requestBody":{
+               "description":"The existing policy model id to be cloned.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"integer",
+                        "format":"int64"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"id"
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/extraSubjectAttribs/{type}":{
+         "get":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Retrieve the enrolled subject attributes or properties based on a component type",
+            "description":"\n1. The type of the policy model can be APPLICATION, USER and HOST.\n",
+            "operationId":"loadExtraSubjectAttributesUsingGET",
+            "parameters":[
+               {
+                  "name":"type",
+                  "in":"path",
+                  "description":"The type of the policy model to be loaded.\n",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1003\",\n    \"message\": \"Data found successfully\",\n    \"data\": [\n        {\n            \"createdDate\": null,\n            \"lastUpdatedDate\": null,\n            \"version\": 0,\n            \"ownerId\": null,\n            \"lastUpdatedBy\": null,\n            \"id\": null,\n            \"name\": \"Windows User SID\",\n            \"shortName\": \"windowsSid\",\n            \"dataType\": \"STRING\",\n            \"operatorConfigs\": [\n                {\n                    \"createdDate\": \"2024-02-01T11:52:52.057+00:00\",\n                    \"lastUpdatedDate\": \"2024-02-01T11:52:52.057+00:00\",\n                    \"version\": 0,\n                    \"ownerId\": 0,\n                    \"lastUpdatedBy\": 0,\n                    \"id\": 5,\n                    \"key\": \"!=\",\n                    \"label\": \"is not\",\n                    \"dataType\": \"STRING\"\n                },\n        {...}\n    ],\n    \"pageNo\": 0,\n    \"pageSize\": 7,\n    \"totalPages\": 1,\n    \"totalNoOfRecords\": 7,\n    \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/modify":{
+         "put":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Creates a new component type (policy model)",
+            "description":"\n1. An existing component type (policy model) have existing id, mandatory name and short name fields.\n\n2. A subject component types are limited or fixed to USER, HOST, and APPLICATION for subject components.\n\n3. A resource component types can be added/customized for resource or action components. e.g. Support Tickets\n\n4. The tags field are labels that identify or classify objects, which can be refer to the documentation, [[Tag Management] GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n\n5. The attributes field are associated data, which have mandatory name, data type, and operator(s) fields. The allowable values for the data types are DATE, TIME_INTERVAL, NUMBER, STRING, and MULTIVAL. The Operator(s) field can be refer to the documentation,[[Operator Configuration] GET/console/api/v1/config/dataType/list-retrieve all the operators](#/1.%20Operator%20Configuration/find_All_Operator).\n\n6. The actions field represent operations that can be performed on resource types, such as opening, copying, printing, or sharing. Authorization requests involve accessing resources and performing actions. For e.g. \"Assign\", \"View\", \"Edit\" support tickets. The Action field have mandatory name and short name fields.\n\n7. The obligations field are sets of operations that must be executed by the Policy Enforcement Point (PEP) alongside an authorization decision, which can be either \"Allow\" or \"Deny\". The Obligations field have mandatory name and short name fields. Adding parameters to an obligation requires mandatory parameter name and short name.\n",
+            "operationId":"modify_PolicyModel",
+            "requestBody":{
+               "description":"\n<a href=\"#model-PolicyModelDTOsReq\">PolicyModelDTOReq</a>: An existing policy model to be saved.\n\n1. Execute [[Tag Management] GET/console/api/v1/config/tags/list/POLICY_MODEL_TAG](#/2.%20Tag%20Management/find_Tag_ByType) and populate the tag {id} in the payload accordingly.\n\n2. Execute [[Operator Configuration] GET/console/api/v1/config/dataType/list](#/1.%20Operator%20Configuration/find_All_Operator) and populate all the operatorConfigs {id} in the payload accordingly.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "id":"{id}",
+                           "name":"Support Tickets",
+                           "shortName":"support_tickets",
+                           "description":"Support Tickets Description",
+                           "type":"RESOURCE",
+                           "status":"ACTIVE",
+                           "tags":[
+                              {
+                                 "id":"{id}",
+                                 "key":"helpdesk",
+                                 "label":"helpdesk",
+                                 "type":"POLICY_MODEL_TAG",
+                                 "status":"ACTIVE"
+                              }
+                           ],
+                           "attributes":[
+                              {
+                                 "id":null,
+                                 "name":"Created By",
+                                 "shortName":"created_by",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":0
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Category",
+                                 "shortName":"category",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":2
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Assigned To",
+                                 "shortName":"assigned_to",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":4
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Priority",
+                                 "shortName":"priority",
+                                 "dataType":"NUMBER",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"<=",
+                                       "label":"<=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"<",
+                                       "label":"<",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":">",
+                                       "label":">",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":">=",
+                                       "label":">=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":7,
+                                       "key":"!=",
+                                       "label":"!=",
+                                       "dataType":"NUMBER"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":5
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Ticket Id",
+                                 "shortName":"ticket_id",
+                                 "dataType":"NUMBER",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"<=",
+                                       "label":"<=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"<",
+                                       "label":"<",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":">",
+                                       "label":">",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":">=",
+                                       "label":">=",
+                                       "dataType":"NUMBER"
+                                    },
+                                    {
+                                       "id":7,
+                                       "key":"!=",
+                                       "label":"!=",
+                                       "dataType":"NUMBER"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":6
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Product Name",
+                                 "shortName":"prod_name",
+                                 "dataType":"STRING",
+                                 "operatorConfigs":[
+                                    {
+                                       "id":"{id}",
+                                       "key":"!=",
+                                       "label":"is not",
+                                       "dataType":"STRING"
+                                    },
+                                    {
+                                       "id":"{id}",
+                                       "key":"=",
+                                       "label":"is",
+                                       "dataType":"STRING"
+                                    }
+                                 ],
+                                 "regExPattern":null,
+                                 "sortOrder":7
+                              }
+                           ],
+                           "actions":[
+                              {
+                                 "id":null,
+                                 "name":"Edit",
+                                 "shortName":"EDIT_TKTS",
+                                 "sortOrder":0
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Assign",
+                                 "shortName":"ASSIGN_TKTS",
+                                 "sortOrder":1
+                              },
+                              {
+                                 "id":null,
+                                 "name":"View",
+                                 "shortName":"VIEW_TKTS",
+                                 "sortOrder":2
+                              }
+                           ],
+                           "obligations":[
+                              {
+                                 "id":null,
+                                 "name":"Policy Violation Notification",
+                                 "shortName":"notify_violation",
+                                 "runAt":"PEP",
+                                 "parameters":[
+                                    {
+                                       "id":null,
+                                       "name":"Ticket Id",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":"${from.ticket_id}",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":0,
+                                       "shortName":"ticket_id"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Assigned To",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":"${from.assigned_to}",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":1,
+                                       "shortName":"assigned_to"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Violation Message",
+                                       "type":"TEXT_MULTIPLE_ROW",
+                                       "defaultValue":"<Enter the reason why access is denied>",
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":true,
+                                       "sortOrder":2,
+                                       "shortName":"message"
+                                    }
+                                 ],
+                                 "sortOrder":0,
+                                 "daeValidation":"No"
+                              },
+                              {
+                                 "id":null,
+                                 "name":"Notify Customer",
+                                 "shortName":"notify_cust",
+                                 "runAt":"PEP",
+                                 "parameters":[
+                                    {
+                                       "id":null,
+                                       "name":"Customer Notification",
+                                       "type":"TEXT_MULTIPLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":0,
+                                       "shortName":"message"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Ticket Id",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":1,
+                                       "shortName":"ticket_id"
+                                    },
+                                    {
+                                       "id":null,
+                                       "name":"Assigned To",
+                                       "type":"TEXT_SINGLE_ROW",
+                                       "defaultValue":null,
+                                       "value":"",
+                                       "listValues":null,
+                                       "hidden":false,
+                                       "editable":true,
+                                       "mandatory":false,
+                                       "sortOrder":2,
+                                       "shortName":"assigned_to"
+                                    }
+                                 ],
+                                 "sortOrder":1,
+                                 "daeValidation":"No"
+                              }
+                           ],
+                           "version":0
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data modified successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1001\",\n    \"message\": \"Data modified successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"policyModelDTO"
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Removes a component type (policy model) based on the given id",
+            "description":"\n1. The component type ID (policy model ID) must exist before trying to delete.\nTo create a new component type, refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add- Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n\n2. If the policy model is being referenced by component(s), it can't be removed. Please unlink them from the components before removing.\n",
+            "operationId":"delete_PolicyModel_ById",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the policy model to be deleted.\n\nPlease ensure that the component type (policy model) you're trying to delete exists.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/mgmt/{id}":{
+         "get":{
+            "tags":[
+               "Component Type Management"
+            ],
+            "summary":"Retrieve the detail of a component type (policy model) based on the given ID",
+            "description":"\n1. The component type ID (policy model ID) must exist before trying to retrieve.\n To create a new component type, refer to the documentation, [[Component Type Management] POST/console/api/v1/policyModel/mgmt/add- Creates a new component type (policy model)](#/3.%20Component%20Type%20Management/add_PolicyModel).\n",
+            "operationId":"view_PolicyModel",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the policy model to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abPolicyModelDTO\u00bb"
+                        },
+                        "example":"{\n    \"id\": {id},\n    \"name\": \"Support Tickets\",\n    \"shortName\": \"support_tickets\",\n    \"description\": \"Support Tickets Description\",\n    \"type\": \"RESOURCE\",\n    \"status\": \"ACTIVE\",\n    \"tags\": [],\n    \"attributes\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.100+00:00\",\n            \"lastUpdatedDate\": \"2024-03-13T08:03:48.100+00:00\",\n            \"version\": 4,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 16,\n            \"name\": \"Priority\",\n            \"shortName\": \"priority\",\n            \"dataType\": \"NUMBER\",\n            \"operatorConfigs\": [...],\n            \"regExPattern\": null,\n            \"policyModel\": null,\n            \"isReferenced\": null,\n            \"sortOrder\": 5\n        },\n        {...}\n    ],\n    \"actions\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.023+00:00\",\n            \"lastUpdatedDate\": \"2024-02-19T03:09:23.023+00:00\",\n            \"version\": 0,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 81,\n            \"name\": \"View\",\n            \"shortName\": \"VIEW_TKTS\",\n            \"shortCode\": \"cc\",\n            \"isReferenced\": null,\n            \"sortOrder\": 0\n        },\n        {...}\n    ],\n    \"obligations\": [\n        {\n            \"createdDate\": \"2024-02-19T03:09:23.120+00:00\",\n            \"lastUpdatedDate\": \"2024-03-13T08:03:48.350+00:00\",\n            \"version\": 4,\n            \"ownerId\": 0,\n            \"lastUpdatedBy\": 0,\n            \"id\": 6,\n            \"name\": \"Notify Customer\",\n            \"shortName\": \"notify_cust\",\n            \"runAt\": \"PEP\",\n            \"parameters\": [...],\n            \"isReferenced\": null,\n            \"sortOrder\": 0,\n            \"daeValidation\": \"No\"\n        },\n        {...}\n    \"authorities\": [\n            {\n                \"authority\": \"VIEW_POLICY_MODEL\"\n            },\n            {...}\n        ]\n     \"lastUpdatedDate\": 1710317028350,\n     \"createdDate\": 0,\n     \"ownerId\": 0,\n     \"ownerDisplayName\": null,\n     \"modifiedById\": 0,\n     \"modifiedBy\": null,\n     \"version\": 8\n     }"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/search":{
+         "post":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Searches for a list of component types based on a given search criteria",
+            "description":"\n1. The search criteria in criteria.fields.field is used to search by type, tags, date, text, etc. The model information can be referred in the documentation, <a href=\"#model-ComponentLite\">ComponentLite</a>.\n\n2. The search by type (criteria.fields.field=type), the allowable values are RESOURCE or SUBJECT.  e.g. \"value\": [\"RESOURCE\"]\n\n3. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status. e.g. \"value\": [\"helpdesk\"] can be refer from documentation, [[Tag Management] GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n\n4. The search by text (criteria.fields.field=text), e.g.\"value\": \"Support\" represents a specific term used to search for the name and description of the component type effectively.\n\n5. The search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date)\n",
+            "operationId":"search_PolicyModel",
+            "requestBody":{
+               "description":"\n<a href=\"#model-SearchCriteriaDTO\">SearchCriteriaDTO</a>: A search criteria to search for component types.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"type",
+                                    "type":"MULTI_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "RESOURCE"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712561680933,
+                                       "toDate":1713166480933
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"support"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 {
+                                    "field":"type",
+                                    "order":"DESC"
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "order":"DESC"
+                                 }
+                              ],
+                              "pageNo":0,
+                              "pageSize":20
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data loaded successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abPolicyModelDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Support Tickets\",\n      \"shortName\": \"support_tickets\",\n      \"description\": \"Support Tickets Description\",\n      \"type\": \"RESOURCE\",\n      \"status\": \"ACTIVE\",\n      \"tags\": [\n        {\n          \"id\": 21,\n          \"key\": \"helpdesk\",\n          \"label\": \"helpdesk\",\n          \"type\": \"POLICY_MODEL_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"attributes\": [],\n      \"actions\": [],\n      \"obligations\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY_MODEL\"\n        }\n      ],\n      \"lastUpdatedDate\": 1713166450257,\n      \"createdDate\": 0,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": null,\n      \"modifiedById\": 0,\n      \"modifiedBy\": null,\n      \"version\": 1\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/policyModel/search/add":{
+         "post":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Saves a new component type (policy model) search criteria",
+            "description":"\n1. A new saved component type search criteria requires mandatory name, description, and type fields.\n\n2. The type field must be chosen from a predefined set of options, including POLICY, COMPONENT, POLICY_MODEL_RESOURCE, POLICY_MODEL_SUBJECT, LOCATION, and PROPERTY.\n\n3. The search criteria in criteria.fields.field is used to search by type, tags, date, text, etc. The model information can be refer in the documentation, <a href=\"#model-ComponentLite\">ComponentLite</a>.\n\n4. The search by type (criteria.fields.field=type), the allowable values are RESOURCE or SUBJECT.  e.g. \"value\": [\"RESOURCE\"]\n\n5. The search by tag (criteria.fields.field=tags), the allowable values for criteria.fields.nestedField include tags.key, tags.label, tags.type, and tags.status. e.g. \"value\": [\"helpdesk\"] can be refer from documentation, [[Tag Management] GET/console/api/v1/config/tags/list/{type}-retrieve a list of tag based on tag type.](#/2.%20Tag%20Management/find_Tag_ByType)\n\n6. The search by text (criteria.fields.field=text), e.g.\"value\": \"Support\" represents a specific term used to search for the name and description of the component type effectively.\n\n7. The search by date (criteria.fields.field=lastUpdatedDate, the allowable values for dateOption include PAST_7_DAYS, PAST_30_DAYS, PAST_3_MONTHS, PAST_1_YEAR and CUSTOM (for from date to date)\n",
+            "operationId":"save_PolicyModel_Search",
+            "requestBody":{
+               "description":"<a href=\"#model-SavedSearchDTO\">SavedSearchDTO</a>: A new search criteria to be saved.\n",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "type":"string",
+                        "example":{
+                           "name":"Saved search for policy model support ticket",
+                           "desc":"saved search description",
+                           "type":"POLICY_MODEL_RESOURCE",
+                           "criteria":{
+                              "fields":[
+                                 {
+                                    "field":"type",
+                                    "type":"MULTI_EXACT_MATCH",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "RESOURCE"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"tags",
+                                    "nestedField":"tags.key",
+                                    "type":"NESTED_MULTI",
+                                    "value":{
+                                       "type":"String",
+                                       "value":[
+                                          "helpdesk"
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    "field":"lastUpdatedDate",
+                                    "type":"DATE",
+                                    "value":{
+                                       "type":"Date",
+                                       "dateOption":"PAST_7_DAYS",
+                                       "fromDate":1712564535526,
+                                       "toDate":1713169335526
+                                    }
+                                 },
+                                 {
+                                    "field":"text",
+                                    "type":"TEXT",
+                                    "value":{
+                                       "type":"Text",
+                                       "fields":[
+                                          "name",
+                                          "description"
+                                       ],
+                                       "value":"support"
+                                    }
+                                 }
+                              ],
+                              "sortFields":[
+                                 
+                              ],
+                              "columns":[
+                                 
+                              ],
+                              "facetField":null,
+                              "properties":null,
+                              "pageNo":0,
+                              "pageSize":20,
+                              "enableFullList":false
+                           }
+                        }
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Data saved successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1000\",\n    \"message\": \"Data saved successfully\",\n    \"data\": {id}\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"criteriaDTO"
+         }
+      },
+      "/console/api/v1/policyModel/search/remove/{id}":{
+         "delete":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Deletes the saved search based on the given ID",
+            "description":"\n1. The saved search ID must exist before trying to delete.To create saved search, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search/add-Saves a new component type (policy model) search criteria](#/4.%20Component%20Type%20Search/save_PolicyModel_Search)\n",
+            "operationId":"remove_PolicyModel_Search_Criteria",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to be deleted.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data deleted successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ResponseDTO"
+                        },
+                        "example":"{\n    \"statusCode\": \"1002\",\n    \"message\": \"Data deleted successfully\",\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/search/saved/{id}":{
+         "get":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Retrieve the saved search based on the given ID",
+            "description":"\n1. The saved search ID must exist before trying to retrieve.To create a new saved search, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search/add-Saves a new component type (policy model) search criteria](#/4.%20Component%20Type%20Search/save_PolicyModel_Search)\n",
+            "operationId":"get_PolicyModel_SavedSearch_byId",
+            "parameters":[
+               {
+                  "name":"id",
+                  "in":"path",
+                  "description":"The ID of the saved search criteria to retrieve\n",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/SimpleResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Support Tickets\",\n      \"shortName\": \"support_tickets\",\n      \"description\": \"Support Tickets Description\",\n      \"type\": \"RESOURCE\",\n      \"status\": \"ACTIVE\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk\",\n          \"label\": \"helpdesk\",\n          \"type\": \"POLICY_MODEL_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"attributes\": [],\n      \"actions\": [],\n      \"obligations\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY_MODEL\"\n        }\n      ],\n      \"lastUpdatedDate\": 1713166450663,\n      \"createdDate\": 0,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": null,\n      \"modifiedById\": 0,\n      \"modifiedBy\": null,\n      \"version\": 2\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/search/savedlist/{type}":{
+         "get":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Retrieves all the saved searches based on the given type",
+            "description":"\n1. The saved search must exist before trying to retrieve.To create a new saved search, refer to the documentation,[[Component Type Search] POST/console/api/v1/policyModel/search/add-Saves a new component type (policy model) search criteria](#/4.%20Component%20Type%20Search/save_PolicyModel_Search)\n\n2. The type field accepts specific values such as POLICY, COMPONENT, POLICY_MODEL_RESOURCE, POLICY_MODEL_SUBJECT, LOCATION, and PROPERTY.",
+            "operationId":"get_PolicyModel_SavedSearch_byType",
+            "parameters":[
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               },
+               {
+                  "name":"type",
+                  "in":"path",
+                  "description":"The type of the saved search criteria to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Support Tickets\",\n      \"shortName\": \"support_tickets\",\n      \"description\": \"Support Tickets Description\",\n      \"type\": \"RESOURCE\",\n      \"status\": \"ACTIVE\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk\",\n          \"label\": \"helpdesk\",\n          \"type\": \"POLICY_MODEL_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"attributes\": [],\n      \"actions\": [],\n      \"obligations\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY_MODEL\"\n        }\n      ],\n      \"lastUpdatedDate\": 1713166450663,\n      \"createdDate\": 0,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": null,\n      \"modifiedById\": 0,\n      \"modifiedBy\": null,\n      \"version\": 2\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/api/v1/policyModel/search/savedlist/{type}/{name}":{
+         "get":{
+            "tags":[
+               "Component Type Search"
+            ],
+            "summary":"Retrieve the saved search based on the given type and name",
+            "description":"\n1. The saved search must exist before trying to retrieve.To create a new saved search, refer to the documentation, [[Component Type Search] POST/console/api/v1/policyModel/search/add-Saves a new component type (policy model) search criteria](#/4.%20Component%20Type%20Search/save_PolicyModel_Search)\n\n2. The name field serves as a substring of the saved search criteria name or description to facilitate searching.\n\n3. The type field accepts specific values such as POLICY, COMPONENT, POLICY_MODEL_RESOURCE, POLICY_MODEL_SUBJECT, LOCATION, and PROPERTY.\n",
+            "operationId":"get_PolicyModel_SavedSearch_byText",
+            "parameters":[
+               {
+                  "name":"name",
+                  "in":"path",
+                  "description":"The name of the saved search criteria to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "name":"pageNo",
+                  "in":"query",
+                  "description":"The number of pages in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  }
+               },
+               {
+                  "name":"pageSize",
+                  "in":"query",
+                  "description":"The size of each page in paginated data",
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":10
+                  }
+               },
+               {
+                  "name":"type",
+                  "in":"path",
+                  "description":"The type of the saved search criteria to be searched",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Data found successfully",
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb"
+                        },
+                        "example":"{\n  \"statusCode\": \"1004\",\n  \"message\": \"Data loaded successfully\",\n  \"data\": [\n    {\n      \"id\": {id},\n      \"name\": \"Support Tickets\",\n      \"shortName\": \"support_tickets\",\n      \"description\": \"Support Tickets Description\",\n      \"type\": \"RESOURCE\",\n      \"status\": \"ACTIVE\",\n      \"tags\": [\n        {\n          \"id\": {id},\n          \"key\": \"helpdesk\",\n          \"label\": \"helpdesk\",\n          \"type\": \"POLICY_MODEL_TAG\",\n          \"status\": \"ACTIVE\"\n        }\n      ],\n      \"attributes\": [],\n      \"actions\": [],\n      \"obligations\": [],\n      \"authorities\": [\n        {\n          \"authority\": \"VIEW_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"EDIT_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DELETE_POLICY_MODEL\"\n        },\n        {\n          \"authority\": \"DEPLOY_POLICY_MODEL\"\n        }\n      ],\n      \"lastUpdatedDate\": 1713166450663,\n      \"createdDate\": 0,\n      \"ownerId\": 0,\n      \"ownerDisplayName\": null,\n      \"modifiedById\": 0,\n      \"modifiedBy\": null,\n      \"version\": 2\n    }\n  ],\n  \"pageNo\": 0,\n  \"pageSize\": 20,\n  \"totalPages\": 1,\n  \"totalNoOfRecords\": 1,\n  \"additionalAttributes\": null\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         }
+      },
+      "/console/scim/v2/Bulk":{
+         "post":{
+            "tags":[
+               "SCIM Bulk Controller"
+            ],
+            "summary":"Performs multiple SCIM operations.",
+            "description":"Returns the results of SCIM operations performed.",
+            "operationId":"bulkRequestUsingPOST",
+            "requestBody":{
+               "description":"Patch request containing the operations to be applied.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/BulkRequest"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/BulkResponse"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:api:messages:2.0:BulkResponse\"\n    ],\n    \"Operations\": [\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n            \"method\": \"POST\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"201\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n            \"method\": \"PUT\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"200\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n            \"method\": \"PATCH\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"200\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n            \"method\": \"DELETE\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"204\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n            \"method\": \"POST\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"201\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n            \"method\": \"PUT\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"200\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n            \"method\": \"PATCH\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"204\"\n        },\n        {\n            \"method\": \"BulkResponseOperation\",\n            \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n            \"method\": \"DELETE\",\n            \"bulkId\": \"qwerty\",\n            \"status\": \"204\"\n        },\n    ]\n}\n"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"request"
+         }
+      },
+      "/console/scim/v2/Groups":{
+         "get":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Retrieves all existing SCIM groups.",
+            "description":"Returns a list of all existing SCIM groups.",
+            "operationId":"getGroupsUsingGET",
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ListResponse\u00abGroupResource\u00bb"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:api:messages:2.0:ListResponse\"\n    ],\n    \"totalResults\": 1,\n    \"Resources\": [\n        {\n            \"schemas\": [\n                \"urn:ietf:params:scim:schemas:core:2.0:Group\"\n            ],\n            \"id\": \"3\",\n            \"meta\": {\n                \"resourceType\": \"Group\",\n                \"created\": \"2023-11-24T03:59:20.658+00:00\",\n                \"lastModified\": \"2023-11-24T03:59:20.658+00:00\",\n                \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n                \"version\": \"1.0\"\n            },\n            \"displayName\": \"SCIM Users\",\n            \"members\": [\n                {\n                    \"value\": \"1\",\n                    \"$ref\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\"\n                }\n            ]\n        }\n    ],\n    \"startIndex\": 1,\n    \"itemsPerPage\": 1\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "post":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Creates a new SCIM group.",
+            "description":"Returns the newly created SCIM group after group is successfully saved.",
+            "operationId":"addGroupUsingPOST",
+            "requestBody":{
+               "description":"The new SCIM group to be saved.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/GroupResourceReq"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "201":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/GroupResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:core:2.0:Group\"\n    ],\n    \"id\": \"3\",\n    \"meta\": {\n        \"resourceType\": \"Group\",\n        \"created\": \"2023-11-24T03:59:19.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:19.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n        \"version\": \"1.0\"\n    },\n    \"displayName\": \"SCIM Users\",\n    \"members\": [\n        {\n            \"value\": \"1\",\n            \"$ref\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\"\n        }\n    ]\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"group"
+         }
+      },
+      "/console/scim/v2/Groups/{groupId}":{
+         "get":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Retrieves an existing SCIM group.",
+            "description":"Returns an existing SCIM group.",
+            "operationId":"getGroupUsingGET",
+            "parameters":[
+               {
+                  "name":"groupId",
+                  "in":"path",
+                  "description":"Id of the group to be retrieved.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/GroupResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:core:2.0:Group\"\n    ],\n    \"id\": \"3\",\n    \"meta\": {\n        \"resourceType\": \"Group\",\n        \"created\": \"2023-11-24T03:59:19.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:19.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n        \"version\": \"1.0\"\n    },\n    \"displayName\": \"SCIM Users\",\n    \"members\": [\n        {\n            \"value\": \"1\",\n            \"$ref\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\"\n        }\n    ]\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "put":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Replaces an existing SCIM group.",
+            "description":"Returns the replaced SCIM group after group is successfully updated.",
+            "operationId":"replaceGroupUsingPUT",
+            "parameters":[
+               {
+                  "name":"groupId",
+                  "in":"path",
+                  "description":"Id of the group to be replaced.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"The existing SCIM group to be updated.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/GroupResourceReq"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/GroupResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:core:2.0:Group\"\n    ],\n    \"id\": \"3\",\n    \"meta\": {\n        \"resourceType\": \"Group\",\n        \"created\": \"2023-11-24T03:59:19.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:19.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Groups/3\",\n        \"version\": \"1.0\"\n    },\n    \"displayName\": \"SCIM Users\",\n    \"members\": [\n        {\n            \"value\": \"1\",\n            \"$ref\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\"\n        }\n    ]\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"group"
+         },
+         "delete":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Deletes an existing SCIM group.",
+            "operationId":"deleteGroupUsingDELETE",
+            "parameters":[
+               {
+                  "name":"groupId",
+                  "in":"path",
+                  "description":"Id of the group to be deleted.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "204":{
+                  "content":{
+                     
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "patch":{
+            "tags":[
+               "SCIM Group Controller"
+            ],
+            "summary":"Patches an existing SCIM group.",
+            "operationId":"patchGroupUsingPATCH",
+            "parameters":[
+               {
+                  "name":"groupId",
+                  "in":"path",
+                  "description":"Id of the group to be patched.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"Patch request containing the operations to be applied.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PatchRequest"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "204":{
+                  "content":{
+                     
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"request"
+         }
+      },
+      "/console/scim/v2/Users":{
+         "get":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Retrieves all existing SCIM users.",
+            "description":"Returns a list of all existing SCIM users.",
+            "operationId":"getUsersUsingGET",
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/ListResponse\u00abUserResource\u00bb"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:api:messages:2.0:ListResponse\"\n    ],\n    \"totalResults\": 2,\n    \"Resources\": [{\n            \"schemas\": [\n                \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n                \"urn:ietf:params:scim:schemas:core:2.0:User\"\n            ],\n            \"id\": \"1\",\n            \"meta\": {\n                \"resourceType\": \"User\",\n                \"created\": \"2023-11-24T03:59:17.658+00:00\",\n                \"lastModified\": \"2023-11-24T03:59:17.658+00:00\",\n                \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n                \"version\": \"1.0\"\n            },\n            \"userName\": \"bjensen\",\n            \"name\": {\n                \"familyName\": \"Barbara\",\n                \"givenName\": \"Jensen\"\n            },\n            \"displayName\": \"Barbara Jensen\",\n            \"active\": true,\n            \"emails\": [{\n                    \"value\": \"bjensen@example.com\",\n                    \"type\": \"work\",\n                    \"primary\": true\n                }\n            ],\n            \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n                \"unixId\": \"701984\"\n            }\n        },\n        {\n            \"schemas\": [\n                \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n                \"urn:ietf:params:scim:schemas:core:2.0:User\"\n            ],\n            \"id\": \"2\",\n            \"externalId\": \"tuser\",\n            \"meta\": {\n                \"resourceType\": \"User\",\n                \"created\": \"2023-11-24T03:59:18.658+00:00\",\n                \"lastModified\": \"2023-11-24T03:59:18.658+00:00\",\n                \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/2\",\n                \"version\": \"1.0\"\n            },\n            \"userName\": \"test_user\",\n            \"name\": {\n                \"familyName\": \"Test\",\n                \"givenName\": \"User\"\n            },\n            \"displayName\": \"Test User\",\n            \"active\": true,\n            \"emails\": [{\n                    \"value\": \"test_user@nextlabs.com\",\n                    \"type\": \"work\",\n                    \"primary\": true\n                }\n            ],\n            \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n                \"windowsSid\": \"S-1-5-21-1004336348-1177238915-682003330-512\"\n            }\n        }\n    ],\n    \"startIndex\": 1,\n    \"itemsPerPage\": 2\n}\n"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "post":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Creates a new SCIM user.",
+            "description":"Returns the newly created SCIM user after user is successfully saved.",
+            "operationId":"addUserUsingPOST",
+            "requestBody":{
+               "description":"The new SCIM user to be saved.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/UserResourceReq"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "201":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/UserResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n        \"urn:ietf:params:scim:schemas:core:2.0:User\"\n    ],\n    \"id\": \"1\",\n    \"meta\": {\n        \"resourceType\": \"User\",\n        \"created\": \"2023-11-24T03:59:17.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:17.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n        \"version\": \"1.0\"\n    },\n    \"userName\": \"bjensen\",\n    \"name\": {\n        \"familyName\": \"Barbara\",\n        \"givenName\": \"Jensen\"\n    },\n    \"displayName\": \"Barbara Jensen\",\n    \"active\": true,\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true\n        }\n    ],\n    \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n        \"unixId\": \"701984\"\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"user"
+         }
+      },
+      "/console/scim/v2/Users/{userId}":{
+         "get":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Retrieves an existing SCIM user.",
+            "description":"Returns an existing SCIM user.",
+            "operationId":"getUserUsingGET",
+            "parameters":[
+               {
+                  "name":"userId",
+                  "in":"path",
+                  "description":"Id of the user to be retrieved.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/UserResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n        \"urn:ietf:params:scim:schemas:core:2.0:User\"\n    ],\n    \"id\": \"1\",\n    \"meta\": {\n        \"resourceType\": \"User\",\n        \"created\": \"2023-11-24T03:59:17.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:17.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n        \"version\": \"1.0\"\n    },\n    \"userName\": \"bjensen\",\n    \"name\": {\n        \"familyName\": \"Barbara\",\n        \"givenName\": \"Jensen\"\n    },\n    \"displayName\": \"Barbara Jensen\",\n    \"active\": true,\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true\n        }\n    ],\n    \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n        \"unixId\": \"701984\"\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "put":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Replaces an existing SCIM user.",
+            "description":"Returns the replaced SCIM user after user is successfully updated.",
+            "operationId":"replaceUserUsingPUT",
+            "parameters":[
+               {
+                  "name":"userId",
+                  "in":"path",
+                  "description":"Id of the user to be replaced.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"The existing SCIM user to be updated.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/UserResourceReq"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/UserResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n        \"urn:ietf:params:scim:schemas:core:2.0:User\"\n    ],\n    \"id\": \"1\",\n    \"meta\": {\n        \"resourceType\": \"User\",\n        \"created\": \"2023-11-24T03:59:17.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:17.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n        \"version\": \"1.0\"\n    },\n    \"userName\": \"bjensen\",\n    \"name\": {\n        \"familyName\": \"Barbara\",\n        \"givenName\": \"Jensen\"\n    },\n    \"displayName\": \"Barbara Jensen\",\n    \"active\": true,\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true\n        }\n    ],\n    \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n        \"unixId\": \"701984\"\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"user"
+         },
+         "delete":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Deletes an existing SCIM user.",
+            "operationId":"deleteUserUsingDELETE",
+            "parameters":[
+               {
+                  "name":"userId",
+                  "in":"path",
+                  "description":"Id of the user to be deleted.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "responses":{
+               "204":{
+                  "content":{
+                     
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ]
+         },
+         "patch":{
+            "tags":[
+               "SCIM User Controller"
+            ],
+            "summary":"Patches an existing SCIM user.",
+            "description":"Returns the patched SCIM user after user is successfully updated.",
+            "operationId":"updateUserUsingPATCH",
+            "parameters":[
+               {
+                  "name":"userId",
+                  "in":"path",
+                  "description":"Id of the user to be patched.",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            ],
+            "requestBody":{
+               "description":"Patch request containing the operations to be applied.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PatchRequest"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "content":{
+                     "*/*":{
+                        "schema":{
+                           "$ref":"#/components/schemas/UserResourceRes"
+                        },
+                        "example":"{\n    \"schemas\": [\n        \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\",\n        \"urn:ietf:params:scim:schemas:core:2.0:User\"\n    ],\n    \"id\": \"1\",\n    \"meta\": {\n        \"resourceType\": \"User\",\n        \"created\": \"2023-11-24T03:59:17.658+00:00\",\n        \"lastModified\": \"2023-11-24T03:59:17.658+00:00\",\n        \"location\": \"https://cloudaz.nextlabs.com/console/scim/v2/Users/1\",\n        \"version\": \"1.0\"\n    },\n    \"userName\": \"bjensen\",\n    \"name\": {\n        \"familyName\": \"Barbara\",\n        \"givenName\": \"Jensen\"\n    },\n    \"displayName\": \"Barbara Jensen\",\n    \"active\": true,\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true\n        }\n    ],\n    \"urn:ietf:params:scim:schemas:extension:nextlabs:2.0:User\": {\n        \"unixId\": \"701984\"\n    }\n}"
+                     }
+                  }
+               }
+            },
+            "security":[
+               {
+                  "Bearer":[
+                     "global"
+                  ]
+               }
+            ],
+            "x-codegen-request-body-name":"req"
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves a policy activity report",
+            "description":"Retrieves the criteria and widget details for a policy activity report by id",
+            "operationId":"getSavedReportById",
+            "parameters":[
+               {
+                  "name":"reportId",
+                  "in":"path",
+                  "description":"Id of a policy activity report",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":100
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a JSON object containing policy activity report criteria and widget details",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "criteria":{
+                                 "filters":{
+                                    "general":{
+                                       "type":"custom",
+                                       "date_mode":"fixed",
+                                       "window_mode":"",
+                                       "start_date":"2024-02-01 00:00:00.0",
+                                       "end_date":"2024-02-29 23:59:59.0",
+                                       "fields":[
+                                          {
+                                             "name":"log_level",
+                                             "operator":"in",
+                                             "value":[
+                                                "3"
+                                             ],
+                                             "has_multi_value":false,
+                                             "function":""
+                                          },
+                                          {
+                                             "name":"policy_decision",
+                                             "operator":"in",
+                                             "value":[
+                                                "A",
+                                                "D"
+                                             ],
+                                             "has_multi_value":false,
+                                             "function":""
+                                          },
+                                          {
+                                             "name":"action",
+                                             "operator":"in",
+                                             "value":[
+                                                
+                                             ],
+                                             "has_multi_value":true,
+                                             "function":""
+                                          }
+                                       ]
+                                    },
+                                    "user_criteria":{
+                                       "look_up_field":{
+                                          "name":"user_name",
+                                          "operator":"in",
+                                          "value":[
+                                             
+                                          ],
+                                          "has_multi_value":true,
+                                          "function":""
+                                       },
+                                       "fields":[
+                                          
+                                       ]
+                                    },
+                                    "resource_criteria":{
+                                       "look_up_field":{
+                                          "name":"from_resource_path",
+                                          "operator":"in",
+                                          "value":[
+                                             
+                                          ],
+                                          "has_multi_value":true,
+                                          "function":""
+                                       },
+                                       "fields":[
+                                          
+                                       ]
+                                    },
+                                    "policy_criteria":{
+                                       "look_up_field":{
+                                          "name":"policy_fullname",
+                                          "operator":"in",
+                                          "value":[
+                                             
+                                          ],
+                                          "has_multi_value":true,
+                                          "function":""
+                                       },
+                                       "fields":[
+                                          
+                                       ]
+                                    },
+                                    "other_criteria":{
+                                       "look_up_field":{
+                                          "name":"",
+                                          "operator":"",
+                                          "value":[
+                                             
+                                          ],
+                                          "has_multi_value":false,
+                                          "function":""
+                                       },
+                                       "fields":[
+                                          
+                                       ]
+                                    }
+                                 },
+                                 "header":[
+                                    "ROW_ID",
+                                    "TIME",
+                                    "USER_NAME",
+                                    "FROM_RESOURCE_NAME",
+                                    "POLICY_NAME",
+                                    "POLICY_DECISION",
+                                    "ACTION"
+                                 ],
+                                 "order_by":[
+                                    
+                                 ],
+                                 "pagesize":null,
+                                 "max_rows":-1,
+                                 "grouping_mode":"",
+                                 "group_by":[
+                                    
+                                 ],
+                                 "aggregators":[
+                                    
+                                 ],
+                                 "save_info":{
+                                    "report_name":"Test Report",
+                                    "report_desc":"Test Description",
+                                    "report_type":"",
+                                    "shared_mode":"public",
+                                    "user_ids":[
+                                       
+                                    ],
+                                    "group_ids":[
+                                       
+                                    ]
+                                 }
+                              },
+                              "widgets":[
+                                 {
+                                    "id":1999,
+                                    "key":"enforcements",
+                                    "title":"Enforcements",
+                                    "enabled":true,
+                                    "chartType":"LINE_CHART",
+                                    "attributeName":"hour",
+                                    "maxSize":-1
+                                 },
+                                 {
+                                    "id":2000,
+                                    "key":"topPolicies",
+                                    "title":"Top Policies",
+                                    "enabled":true,
+                                    "chartType":"HORIZONTAL_BAR_CHART",
+                                    "attributeName":"policyName",
+                                    "maxSize":5
+                                 },
+                                 {
+                                    "id":2001,
+                                    "key":"topSubjects",
+                                    "title":"Top Subjects",
+                                    "enabled":true,
+                                    "chartType":"VERTICAL_BAR_CHART",
+                                    "attributeName":"userName",
+                                    "maxSize":5
+                                 },
+                                 {
+                                    "id":2002,
+                                    "key":"topResources",
+                                    "title":"Top Resources",
+                                    "enabled":true,
+                                    "chartType":"PIE_CHART",
+                                    "attributeName":"resourceName",
+                                    "maxSize":5
+                                 },
+                                 {
+                                    "id":2003,
+                                    "key":"enforcementLogs",
+                                    "title":"Enforcement Logs",
+                                    "enabled":true,
+                                    "chartType":"TABLE",
+                                    "attributeName":"rowId",
+                                    "maxSize":-1
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         },
+         "put":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Modifies a policy activity report",
+            "description":"Modifies a policy activity report by id",
+            "operationId":"updateSavedReportById",
+            "parameters":[
+               {
+                  "name":"reportId",
+                  "in":"path",
+                  "description":"Id of a policy activity report",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":100
+               }
+            ],
+            "requestBody":{
+               "description":"Policy activity report parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a JSON object containing summary of the policy activity report",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "id":221,
+                              "title":"Test Report",
+                              "description":"Test Description",
+                              "sharedMode":"public",
+                              "decision":"A",
+                              "dateMode":"fixed",
+                              "windowMode":"",
+                              "startDate":"2024-01-31T16:00:00.000+00:00",
+                              "endDate":"2024-02-29T15:59:59.000+00:00",
+                              "lastUpdatedDate":"2024-08-22T08:03:17.793+00:00",
+                              "type":"custom"
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/report-activity-logs":{
+         "post":{
+            "tags":[
+               "Report Activity Log"
+            ],
+            "summary":"Retrieves policy activity logs",
+            "description":"Retrieves policy activity logs for the query parameters provided",
+            "operationId":"getReportActivityLogs",
+            "requestBody":{
+               "description":"Policy activity log query parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/EnforcementQueryDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing policy activity logs",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "content":[
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":2,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":3,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":4,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":5,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":1,
+                                    "POLICY_DECISION":"A"
+                                 }
+                              ],
+                              "pageable":{
+                                 "sort":{
+                                    "empty":false,
+                                    "unsorted":false,
+                                    "sorted":true
+                                 },
+                                 "offset":0,
+                                 "pageSize":5,
+                                 "pageNumber":0,
+                                 "unpaged":false,
+                                 "paged":true
+                              },
+                              "last":false,
+                              "totalPages":1622,
+                              "totalElements":8110,
+                              "size":5,
+                              "number":0,
+                              "sort":{
+                                 "empty":false,
+                                 "unsorted":false,
+                                 "sorted":true
+                              },
+                              "first":true,
+                              "numberOfElements":5,
+                              "empty":false
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/report-activity-logs/{rowId}/export":{
+         "post":{
+            "tags":[
+               "Report Activity Log"
+            ],
+            "summary":"Exports a policy activity log",
+            "description":"Exports a policy activity log by row id",
+            "operationId":"exportReportActivityLogByRowId",
+            "parameters":[
+               {
+                  "name":"rowId",
+                  "in":"path",
+                  "description":"Row id of a policy activity log",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":10001
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Exports a spreadsheet containing attributes for a policy activity log",
+                  "content":{
+                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":{
+                        
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/report-activity-logs/export":{
+         "post":{
+            "tags":[
+               "Report Activity Log"
+            ],
+            "summary":"Exports policy activity logs",
+            "description":"Exports policy activity logs for the query parameters provided",
+            "operationId":"exportReportActivityLogs",
+            "requestBody":{
+               "description":"Policy activity log export parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/EnforcementQueryDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Exports a spreadsheet containing list of policy activity logs",
+                  "content":{
+                     "application/json":{
+                        
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves a list of policy activity reports",
+            "description":"Retrieves a list of policy activity reports by query parameters",
+            "operationId":"getSavedReportsForUser",
+            "parameters":[
+               {
+                  "name":"title",
+                  "in":"query",
+                  "description":"The title value to filter",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":""
+                  },
+                  "example":"Deny policies"
+               },
+               {
+                  "name":"page",
+                  "in":"query",
+                  "description":"The page number for pagination",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  },
+                  "example":0
+               },
+               {
+                  "name":"size",
+                  "in":"query",
+                  "description":"The number of records per page",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":20
+                  },
+                  "example":20
+               },
+               {
+                  "name":"sortBy",
+                  "in":"query",
+                  "description":"The field to sort by",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"title"
+                  },
+                  "example":"title"
+               },
+               {
+                  "name":"isShared",
+                  "in":"query",
+                  "description":"The shared reports needed",
+                  "required":false,
+                  "schema":{
+                     "type":"boolean",
+                     "default":true
+                  },
+                  "example":true
+               },
+               {
+                  "name":"policyDecision",
+                  "in":"query",
+                  "description":"The policy decision value to filter",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"AD"
+                  },
+                  "example":"AD"
+               },
+               {
+                  "name":"sortOrder",
+                  "in":"query",
+                  "description":"The order of sorting",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"ascending"
+                  },
+                  "example":"ascending"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing details for a policy activity report",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "content":[
+                                 {
+                                    "id":8,
+                                    "title":"Allow Enforcement in Last 7 Days",
+                                    "description":"Allow Enforcement in Last 7 Days v1.0",
+                                    "sharedMode":"public",
+                                    "decision":"A",
+                                    "dateMode":"Relative",
+                                    "windowMode":"last_7_days",
+                                    "startDate":"2024-08-14T03:05:16.148+00:00",
+                                    "endDate":"2024-08-21T03:05:16.148+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:17:23.484+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":12,
+                                    "title":"Allow Resource in Last 7 Days",
+                                    "description":"Allow Resource in Last 7 Days v1.0",
+                                    "sharedMode":"public",
+                                    "decision":"A",
+                                    "dateMode":"Relative",
+                                    "windowMode":"last_7_days",
+                                    "startDate":"2024-08-14T03:05:16.152+00:00",
+                                    "endDate":"2024-08-21T03:05:16.152+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:17:23.484+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":10,
+                                    "title":"Denied Users in Last 30 Days",
+                                    "description":"Denied Users in Last 30 Days v1.0",
+                                    "sharedMode":"public",
+                                    "decision":"D",
+                                    "dateMode":"Relative",
+                                    "windowMode":"last_30_days",
+                                    "startDate":"2024-07-22T03:05:16.151+00:00",
+                                    "endDate":"2024-08-21T03:05:16.151+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:17:23.484+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":9,
+                                    "title":"Deny Enforcement in Last 7 Days",
+                                    "description":"Deny Enforcement in Last 7 Days v1.0",
+                                    "sharedMode":"public",
+                                    "decision":"D",
+                                    "dateMode":"Relative",
+                                    "windowMode":"last_7_days",
+                                    "startDate":"2024-08-14T03:05:16.149+00:00",
+                                    "endDate":"2024-08-21T03:05:16.149+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:17:23.484+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":11,
+                                    "title":"Deny Policies in Last 30 Days",
+                                    "description":"Deny Policies in Last 30 Days v1.0",
+                                    "sharedMode":"public",
+                                    "decision":"D",
+                                    "dateMode":"Relative",
+                                    "windowMode":"last_30_days",
+                                    "startDate":"2024-07-22T03:05:16.151+00:00",
+                                    "endDate":"2024-08-21T03:05:16.151+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:17:23.484+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":100,
+                                    "title":"Test 1",
+                                    "description":"",
+                                    "sharedMode":"only_me",
+                                    "decision":"A",
+                                    "dateMode":"Fixed",
+                                    "windowMode":"today",
+                                    "startDate":"2024-02-01T02:26:32.000+00:00",
+                                    "endDate":"2024-02-29T02:26:32.000+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:27:04.885+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":101,
+                                    "title":"Test 2",
+                                    "description":"",
+                                    "sharedMode":"only_me",
+                                    "decision":"A",
+                                    "dateMode":"Fixed",
+                                    "windowMode":"today",
+                                    "startDate":"2024-02-01T02:27:09.000+00:00",
+                                    "endDate":"2024-02-29T02:27:09.000+00:00",
+                                    "lastUpdatedDate":"2024-08-18T02:27:34.235+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":102,
+                                    "title":"Test 3",
+                                    "description":"",
+                                    "sharedMode":"only_me",
+                                    "decision":"A",
+                                    "dateMode":"Fixed",
+                                    "windowMode":"today",
+                                    "startDate":"2024-02-01T02:27:46.000+00:00",
+                                    "endDate":"2024-02-29T02:27:46.000+00:00",
+                                    "lastUpdatedDate":"2024-08-19T03:15:22.038+00:00",
+                                    "type":"report"
+                                 },
+                                 {
+                                    "id":180,
+                                    "title":"Test Report",
+                                    "description":"Test Description",
+                                    "sharedMode":"public",
+                                    "decision":"A",
+                                    "dateMode":"fixed",
+                                    "windowMode":"",
+                                    "startDate":"2024-01-31T16:00:00.000+00:00",
+                                    "endDate":"2024-02-29T15:59:59.000+00:00",
+                                    "lastUpdatedDate":"2024-08-20T09:40:13.660+00:00",
+                                    "type":"report"
+                                 }
+                              ],
+                              "pageable":{
+                                 "sort":{
+                                    "empty":false,
+                                    "unsorted":false,
+                                    "sorted":true
+                                 },
+                                 "offset":0,
+                                 "pageNumber":0,
+                                 "pageSize":20,
+                                 "paged":true,
+                                 "unpaged":false
+                              },
+                              "last":true,
+                              "totalElements":9,
+                              "totalPages":1,
+                              "size":20,
+                              "number":0,
+                              "sort":{
+                                 "empty":false,
+                                 "unsorted":false,
+                                 "sorted":true
+                              },
+                              "first":true,
+                              "numberOfElements":9,
+                              "empty":false
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         },
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Creates a policy activity report",
+            "description":"Creates a policy activity report using criteria and widgets details",
+            "operationId":"createSavedReport",
+            "requestBody":{
+               "description":"Policy activity report parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a JSON object containing summary of the policy activity report",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "id":190,
+                              "title":"Test Report",
+                              "description":"Test Description",
+                              "sharedMode":"public",
+                              "decision":"A",
+                              "dateMode":"fixed",
+                              "windowMode":"",
+                              "startDate":"2024-01-31T16:00:00.000+00:00",
+                              "endDate":"2024-02-29T15:59:59.000+00:00",
+                              "lastUpdatedDate":"2024-08-21T03:24:30.028+00:00",
+                              "type":"custom"
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}/export":{
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Exports policy activity logs for a report",
+            "description":"Exports policy activity logs for a report by id",
+            "operationId":"exportSavedReportById",
+            "parameters":[
+               {
+                  "name":"reportId",
+                  "in":"path",
+                  "description":"Id of a policy activity report",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":100
+               },
+               {
+                  "name":"sortBy",
+                  "in":"query",
+                  "description":"The field to sort by",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"rowId"
+                  },
+                  "example":"rowId"
+               },
+               {
+                  "name":"sortOrder",
+                  "in":"query",
+                  "description":"The order of sorting",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"ascending"
+                  },
+                  "example":"ascending"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Exports a spreadsheet containing policy activity logs for a report",
+                  "content":{
+                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":{
+                        
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/generate/widgets":{
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves widget data",
+            "description":"Retrieves widget data for a criteria",
+            "operationId":"generateWidgets",
+            "requestBody":{
+               "description":"Policy activity report parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing widget data for a criteria",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "enforcements":[
+                                 {
+                                    "hour":1708070400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708117200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708120800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708124400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708128000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708153200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708156800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708160400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708164000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708167600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708171200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708174800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708178400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708203600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708207200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708210800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708214400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708218000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708221600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708257600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 }
+                              ],
+                              "topSubjects":[
+                                 {
+                                    "name":"John",
+                                    "allowCount":360,
+                                    "denyCount":428,
+                                    "decisionCount":788
+                                 },
+                                 {
+                                    "name":"pmehta",
+                                    "allowCount":60,
+                                    "denyCount":92,
+                                    "decisionCount":152
+                                 },
+                                 {
+                                    "name":"Tuos Chirtante",
+                                    "allowCount":120,
+                                    "denyCount":30,
+                                    "decisionCount":150
+                                 },
+                                 {
+                                    "name":"agupta",
+                                    "allowCount":0,
+                                    "denyCount":61,
+                                    "decisionCount":61
+                                 },
+                                 {
+                                    "name":"tmehta",
+                                    "allowCount":0,
+                                    "denyCount":61,
+                                    "decisionCount":61
+                                 }
+                              ],
+                              "topResources":[
+                                 {
+                                    "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001317",
+                                    "allowCount":480,
+                                    "denyCount":488,
+                                    "decisionCount":968
+                                 },
+                                 {
+                                    "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001316",
+                                    "allowCount":60,
+                                    "denyCount":244,
+                                    "decisionCount":304
+                                 }
+                              ],
+                              "topPolicies":[
+                                 {
+                                    "name":"6.0 Deny access for ECL document or material",
+                                    "allowCount":180,
+                                    "denyCount":180,
+                                    "decisionCount":360
+                                 },
+                                 {
+                                    "name":"2.0 Deny access for ITAR document or material",
+                                    "allowCount":30,
+                                    "denyCount":182,
+                                    "decisionCount":212
+                                 },
+                                 {
+                                    "name":"4.0 Deny access for unapproved contractor",
+                                    "allowCount":0,
+                                    "denyCount":124,
+                                    "decisionCount":124
+                                 },
+                                 {
+                                    "name":"3.0 Deny access for EAR document or material",
+                                    "allowCount":60,
+                                    "denyCount":60,
+                                    "decisionCount":120
+                                 },
+                                 {
+                                    "name":"7.0 Deny Access if user physical location attribute value is missing",
+                                    "allowCount":0,
+                                    "denyCount":93,
+                                    "decisionCount":93
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/generate/export":{
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Exports policy activity logs",
+            "description":"Exports policy activity logs for a criteria",
+            "operationId":"generateExport",
+            "parameters":[
+               {
+                  "name":"sortBy",
+                  "in":"query",
+                  "description":"The field to sort by",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"rowId"
+                  },
+                  "example":"rowId"
+               },
+               {
+                  "name":"sortOrder",
+                  "in":"query",
+                  "description":"The order of sorting",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"ascending"
+                  },
+                  "example":"ascending"
+               }
+            ],
+            "requestBody":{
+               "description":"Policy activity report parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Exports a spreadsheet containing policy activity logs for a criteria",
+                  "content":{
+                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":{
+                        
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/generate/enforcements":{
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves policy activity logs",
+            "description":"Retrieves policy activity logs for a criteria",
+            "operationId":"generateEnforcementLogs",
+            "parameters":[
+               {
+                  "name":"page",
+                  "in":"query",
+                  "description":"The page number for pagination",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  },
+                  "example":0
+               },
+               {
+                  "name":"size",
+                  "in":"query",
+                  "description":"The number of records per page",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":20
+                  },
+                  "example":20
+               },
+               {
+                  "name":"sortBy",
+                  "in":"query",
+                  "description":"The field to sort by",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"rowId"
+                  },
+                  "example":"rowId"
+               },
+               {
+                  "name":"sortOrder",
+                  "in":"query",
+                  "description":"The order of sorting",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"ascending"
+                  },
+                  "example":"ascending"
+               }
+            ],
+            "requestBody":{
+               "description":"Policy activity report query parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing policy activity logs for a criteria",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "content":[
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":2,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":3,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":4,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":5,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":1,
+                                    "POLICY_DECISION":"A"
+                                 }
+                              ],
+                              "pageable":{
+                                 "sort":{
+                                    "empty":false,
+                                    "unsorted":false,
+                                    "sorted":true
+                                 },
+                                 "offset":0,
+                                 "pageSize":5,
+                                 "pageNumber":0,
+                                 "unpaged":false,
+                                 "paged":true
+                              },
+                              "last":false,
+                              "totalPages":1622,
+                              "totalElements":8110,
+                              "size":5,
+                              "number":0,
+                              "sort":{
+                                 "empty":false,
+                                 "unsorted":false,
+                                 "sorted":true
+                              },
+                              "first":true,
+                              "numberOfElements":5,
+                              "empty":false
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/delete":{
+         "post":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Delete policy activity logs",
+            "description":"Delete policy activity logs by id or query parameters",
+            "operationId":"deleteSavedReportsByRequest",
+            "requestBody":{
+               "description":"Policy activity report delete parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/PolicyActivityReportDeleteDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a JSON object with data deleted successfully message",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1002",
+                           "message":"Data deleted successfully"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/auditLogs/search":{
+         "post":{
+            "tags":[
+               "Entity Audit Log"
+            ],
+            "summary":"Retrieves the entity audit logs",
+            "description":"This endpoint allows users to search for audit logs based on various query parameters such as date range, action, entity type, username, entity ID, and pagination settings.",
+            "operationId":"searchAuditLogs",
+            "requestBody":{
+               "description":"Entity audit logs query parameters",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/AuditLogsQueryDTO"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "200":{
+                  "description":"Returns a list containing JSON objects of entity audit logs for the parameters provided",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "content":[
+                                 {
+                                    "id":12,
+                                    "timestamp":1718782853766,
+                                    "action":"LOGOUT",
+                                    "actorId":0,
+                                    "actor":"Administrator",
+                                    "entityType":"AU",
+                                    "entityId":0,
+                                    "oldValue":null,
+                                    "newValue":"{\"Message\":\"Administrator has logged out successfully.\"}"
+                                 },
+                                 {
+                                    "id":11,
+                                    "timestamp":1718781591081,
+                                    "action":"LOGIN",
+                                    "actorId":0,
+                                    "actor":"Administrator",
+                                    "entityType":"AU",
+                                    "entityId":0,
+                                    "oldValue":null,
+                                    "newValue":"{\"User Type\":\"internal\",\"User Category\":\"ADMIN\",\"Display Name\":\"Administrator \",\"username\":\"Administrator\"}"
+                                 },
+                                 {
+                                    "id":10,
+                                    "timestamp":1718777094048,
+                                    "action":"LOGOUT",
+                                    "actorId":0,
+                                    "actor":"Administrator",
+                                    "entityType":"AU",
+                                    "entityId":0,
+                                    "oldValue":null,
+                                    "newValue":"{\"Message\":\"Administrator has logged out successfully.\"}"
+                                 },
+                                 {
+                                    "id":9,
+                                    "timestamp":1718776011682,
+                                    "action":"LOGIN",
+                                    "actorId":0,
+                                    "actor":"Administrator",
+                                    "entityType":"AU",
+                                    "entityId":0,
+                                    "oldValue":null,
+                                    "newValue":"{\"User Type\":\"internal\",\"User Category\":\"ADMIN\",\"Display Name\":\"Administrator \",\"username\":\"Administrator\"}"
+                                 },
+                                 {
+                                    "id":8,
+                                    "timestamp":1718697922091,
+                                    "action":"UPDATE",
+                                    "actorId":0,
+                                    "actor":"Administrator",
+                                    "entityType":"PL",
+                                    "entityId":128,
+                                    "oldValue":"{\"Name\":\"test2\",\"Description\":null,\"Effect\":\"allow\",\"Tags\":null,\"Subject Components\":null,\"To Subject Components\":null,\"From Resource Components\":null,\"To Resource Components\":null,\"Action Components\":null,\"Obligations on Allow\":null,\"Obligations on Deny\":[{\"Component Type ID\":0,\"Name\":\"log\"}],\"Schedule\":null,\"Attributes\":\"TRUE_ALLOW\",\"Manual Deploy\":false,\"Deployment Time\":0,\"Deployed\":false,\"Folder Path\":null}",
+                                    "newValue":"{\"Name\":\"test3\",\"Description\":\"Test description\",\"Effect\":\"allow\",\"Tags\":\"tag1\",\"Subject Components\":null,\"To Subject Components\":null,\"From Resource Components\":null,\"To Resource Components\":null,\"Action Components\":null,\"Obligations on Allow\":[{\"Component Type ID\":0,\"Name\":\"log\"}],\"Obligations on Deny\":[{\"Component Type ID\":0,\"Name\":\"log\"}],\"Schedule\":null,\"Attributes\":\"TRUE_ALLOW\",\"Manual Deploy\":false,\"Deployment Time\":0,\"Deployed\":false,\"Folder Path\":null}"
+                                 }
+                              ],
+                              "lastId":0,
+                              "totalElements":12
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/auditLogs/export":{
+         "post":{
+            "tags":[
+               "Entity Audit Log"
+            ],
+            "summary":"Exports the entity audit logs",
+            "description":"This endpoint allows users to export audit logs to an Excel file based on either a list of audit log IDs or a search query. Only one of the fields (ids or query) must be provided in the request body; providing both or neither will result in a bad request.",
+            "operationId":"exportAuditLogs",
+            "requestBody":{
+               "description":"Only one of ids or query should be set in the request. If both are set or if neither is set, the request is invalid.",
+               "content":{
+                  "application/json":{
+                     "schema":{
+                        "$ref":"#/components/schemas/ExportAuditLogsRequest"
+                     }
+                  }
+               },
+               "required":true
+            },
+            "responses":{
+               "400":{
+                  "description":"If the request is invalid (neither ids nor query is provided, or both are provided)",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"4001",
+                           "message":"Either ids or query must be provided, but not both."
+                        }
+                     }
+                  }
+               },
+               "200":{
+                  "description":"Exports a spreadsheet containing entity audit logs for the parameters provided",
+                  "content":{
+                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":{
+                        
+                     }
+                  }
+               },
+               "500":{
+                  "description":"If an error occurs while processing the export",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"5001",
+                           "message":"An error occurred while exporting audit logs."
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/report-activity-logs/{rowId}":{
+         "get":{
+            "tags":[
+               "Report Activity Log"
+            ],
+            "summary":"Retrieves a policy activity log",
+            "description":"Retrieves a policy activity log by row id",
+            "operationId":"getReportActivityLogByRowId",
+            "parameters":[
+               {
+                  "name":"rowId",
+                  "in":"path",
+                  "description":"Row id of a policy activity log",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":10001
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing attributes for a policy activity log",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"TIMESTAMP",
+                                 "attrType":"Others",
+                                 "name":"DATE",
+                                 "value":"2024-02-22 06:15:23.177"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"User",
+                                 "name":"USER_NAME",
+                                 "value":"John"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Others",
+                                 "name":"ACTION",
+                                 "value":"View "
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Others",
+                                 "name":"LOG_LEVEL",
+                                 "value":"3"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Others",
+                                 "name":"APPLICATION_NAME",
+                                 "value":"SAP"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Others",
+                                 "name":"HOST_NAME",
+                                 "value":"ux-cc"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Others",
+                                 "name":"HOST_IP",
+                                 "value":"10.23.58.229"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Policy",
+                                 "name":"POLICY_NAME",
+                                 "value":"6.0 Deny access for ECL document or material"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Policy",
+                                 "name":"POLICY_FULLNAME",
+                                 "value":"/root_132/6.0 deny access for ecl document or material"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Policy",
+                                 "name":"POLICY_DECISION",
+                                 "value":"Allow"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Resource",
+                                 "name":"FROM_RESOURCE_NAME",
+                                 "value":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001317"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Resource",
+                                 "name":"FROM_RESOURCE_PATH",
+                                 "value":"ed6/ed6/100/ecc/cv02n"
+                              },
+                              {
+                                 "isDynamic":false,
+                                 "dataType":"STRING",
+                                 "attrType":"Resource",
+                                 "name":"TO_RESOURCE_NAME",
+                                 "value":null
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}/widgets":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves widget data for a report",
+            "description":"Retrieves widget data for a report by id",
+            "operationId":"getWidgetsById",
+            "parameters":[
+               {
+                  "name":"reportId",
+                  "in":"path",
+                  "description":"Id of a policy activity report",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":100
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing widget data for a report",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "enforcements":[
+                                 {
+                                    "hour":1708070400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708117200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708120800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708124400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708128000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708153200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708156800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708160400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708164000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708167600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708171200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708174800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708178400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708203600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708207200000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708210800000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708214400000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708218000000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708221600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 },
+                                 {
+                                    "hour":1708257600000,
+                                    "allowCount":0,
+                                    "denyCount":0,
+                                    "decisionCount":0
+                                 }
+                              ],
+                              "topSubjects":[
+                                 {
+                                    "name":"John",
+                                    "allowCount":360,
+                                    "denyCount":428,
+                                    "decisionCount":788
+                                 },
+                                 {
+                                    "name":"pmehta",
+                                    "allowCount":60,
+                                    "denyCount":92,
+                                    "decisionCount":152
+                                 },
+                                 {
+                                    "name":"Tuos Chirtante",
+                                    "allowCount":120,
+                                    "denyCount":30,
+                                    "decisionCount":150
+                                 },
+                                 {
+                                    "name":"agupta",
+                                    "allowCount":0,
+                                    "denyCount":61,
+                                    "decisionCount":61
+                                 },
+                                 {
+                                    "name":"tmehta",
+                                    "allowCount":0,
+                                    "denyCount":61,
+                                    "decisionCount":61
+                                 }
+                              ],
+                              "topResources":[
+                                 {
+                                    "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001317",
+                                    "allowCount":480,
+                                    "denyCount":488,
+                                    "decisionCount":968
+                                 },
+                                 {
+                                    "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001316",
+                                    "allowCount":60,
+                                    "denyCount":244,
+                                    "decisionCount":304
+                                 }
+                              ],
+                              "topPolicies":[
+                                 {
+                                    "name":"6.0 Deny access for ECL document or material",
+                                    "allowCount":180,
+                                    "denyCount":180,
+                                    "decisionCount":360
+                                 },
+                                 {
+                                    "name":"2.0 Deny access for ITAR document or material",
+                                    "allowCount":30,
+                                    "denyCount":182,
+                                    "decisionCount":212
+                                 },
+                                 {
+                                    "name":"4.0 Deny access for unapproved contractor",
+                                    "allowCount":0,
+                                    "denyCount":124,
+                                    "decisionCount":124
+                                 },
+                                 {
+                                    "name":"3.0 Deny access for EAR document or material",
+                                    "allowCount":60,
+                                    "denyCount":60,
+                                    "decisionCount":120
+                                 },
+                                 {
+                                    "name":"7.0 Deny Access if user physical location attribute value is missing",
+                                    "allowCount":0,
+                                    "denyCount":93,
+                                    "decisionCount":93
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/{reportId}/enforcements":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves policy activity logs for a report",
+            "description":"Retrieves policy activity logs for a report by id",
+            "operationId":"getEnforcementLogsById",
+            "parameters":[
+               {
+                  "name":"reportId",
+                  "in":"path",
+                  "description":"Id of a policy activity report",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":100
+               },
+               {
+                  "name":"page",
+                  "in":"query",
+                  "description":"The page number for pagination",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":0
+                  },
+                  "example":0
+               },
+               {
+                  "name":"size",
+                  "in":"query",
+                  "description":"The number of records per page",
+                  "required":false,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int32",
+                     "default":20
+                  },
+                  "example":20
+               },
+               {
+                  "name":"sortBy",
+                  "in":"query",
+                  "description":"The field to sort by",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"rowId"
+                  },
+                  "example":"rowId"
+               },
+               {
+                  "name":"sortOrder",
+                  "in":"query",
+                  "description":"The order of sorting",
+                  "required":false,
+                  "schema":{
+                     "type":"string",
+                     "default":"ascending"
+                  },
+                  "example":"ascending"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing policy activity logs for a report",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "content":[
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":2,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":3,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":4,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.559+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":5,
+                                    "POLICY_DECISION":"A"
+                                 },
+                                 {
+                                    "POLICY_NAME":"Encryption of Client Data in ERP Finance",
+                                    "ACTION":"SELECT",
+                                    "FROM_RESOURCE_NAME":"file1.txt",
+                                    "TIME":"2024-10-07T07:26:14.556+00:00",
+                                    "USER_NAME":"automation_test@nextlabs.com",
+                                    "ACTION_SHORT_CODE":"e3",
+                                    "ROW_ID":1,
+                                    "POLICY_DECISION":"A"
+                                 }
+                              ],
+                              "pageable":{
+                                 "sort":{
+                                    "empty":false,
+                                    "unsorted":false,
+                                    "sorted":true
+                                 },
+                                 "offset":0,
+                                 "pageSize":5,
+                                 "pageNumber":0,
+                                 "unpaged":false,
+                                 "paged":true
+                              },
+                              "last":false,
+                              "totalPages":1622,
+                              "totalElements":8110,
+                              "size":5,
+                              "number":0,
+                              "sort":{
+                                 "empty":false,
+                                 "unsorted":false,
+                                 "sorted":true
+                              },
+                              "first":true,
+                              "numberOfElements":5,
+                              "empty":false
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/users":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the cached users",
+            "description":"Retrieves the list of cached users",
+            "operationId":"listUsers",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing cached users",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "displayName":"LocalSystem@localhost",
+                                 "firstName":"User",
+                                 "lastName":"System"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/share/user-groups":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the user groups",
+            "description":"Retrieves the list of user groups",
+            "operationId":"listAccessGroups",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing user group details",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "title":"All Policy Server Users",
+                                 "id":1
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/share/application-users":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the application users",
+            "description":"Retrieves the list of application users",
+            "operationId":"listApplicationUsers",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing application user details",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "firstName":"Test",
+                                 "lastName":"User",
+                                 "username":"testuser"
+                              },
+                              {
+                                 "firstName":"test",
+                                 "lastName":"admin",
+                                 "username":"testadmin"
+                              },
+                              {
+                                 "firstName":"test",
+                                 "lastName":"api",
+                                 "username":"testapi"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/resource-actions":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the policy models",
+            "description":"Retrieves the list of policy models",
+            "operationId":"listResourceActions",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing policy models",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "policyModelActions":{
+                                 "testing resource type":[
+                                    {
+                                       "policyModelId":43,
+                                       "label":"action1",
+                                       "shortCode":"dw"
+                                    },
+                                    {
+                                       "policyModelId":43,
+                                       "label":"action2",
+                                       "shortCode":"dv"
+                                    }
+                                 ],
+                                 "another resource type":[
+                                    {
+                                       "policyModelId":44,
+                                       "label":"action3",
+                                       "shortCode":"dy"
+                                    },
+                                    {
+                                       "policyModelId":44,
+                                       "label":"action4",
+                                       "shortCode":"dx"
+                                    }
+                                 ]
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/policies":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the cached policies",
+            "description":"Retrieves the list of cached policies",
+            "operationId":"listPolicies",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing cached policies",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "name":"Test",
+                                 "fullName":"/ROOT_187/Testing Policy"
+                              },
+                              {
+                                 "name":"Main policy to deny",
+                                 "fullName":"/ROOT_187/Main policy to deny"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/policy-activity-reports/mappings":{
+         "get":{
+            "tags":[
+               "Policy Activity Report"
+            ],
+            "summary":"Retrieves the attribute mapping",
+            "description":"Retrieves the list of attribute mapping details",
+            "operationId":"getMappingData",
+            "responses":{
+               "200":{
+                  "description":"Returns a map containing attribute mapping details",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":{
+                              "resource":[
+                                 {
+                                    "id":11,
+                                    "name":"FROM_RESOURCE_NAME",
+                                    "mappedColumn":"FROM_RESOURCE_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"RESOURCE",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":12,
+                                    "name":"FROM_RESOURCE_PATH",
+                                    "mappedColumn":"FROM_RESOURCE_PATH",
+                                    "dataType":"STRING",
+                                    "attrType":"RESOURCE",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":13,
+                                    "name":"TO_RESOURCE_NAME",
+                                    "mappedColumn":"TO_RESOURCE_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"RESOURCE",
+                                    "isDynamic":false
+                                 }
+                              ],
+                              "user":[
+                                 {
+                                    "id":2,
+                                    "name":"USER_NAME",
+                                    "mappedColumn":"USER_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"USER",
+                                    "isDynamic":false
+                                 }
+                              ],
+                              "others":[
+                                 {
+                                    "id":1,
+                                    "name":"DATE",
+                                    "mappedColumn":"TIME",
+                                    "dataType":"TIMESTAMP",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":3,
+                                    "name":"ACTION",
+                                    "mappedColumn":"ACTION",
+                                    "dataType":"STRING",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":4,
+                                    "name":"LOG_LEVEL",
+                                    "mappedColumn":"LOG_LEVEL",
+                                    "dataType":"STRING",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":5,
+                                    "name":"APPLICATION_NAME",
+                                    "mappedColumn":"APPLICATION_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":6,
+                                    "name":"HOST_NAME",
+                                    "mappedColumn":"HOST_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":7,
+                                    "name":"HOST_IP",
+                                    "mappedColumn":"HOST_IP",
+                                    "dataType":"STRING",
+                                    "attrType":"OTHERS",
+                                    "isDynamic":false
+                                 }
+                              ],
+                              "policy":[
+                                 {
+                                    "id":8,
+                                    "name":"POLICY_NAME",
+                                    "mappedColumn":"POLICY_NAME",
+                                    "dataType":"STRING",
+                                    "attrType":"POLICY",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":9,
+                                    "name":"POLICY_FULLNAME",
+                                    "mappedColumn":"POLICY_FULLNAME",
+                                    "dataType":"STRING",
+                                    "attrType":"POLICY",
+                                    "isDynamic":false
+                                 },
+                                 {
+                                    "id":10,
+                                    "name":"POLICY_DECISION",
+                                    "mappedColumn":"POLICY_DECISION",
+                                    "dataType":"STRING",
+                                    "attrType":"POLICY",
+                                    "isDynamic":false
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/dashboard/latestAlerts/{fromDate}/{toDate}":{
+         "get":{
+            "tags":[
+               "Reporter Dashboard"
+            ],
+            "summary":"Retrieves the latest alerts",
+            "description":"Retrieves the latest alerts between the from date and to date",
+            "operationId":"latestAlerts",
+            "parameters":[
+               {
+                  "name":"fromDate",
+                  "in":"path",
+                  "description":"From date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680307200000
+               },
+               {
+                  "name":"toDate",
+                  "in":"path",
+                  "description":"To date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680652799000
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing log level, alert message, monitor name and triggered date time",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "level":"L3",
+                                 "alertMessage":"",
+                                 "monitorName":"Deny Policy",
+                                 "triggeredAt":"2024-02-22T15:55:27.407+00:00"
+                              },
+                              {
+                                 "level":"L3",
+                                 "alertMessage":"",
+                                 "monitorName":"Allow Policy",
+                                 "triggeredAt":"2024-02-21T22:20:24.077+00:00"
+                              },
+                              {
+                                 "level":"L3",
+                                 "alertMessage":"",
+                                 "monitorName":"Deny Policy",
+                                 "triggeredAt":"2024-02-21T22:20:24.077+00:00"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/dashboard/alertByMonitorTags/{fromDate}/{toDate}":{
+         "get":{
+            "tags":[
+               "Reporter Dashboard"
+            ],
+            "summary":"Retrieves the alerts by monitor tags",
+            "description":"Retrieves the alerts between the from date and to date",
+            "operationId":"alertByMonitorTags",
+            "parameters":[
+               {
+                  "name":"fromDate",
+                  "in":"path",
+                  "description":"From date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680307200000
+               },
+               {
+                  "name":"toDate",
+                  "in":"path",
+                  "description":"To date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680652799000
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing tag name, monitor name and alert count",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "tagValue":"Weekly Monitoring",
+                                 "monitorName":"Deny Policy",
+                                 "alertCount":1
+                              },
+                              {
+                                 "tagValue":"Weekly Monitoring",
+                                 "monitorName":"Allow Policy",
+                                 "alertCount":1
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/dashboard/activityByUsers/{fromDate}/{toDate}/{policyDecision}":{
+         "get":{
+            "tags":[
+               "Reporter Dashboard"
+            ],
+            "summary":"Retrieves the top users by policy activity",
+            "description":"Retrieves the most evaluated users for the dates and decision",
+            "operationId":"alertSummary",
+            "parameters":[
+               {
+                  "name":"fromDate",
+                  "in":"path",
+                  "description":"From date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680307200000
+               },
+               {
+                  "name":"toDate",
+                  "in":"path",
+                  "description":"To date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680652799000
+               },
+               {
+                  "name":"policyDecision",
+                  "in":"path",
+                  "description":"Policy decision in character format",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  },
+                  "example":"AD"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing username and allow or deny count",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "name":"John Mason",
+                                 "allowCount":360,
+                                 "denyCount":428,
+                                 "decisionCount":788
+                              },
+                              {
+                                 "name":"Tuos Chirtante",
+                                 "allowCount":120,
+                                 "denyCount":30,
+                                 "decisionCount":150
+                              },
+                              {
+                                 "name":"Zeus Chirtante",
+                                 "allowCount":0,
+                                 "denyCount":30,
+                                 "decisionCount":30
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/dashboard/activityByResources/{fromDate}/{toDate}/{policyDecision}":{
+         "get":{
+            "tags":[
+               "Reporter Dashboard"
+            ],
+            "summary":"Retrieves the top resources by policy activity",
+            "description":"Retrieves the most evaluated resources for the dates and decision",
+            "operationId":"activityByResources",
+            "parameters":[
+               {
+                  "name":"fromDate",
+                  "in":"path",
+                  "description":"From date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680307200000
+               },
+               {
+                  "name":"toDate",
+                  "in":"path",
+                  "description":"To date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680652799000
+               },
+               {
+                  "name":"policyDecision",
+                  "in":"path",
+                  "description":"Policy decision in character format",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  },
+                  "example":"AD"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing resource name and allow or deny count",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001317",
+                                 "allowCount":480,
+                                 "denyCount":488,
+                                 "decisionCount":968
+                              },
+                              {
+                                 "name":"sap://ed6/ed6/100/ecc/cv02n/0000000000000010000001316",
+                                 "allowCount":60,
+                                 "denyCount":244,
+                                 "decisionCount":304
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/dashboard/activityByPolicies/{fromDate}/{toDate}/{policyDecision}":{
+         "get":{
+            "tags":[
+               "Reporter Dashboard"
+            ],
+            "summary":"Retrieves the top policies by policy activity",
+            "description":"Retrieves the most evaluated policies for the dates and decision",
+            "operationId":"activityByPolicies",
+            "parameters":[
+               {
+                  "name":"fromDate",
+                  "in":"path",
+                  "description":"From date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680307200000
+               },
+               {
+                  "name":"toDate",
+                  "in":"path",
+                  "description":"To date in Epoch milliseconds format",
+                  "required":true,
+                  "schema":{
+                     "type":"integer",
+                     "format":"int64"
+                  },
+                  "example":1680652799000
+               },
+               {
+                  "name":"policyDecision",
+                  "in":"path",
+                  "description":"Policy decision in character format",
+                  "required":true,
+                  "schema":{
+                     "type":"string"
+                  },
+                  "example":"AD"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing policy name and evaluations grouped by date",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "policy_decisions":[
+                                    {
+                                       "day_nb":1680505200000,
+                                       "allow_count":17,
+                                       "deny_count":13
+                                    },
+                                    {
+                                       "day_nb":1680591600000,
+                                       "allow_count":13,
+                                       "deny_count":10
+                                    },
+                                    {
+                                       "day_nb":1680418800000,
+                                       "allow_count":7,
+                                       "deny_count":0
+                                    },
+                                    {
+                                       "day_nb":1680332400000,
+                                       "allow_count":3,
+                                       "deny_count":0
+                                    }
+                                 ],
+                                 "policy_name":"Deny access to Security Vulnerabilities if not Created By or Assigned To the User"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/v1/auditLogs/users":{
+         "get":{
+            "tags":[
+               "Entity Audit Log"
+            ],
+            "summary":"Retrieves the application users",
+            "description":"Retrieves the list of application users",
+            "operationId":"listUsers_1",
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing application user details",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "statusCode":"1003",
+                           "message":"Data found successfully",
+                           "data":[
+                              {
+                                 "firstName":"Test",
+                                 "lastName":"User",
+                                 "username":"testuser"
+                              },
+                              {
+                                 "firstName":"test",
+                                 "lastName":"admin",
+                                 "username":"testadmin"
+                              },
+                              {
+                                 "firstName":"test",
+                                 "lastName":"api",
+                                 "username":"testapi"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/system-configuration/getUIConfigs":{
+         "get":{
+            "tags":[
+               "Reporter System Configuration"
+            ],
+            "summary":"Retrieves the Reporter UI configuration",
+            "description":"Retrieves the UI configurations for Reporter",
+            "operationId":"findUiConfigs",
+            "responses":{
+               "200":{
+                  "description":"Returns a JSON object containing map of UI configurations",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "skydrm.installed":"false",
+                           "dashboard.widget.top-policies-and-trends.enabled":"true",
+                           "application.version":"2025.02",
+                           "dashboard.widget.top-subjects.enabled":"false",
+                           "application.build":"3240",
+                           "mfa.gauth.enabled":"false",
+                           "dashboard.widget.top-resources.enabled":"false",
+                           "allow.multipleOIDC":"false",
+                           "help.url.base":"https://docs.nextlabs.com/cc/2023.07",
+                           "help.content.link.display":"false",
+                           "dashboard.widget.refresh.interval":"120",
+                           "dashboard.widget.enforcement-logs.enabled":"true",
+                           "allow.multipleAzureAD":"false",
+                           "allow.multipleSAML":"false",
+                           "dashboard.widget.recent-activities.enabled":"true"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/nextlabs-reporter/api/activity-logs/search":{
+         "get":{
+            "tags":[
+               "Audit Log"
+            ],
+            "summary":"Retrieves the audit logs for Reporter components",
+            "description":"Retrieves the audit logs for Policy Activity Reports, Monitors and Alerts",
+            "operationId":"search",
+            "parameters":[
+               {
+                  "name":"pageable",
+                  "in":"query",
+                  "required":true,
+                  "schema":{
+                     "$ref":"#/components/schemas/Pageable"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"Returns a list of JSON objects containing audit logs for Reporter components",
+                  "content":{
+                     "application/json":{
+                        "example":{
+                           "content":[
+                              {
+                                 "id":1339,
+                                 "component":"REPORTER",
+                                 "createdBy":0,
+                                 "createdDate":1746587919483,
+                                 "hidden":false,
+                                 "lastUpdated":1746587919483,
+                                 "lastUpdatedBy":0,
+                                 "msgCode":"audit.export.generated.report",
+                                 "msgParams":"[\"Test Report\"]",
+                                 "ownerDisplayName":"Administrator",
+                                 "activityMsg":"exported {0} generated report"
+                              },
+                              {
+                                 "id":1337,
+                                 "component":"REPORTER",
+                                 "createdBy":0,
+                                 "createdDate":1746587911985,
+                                 "hidden":false,
+                                 "lastUpdated":1746587911985,
+                                 "lastUpdatedBy":0,
+                                 "msgCode":"audit.new.saved.report",
+                                 "msgParams":"[\"Test Report\"]",
+                                 "ownerDisplayName":"Administrator",
+                                 "activityMsg":"created {0} report"
+                              }
+                           ],
+                           "pageable":{
+                              "sort":{
+                                 "unsorted":false,
+                                 "sorted":true,
+                                 "empty":false
+                              },
+                              "pageSize":20,
+                              "pageNumber":0,
+                              "offset":0,
+                              "paged":true,
+                              "unpaged":false
+                           },
+                           "totalPages":1,
+                           "totalElements":2,
+                           "last":true,
+                           "sort":{
+                              "unsorted":false,
+                              "sorted":true,
+                              "empty":false
+                           },
+                           "first":true,
+                           "numberOfElements":2,
+                           "size":20,
+                           "number":0,
+                           "empty":false
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   },
+   "components":{
+      "schemas":{
+         "ActionConfig":{
+            "title":"ActionConfig",
+            "required":[
+               "name",
+               "shortName",
+               "sortOrder"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":21
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the action.\nThis should be an expressive verb.",
+                  "example":"Read File"
+               },
+               "shortName":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The code/unique identifier of the action.",
+                  "example":"READ_FILE"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of this action in the policy model actions list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "AddOperation":{
+            "title":"AddOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/PatchOperation"
+               },
+               {
+                  "title":"AddOperation",
+                  "required":[
+                     "value"
+                  ],
+                  "type":"object",
+                  "properties":{
+                     "path":{
+                        "$ref":"#/components/schemas/Path"
+                     },
+                     "value":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     }
+                  }
+               }
+            ]
+         },
+         "AgentDTO":{
+            "title":"AgentDTO",
+            "type":"object",
+            "properties":{
+               "host":{
+                  "type":"string",
+                  "description":"The agent hostname value registered by PDP.",
+                  "example":"jpc-prod-01"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "type":{
+                  "type":"string",
+                  "description":"Type of agent.",
+                  "example":"PORTAL",
+                  "enum":[
+                     "DESKTOP",
+                     "FILE_SERVER",
+                     "PORTAL"
+                  ]
+               }
+            }
+         },
+         "Attribute":{
+            "title":"Attribute",
+            "required":[
+               "lhs",
+               "operator",
+               "rhs"
+            ],
+            "type":"object",
+            "properties":{
+               "lhs":{
+                  "type":"string",
+                  "description":"Short name of the attribute.",
+                  "example":"department"
+               },
+               "operator":{
+                  "type":"string",
+                  "description":"The arithmetic comparator value for evaluation engine.\nPossible values by data type of attribute:\nDATE: <, >=\nSTRING: =, !=\nNUMBER: =, !=, <, <=, >, >=\nMULTIVAL: includes, equals_unordered, =, !=",
+                  "example":"!=",
+                  "enum":[
+                     "!=",
+                     "<",
+                     "<=",
+                     "=",
+                     ">",
+                     ">=",
+                     "equals_unordered",
+                     "includes"
+                  ]
+               },
+               "rhs":{
+                  "type":"string",
+                  "description":"The value of the condition. The value could be a constant or variable.\nIt could also be a list of values.\nA variable value in a list is enclosed with ${}.\nA list of values are comma separated and enclosed with [].\nThe values of a list are treated as strings and is surrounded by \"\".",
+                  "example":"user.principalname, [\"Williams\",\"Adams\"], [\\\"${application.systemReference}\\\", \\\"${application.displayName}\\\", \\\"a constant\\\"]"
+               }
+            }
+         },
+         "AttributeConfig":{
+            "title":"AttributeConfig",
+            "required":[
+               "dataType",
+               "name",
+               "operatorConfigs",
+               "shortName",
+               "sortOrder"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "dataType":{
+                  "type":"string",
+                  "description":"The data type of the attribute.",
+                  "example":"STRING",
+                  "enum":[
+                     "COLLECTION",
+                     "DATE",
+                     "MULTIVAL",
+                     "NUMBER",
+                     "STRING",
+                     "TIME_INTERVAL"
+                  ]
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The display name of the attribute.",
+                  "example":"Document category"
+               },
+               "operatorConfigs":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The collection of evaluation operators allowed for this attribute.",
+                  "items":{
+                     "$ref":"#/components/schemas/OperatorConfig"
+                  }
+               },
+               "shortName":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The code/unique identifier of the attribute.",
+                  "example":"doc_cat"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of this attribute in the policy model attributes list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "BulkOperation":{
+            "title":"BulkOperation",
+            "type":"object",
+            "properties":{
+               "bulkId":{
+                  "type":"string",
+                  "example":"qwerty"
+               },
+               "data":{
+                  "$ref":"#/components/schemas/JsonNode"
+               },
+               "method":{
+                  "type":"string",
+                  "example":"POST",
+                  "enum":[
+                     "DELETE",
+                     "PATCH",
+                     "POST",
+                     "PUT"
+                  ]
+               },
+               "path":{
+                  "type":"string",
+                  "example":"/Users"
+               }
+            }
+         },
+         "BulkRequest":{
+            "title":"BulkRequest",
+            "required":[
+               "Operations"
+            ],
+            "type":"object",
+            "properties":{
+               "Operations":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/BulkOperation"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "failOnErrors":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":1
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaReq"
+               },
+               "schemas":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "BulkResponse":{
+            "title":"BulkResponse",
+            "required":[
+               "Operations"
+            ],
+            "type":"object",
+            "properties":{
+               "Operations":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/BulkResponseOperation"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "BulkResponseOperation":{
+            "title":"BulkResponseOperation",
+            "required":[
+               "bulkId",
+               "location",
+               "method",
+               "response",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "bulkId":{
+                  "type":"string"
+               },
+               "location":{
+                  "type":"string"
+               },
+               "method":{
+                  "type":"string",
+                  "enum":[
+                     "DELETE",
+                     "PATCH",
+                     "POST",
+                     "PUT"
+                  ]
+               },
+               "response":{
+                  "$ref":"#/components/schemas/ErrorResponse"
+               },
+               "status":{
+                  "type":"integer",
+                  "format":"int32"
+               }
+            }
+         },
+         "ByteArrayResource":{
+            "title":"ByteArrayResource",
+            "type":"object",
+            "properties":{
+               "byteArray":{
+                  "pattern":"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+                  "type":"string",
+                  "format":"byte"
+               },
+               "description":{
+                  "type":"string"
+               },
+               "file":{
+                  "type":"file",
+                  "format":"binary"
+               },
+               "filename":{
+                  "type":"string"
+               },
+               "inputStream":{
+                  "$ref":"#/components/schemas/InputStream"
+               },
+               "open":{
+                  "type":"boolean"
+               },
+               "readable":{
+                  "type":"boolean"
+               },
+               "uri":{
+                  "type":"string",
+                  "format":"uri"
+               },
+               "url":{
+                  "type":"string",
+                  "format":"url"
+               }
+            }
+         },
+         "CalendarReq":{
+            "title":"CalendarReq",
+            "type":"object",
+            "properties":{
+               "firstDayOfWeek":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "lenient":{
+                  "type":"boolean"
+               },
+               "minimalDaysInFirstWeek":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "time":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+               "timeInMillis":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "timeZone":{
+                  "$ref":"#/components/schemas/TimeZoneReq"
+               }
+            }
+         },
+         "CalendarRes":{
+            "title":"CalendarRes",
+            "type":"object",
+            "properties":{
+               "calendarType":{
+                  "type":"string"
+               },
+               "firstDayOfWeek":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "lenient":{
+                  "type":"boolean"
+               },
+               "minimalDaysInFirstWeek":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "time":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+               "timeInMillis":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "timeZone":{
+                  "$ref":"#/components/schemas/TimeZoneRes"
+               },
+               "weekDateSupported":{
+                  "type":"boolean"
+               },
+               "weekYear":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "weeksInWeekYear":{
+                  "type":"integer",
+                  "format":"int32"
+               }
+            }
+         },
+         "CollectionDataResponseDTO":{
+            "title":"CollectionDataResponseDTO",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "type":"object",
+                     "properties":{
+                        
+                     }
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abComponentLite\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abComponentLite\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentLite"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abDeploymentResponseDTO\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abDeploymentResponseDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/DeploymentResponseDTO"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abLiteDTO\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abLiteDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/LiteDTO"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abPolicyLite\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abPolicyLite\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyLite"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abPolicyModelDTO\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abPolicyModelDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyModelDTO"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb":{
+            "title":"CollectionDataResponseDTO\u00abSavedSearchDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "additionalAttributes":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"Any required additional attributes as key value pairs",
+                  "example":"null"
+               },
+               "data":{
+                  "type":"array",
+                  "description":"Response object values.",
+                  "items":{
+                     "$ref":"#/components/schemas/SavedSearchDTO"
+                  }
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":1
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in a page.",
+                  "format":"int32",
+                  "example":10
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               },
+               "totalNoOfRecords":{
+                  "type":"integer",
+                  "description":"Total number of records.",
+                  "format":"int64",
+                  "example":0
+               },
+               "totalPages":{
+                  "type":"integer",
+                  "description":"Total number of pages.",
+                  "format":"int32",
+                  "example":0
+               }
+            }
+         },
+         "ComponentConditionDTOReq":{
+            "title":"ComponentConditionDTOReq",
+            "required":[
+               "attribute",
+               "operator",
+               "value"
+            ],
+            "type":"object",
+            "properties":{
+               "attribute":{
+                  "type":"string",
+                  "description":"Short name of the attribute.",
+                  "example":"department"
+               },
+               "operator":{
+                  "type":"string",
+                  "description":"The arithmetic comparator value for evaluation engine.\nPossible values by data type of attribute:\nDATE: <, >=\nSTRING: =, !=\nNUMBER: =, !=, <, <=, >, >=\nMULTIVAL: includes, equals_unordered, =, !=",
+                  "example":"!=",
+                  "enum":[
+                     "!=",
+                     "<",
+                     "<=",
+                     "=",
+                     ">",
+                     ">=",
+                     "equals_unordered",
+                     "includes"
+                  ]
+               },
+               "rhsType":{
+                  "type":"string",
+                  "description":"The type of value of condition.\nIf the condition value is a variable and is attribute of subject or resource, possible values for rhsType are SUBJECT or RESOURCE.\nIf the condition value is a strong constant, value of rhsType is CONSTANT.",
+                  "enum":[
+                     "CONSTANT",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "value":{
+                  "type":"string",
+                  "description":"The value of the condition. The value could be a constant or variable.\nIt could also be a list of values.\nA variable value is enclosed with ${}.\nA list of values are comma separated and enclosed with [].\nA constant is surrounded by \"\".",
+                  "example":"${user.principalname}, [\"Williams\",\"Adams\"]"
+               }
+            }
+         },
+         "ComponentConditionDTORes":{
+            "title":"ComponentConditionDTORes",
+            "required":[
+               "attribute",
+               "operator",
+               "value"
+            ],
+            "type":"object",
+            "properties":{
+               "attribute":{
+                  "type":"string",
+                  "description":"Short name of the attribute.",
+                  "example":"department"
+               },
+               "operator":{
+                  "type":"string",
+                  "description":"The arithmetic comparator value for evaluation engine.\nPossible values by data type of attribute:\nDATE: <, >=\nSTRING: =, !=\nNUMBER: =, !=, <, <=, >, >=\nMULTIVAL: includes, equals_unordered, =, !=",
+                  "example":"!=",
+                  "enum":[
+                     "!=",
+                     "<",
+                     "<=",
+                     "=",
+                     ">",
+                     ">=",
+                     "equals_unordered",
+                     "includes"
+                  ]
+               },
+               "rhsType":{
+                  "type":"string",
+                  "description":"The type of value of condition.\nIf the condition value is a variable and is attribute of subject or resource, possible values for rhsType are SUBJECT or RESOURCE.\nIf the condition value is a strong constant, value of rhsType is CONSTANT.",
+                  "enum":[
+                     "CONSTANT",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "rhsvalue":{
+                  "type":"string",
+                  "description":"The condition value without enclosing ${}.\nFor Constant RHS type, rhsvalue would be same as condition value attribute.",
+                  "example":"user.principalname"
+               },
+               "value":{
+                  "type":"string",
+                  "description":"The value of the condition. The value could be a constant or variable.\nIt could also be a list of values.\nA variable value is enclosed with ${}.\nA list of values are comma separated and enclosed with [].\nA constant is surrounded by \"\".",
+                  "example":"${user.principalname}, [\"Williams\",\"Adams\"]"
+               }
+            }
+         },
+         "ComponentDTOReq":{
+            "title":"ComponentDTOReq",
+            "required":[
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates whether the the component is to be deployed or undeployed.\n<ul><li><strong>DE</strong>: Deploy</li><li><strong>UN</strong>: Undeploy</li></ul>",
+                  "enum":[
+                     "DE",
+                     "UN"
+                  ]
+               },
+               "actions":{
+                  "type":"array",
+                  "description":"The list of short names of actions of the component. Applicable only for components of type ACTION.",
+                  "example":[
+                     "VIEW",
+                     "EDIT"
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this component. Mainly used in CloudAz Console UI.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityReq"
+                  }
+               },
+               "category":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FOLDER</strong></li><li><strong>POLICY</strong></li><li><strong>COMPONENT</strong></li><li><strong>DELEGATION_POLICY</strong></li><li><strong>XACML_POLICY</strong></li><li><strong>LOCATION</strong></li><li><strong>DELEGATION_COMPONENT</strong></li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "conditions":{
+                  "type":"array",
+                  "description":"The conditions of the component.",
+                  "example":[
+                     {
+                        "attribute":"lastName",
+                        "operator":"=",
+                        "value":"Sample"
+                     }
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentConditionDTOReq"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether this component is deployed or not."
+               },
+               "deploymentRequest":{
+                  "$ref":"#/components/schemas/DeploymentRequestDTO"
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "description":"The scheduled deployed time of the component.\nThe value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the component.",
+                  "example":"This is a sample component"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this component belongs.",
+                  "format":"int64"
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this component belongs"
+               },
+               "hasInactiveSubComponets":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "memberConditions":{
+                  "type":"array",
+                  "description":"The member conditions of the component.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/MemberCondition"
+                  }
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the component.",
+                  "example":"Sample Component"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32"
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in page.",
+                  "format":"int32"
+               },
+               "parentId":{
+                  "type":"integer",
+                  "description":"The id of the parent component.",
+                  "format":"int64"
+               },
+               "parentName":{
+                  "type":"string",
+                  "description":"The parent component's name."
+               },
+               "policyModel":{
+                  "$ref":"#/components/schemas/PolicyModelDTOReq"
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the component is deployed.",
+                  "format":"int32"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the component.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subComponents":{
+                  "type":"array",
+                  "description":"The sub components of the component. The sub components is of model ComponentDTO.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentDTOReq"
+                  }
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"Tags of the component.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The type of the component.",
+                  "example":"SUBJECT",
+                  "enum":[
+                     "ACTION",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Required only in modify request.",
+                  "format":"int32"
+               }
+            }
+         },
+         "ComponentDTORes":{
+            "title":"ComponentDTORes",
+            "required":[
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates whether the the component is to be deployed or undeployed.\n<ul><li><strong>DE</strong>: Deploy</li><li><strong>UN</strong>: Undeploy</li></ul>",
+                  "enum":[
+                     "DE",
+                     "UN"
+                  ]
+               },
+               "actions":{
+                  "type":"array",
+                  "description":"The list of short names of actions of the component. Applicable only for components of type ACTION.",
+                  "example":[
+                     "VIEW",
+                     "EDIT"
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this component. Mainly used in CloudAz Console UI.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityRes"
+                  }
+               },
+               "category":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FOLDER</strong></li><li><strong>POLICY</strong></li><li><strong>COMPONENT</strong></li><li><strong>DELEGATION_POLICY</strong></li><li><strong>XACML_POLICY</strong></li><li><strong>LOCATION</strong></li><li><strong>DELEGATION_COMPONENT</strong></li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "conditions":{
+                  "type":"array",
+                  "description":"The conditions of the component.",
+                  "example":[
+                     {
+                        "attribute":"lastName",
+                        "operator":"=",
+                        "value":"Sample"
+                     }
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentConditionDTORes"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether this component is deployed or not."
+               },
+               "deploymentPending":{
+                  "type":"boolean",
+                  "description":"Indicates if a deployment is pending for the component."
+               },
+               "deploymentRequest":{
+                  "$ref":"#/components/schemas/DeploymentRequestDTO"
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "description":"The scheduled deployed time of the component.\nThe value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the component.",
+                  "example":"This is a sample component"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this component belongs.",
+                  "format":"int64"
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this component belongs"
+               },
+               "hasInactiveSubComponets":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64"
+               },
+               "memberConditions":{
+                  "type":"array",
+                  "description":"The member conditions of the component.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/MemberCondition"
+                  }
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the component.",
+                  "example":"Sample Component"
+               },
+               "pageNo":{
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32"
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"Number of items in page.",
+                  "format":"int32"
+               },
+               "parentId":{
+                  "type":"integer",
+                  "description":"The id of the parent component.",
+                  "format":"int64"
+               },
+               "parentName":{
+                  "type":"string",
+                  "description":"The parent component's name."
+               },
+               "policyModel":{
+                  "$ref":"#/components/schemas/PolicyModelDTORes"
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the component is deployed.",
+                  "format":"int32"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the component.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subComponents":{
+                  "type":"array",
+                  "description":"The sub components of the component. The sub components is of model ComponentDTO.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentDTORes"
+                  }
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"Tags of the component.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The type of the component.",
+                  "example":"SUBJECT",
+                  "enum":[
+                     "ACTION",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Required only in modify request.",
+                  "format":"int32"
+               }
+            }
+         },
+         "ComponentLite":{
+            "title":"ComponentLite",
+            "required":[
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates the last action performed on this component.\n<ul><li><strong>DE</strong>: Deployed</li><li><strong>N/A</strong>: Undeployed</li></ul>",
+                  "example":"DE"
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this component. Mainly used in CloudAz Console UI.",
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether this component is deployed or not."
+               },
+               "deploymentPending":{
+                  "type":"boolean"
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "description":"Indicates the datetime of last deployment.\nThe value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the component.",
+                  "example":"This is a sample component"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this component belongs.",
+                  "format":"int64",
+                  "example":2
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this component belongs",
+                  "example":"folder/sub-folder"
+               },
+               "fullName":{
+                  "type":"string",
+                  "description":"The full name of the component.",
+                  "example":"SUBJECT/Sample Component"
+               },
+               "group":{
+                  "type":"string",
+                  "description":"The group of the component.",
+                  "example":"SUBJECT",
+                  "enum":[
+                     "ACTION",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "hasSubComponents":{
+                  "type":"boolean",
+                  "description":"Indicates whether the component have sub components."
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this component was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "lowercase_name":{
+                  "type":"string",
+                  "description":"The name of the component in lowercase.",
+                  "example":"sample component"
+               },
+               "modelId":{
+                  "type":"integer",
+                  "description":"The ID of the component type.",
+                  "format":"int64",
+                  "example":183
+               },
+               "modelType":{
+                  "type":"string",
+                  "description":"The name of the component type.",
+                  "example":"Host"
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the component.",
+                  "example":"user1"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the component.",
+                  "format":"int64",
+                  "example":0
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the component.",
+                  "example":"Sample Component"
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the component.",
+                  "example":"user1"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the component.",
+                  "format":"int64",
+                  "example":0
+               },
+               "preCreated":{
+                  "type":"boolean"
+               },
+               "predicateData":{
+                  "$ref":"#/components/schemas/PredicateData"
+               },
+               "referedInPolicies":{
+                  "type":"boolean"
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the component is deployed.",
+                  "format":"int32"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the component.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subComponents":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/SubComponentLite"
+                  }
+               },
+               "tags":{
+                  "type":"array",
+                  "description":"Tags of the component.",
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "Date":{
+            "title":"Date",
+            "type":"object",
+            "properties":{
+               "dateOption":{
+                  "type":"string",
+                  "description":"Date criteria",
+                  "enum":[
+                     "CUSTOM",
+                     "PAST_1_YEAR",
+                     "PAST_30_DAYS",
+                     "PAST_3_MONTHS",
+                     "PAST_6_MONTHS",
+                     "PAST_7_DAYS"
+                  ]
+               },
+               "fromDate":{
+                  "type":"integer",
+                  "description":"Start date in Epoch time",
+                  "format":"int64",
+                  "example":1573626776292
+               },
+               "toDate":{
+                  "type":"integer",
+                  "description":"End date in Epoch time",
+                  "format":"int64",
+                  "example":1573626776292
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The type of FieldValue.",
+                  "enum":[
+                     "Date",
+                     "String",
+                     "Text"
+                  ]
+               }
+            },
+            "description":"Date value to search for"
+         },
+         "DeleteOperation":{
+            "title":"DeleteOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/BulkOperation"
+               },
+               {
+                  "title":"DeleteOperation",
+                  "type":"object",
+                  "properties":{
+                     "bulkId":{
+                        "type":"string",
+                        "example":"qwerty"
+                     },
+                     "data":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     },
+                     "method":{
+                        "type":"string",
+                        "example":"POST",
+                        "enum":[
+                           "DELETE",
+                           "PATCH",
+                           "POST",
+                           "PUT"
+                        ]
+                     },
+                     "path":{
+                        "type":"string",
+                        "example":"/Users"
+                     }
+                  }
+               }
+            ]
+         },
+         "DeploymentRequestDTO":{
+            "title":"DeploymentRequestDTO",
+            "type":"object",
+            "properties":{
+               "deployDependencies":{
+                  "type":"boolean",
+                  "description":"Indicates whether there are dependencies on other components.",
+                  "example":false
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "description":"Indicates the datetime at which to execute the deployment. Provide value of -1 to deploy immediately.\nThe value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":-1
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "push":{
+                  "type":"boolean",
+                  "description":"Indicates whether to push to deploy.",
+                  "example":true
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>XP</strong>: Xacml Policy</li><li><strong>LC</strong>: Location</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "example":"POLICY",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               }
+            }
+         },
+         "DeploymentResponseDTO":{
+            "title":"DeploymentResponseDTO",
+            "type":"object",
+            "properties":{
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "pushResults":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/PushResultDTO"
+                  }
+               }
+            }
+         },
+         "Email":{
+            "title":"Email",
+            "type":"object",
+            "properties":{
+               "primary":{
+                  "type":"boolean",
+                  "example":true
+               },
+               "type":{
+                  "type":"string",
+                  "example":"work"
+               },
+               "value":{
+                  "type":"string",
+                  "example":"bjensen@example.com"
+               }
+            }
+         },
+         "EntityWorkflowRequestDTO":{
+            "title":"EntityWorkflowRequestDTO",
+            "type":"object",
+            "properties":{
+               "activeWorkflowRequestLevel":{
+                  "$ref":"#/components/schemas/WorkflowRequestLevelDTO"
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this workflow request was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "devEntityType":{
+                  "type":"string",
+                  "description":"The entity type can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this workflow request was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the workflow request.",
+                  "example":"John"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the workflow request.",
+                  "format":"int64",
+                  "example":3
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the workflow request.",
+                  "example":"Stuart"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the workflow request.",
+                  "format":"int64",
+                  "example":1
+               },
+               "status":{
+                  "type":"string",
+                  "description":"The status of the workflow request.",
+                  "enum":[
+                     "APPROVED",
+                     "CANCELLED",
+                     "DEPLOYED",
+                     "PENDING"
+                  ]
+               },
+               "workflowRequestLevels":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/WorkflowRequestLevelDTO"
+                  }
+               }
+            }
+         },
+         "ErrorResponse":{
+            "title":"ErrorResponse",
+            "required":[
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "detail":{
+                  "type":"string"
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "scimType":{
+                  "type":"string"
+               },
+               "status":{
+                  "type":"integer",
+                  "format":"int32"
+               }
+            }
+         },
+         "ExportEntityDTO":{
+            "title":"ExportEntityDTO",
+            "required":[
+               "id"
+            ],
+            "type":"object",
+            "properties":{
+               "entityType":{
+                  "type":"string",
+                  "description":"The entity type can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "id":{
+                  "type":"integer",
+                  "description":"The entity id",
+                  "format":"int64",
+                  "example":1
+               }
+            }
+         },
+         "FieldValue":{
+            "title":"FieldValue",
+            "type":"object",
+            "properties":{
+               "type":{
+                  "type":"string",
+                  "description":"The type of FieldValue.",
+                  "enum":[
+                     "Date",
+                     "String",
+                     "Text"
+                  ]
+               }
+            },
+            "discriminator":{
+               "propertyName":"type"
+            }
+         },
+         "GrantedAuthority":{
+            "title":"GrantedAuthority",
+            "type":"object",
+            "properties":{
+               "authority":{
+                  "type":"string"
+               }
+            }
+         },
+         "GrantedAuthorityReq":{
+            "title":"GrantedAuthorityReq",
+            "type":"object"
+         },
+         "GrantedAuthorityRes":{
+            "title":"GrantedAuthorityRes",
+            "type":"object",
+            "properties":{
+               "authority":{
+                  "type":"string"
+               }
+            }
+         },
+         "Group":{
+            "title":"Group",
+            "type":"object",
+            "properties":{
+               "$ref":{
+                  "type":"string",
+                  "format":"uri"
+               },
+               "display":{
+                  "type":"string"
+               },
+               "type":{
+                  "type":"string"
+               },
+               "value":{
+                  "type":"string"
+               }
+            }
+         },
+         "GroupResourceReq":{
+            "title":"GroupResourceReq",
+            "type":"object",
+            "properties":{
+               "displayName":{
+                  "type":"string",
+                  "example":"SCIM Users"
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "members":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Member"
+                  }
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaReq"
+               },
+               "schemas":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "GroupResourceRes":{
+            "title":"GroupResourceRes",
+            "type":"object",
+            "properties":{
+               "displayName":{
+                  "type":"string",
+                  "example":"SCIM Users"
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "members":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Member"
+                  }
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "InputStream":{
+            "title":"InputStream",
+            "type":"object"
+         },
+         "JsonNode":{
+            "title":"JsonNode",
+            "type":"object"
+         },
+         "ListResponse\u00abGroupResource\u00bb":{
+            "title":"ListResponse\u00abGroupResource\u00bb",
+            "required":[
+               "Resources",
+               "totalResults"
+            ],
+            "type":"object",
+            "properties":{
+               "Resources":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/GroupResourceRes"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "itemsPerPage":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "startIndex":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "totalResults":{
+                  "type":"integer",
+                  "format":"int64"
+               }
+            }
+         },
+         "ListResponse\u00abUserResource\u00bb":{
+            "title":"ListResponse\u00abUserResource\u00bb",
+            "required":[
+               "Resources",
+               "totalResults"
+            ],
+            "type":"object",
+            "properties":{
+               "Resources":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/UserResourceRes"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "itemsPerPage":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "startIndex":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "totalResults":{
+                  "type":"integer",
+                  "format":"int64"
+               }
+            }
+         },
+         "LiteDTO":{
+            "title":"LiteDTO",
+            "type":"object",
+            "properties":{
+               "empty":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "name":{
+                  "type":"string"
+               },
+               "status":{
+                  "type":"string"
+               }
+            }
+         },
+         "Member":{
+            "title":"Member",
+            "type":"object",
+            "properties":{
+               "$ref":{
+                  "type":"string",
+                  "format":"uri"
+               },
+               "display":{
+                  "type":"string"
+               },
+               "value":{
+                  "type":"string",
+                  "example":"1"
+               }
+            }
+         },
+         "MemberCondition":{
+            "title":"MemberCondition",
+            "type":"object",
+            "properties":{
+               "members":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/MemberDTO"
+                  }
+               },
+               "operator":{
+                  "type":"string",
+                  "enum":[
+                     "IN",
+                     "NOT"
+                  ]
+               }
+            }
+         },
+         "MemberDTO":{
+            "title":"MemberDTO",
+            "type":"object",
+            "properties":{
+               "description":{
+                  "type":"string",
+                  "description":"Description of the member.",
+                  "example":"Sample description"
+               },
+               "domainName":{
+                  "type":"string",
+                  "description":"Domain name of the member. Applicable only when value of type attribute is MEMBER.",
+                  "example":"constessa.com"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "memberType":{
+                  "type":"string",
+                  "description":"The type of the member value. Applicable only when value of type attribute is MEMBER.",
+                  "example":"USER",
+                  "enum":[
+                     "APPLICATION",
+                     "HOST",
+                     "HOST_GROUP",
+                     "USER",
+                     "USER_GROUP"
+                  ]
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the member component.",
+                  "example":"Sample Member Component"
+               },
+               "notFound":{
+                  "type":"boolean",
+                  "description":"Indicates if the member is not found while retrieving the component."
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the component.",
+                  "example":"APPROVED",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The type of the member component.\nWhen member is a User or User Group, applicable value for type is MEMBER.",
+                  "example":"RESOURCE",
+                  "enum":[
+                     "ACTION",
+                     "MEMBER",
+                     "RESOURCE",
+                     "SUBJECT"
+                  ]
+               },
+               "uid":{
+                  "type":"string",
+                  "description":"Unique identifier of the member.",
+                  "example":"S-11555-12"
+               },
+               "uniqueName":{
+                  "type":"string",
+                  "description":"The unique name of the member. Applicable only when value of type attribute is MEMBER.",
+                  "example":"sarah.o.myers@mycompany.com"
+               }
+            }
+         },
+         "MetaReq":{
+            "title":"MetaReq",
+            "type":"object",
+            "properties":{
+               "created":{
+                  "$ref":"#/components/schemas/CalendarReq"
+               },
+               "lastModified":{
+                  "$ref":"#/components/schemas/CalendarReq"
+               },
+               "location":{
+                  "type":"string",
+                  "format":"uri"
+               },
+               "resourceType":{
+                  "type":"string"
+               },
+               "version":{
+                  "type":"string"
+               }
+            }
+         },
+         "MetaRes":{
+            "title":"MetaRes",
+            "type":"object",
+            "properties":{
+               "created":{
+                  "$ref":"#/components/schemas/CalendarRes"
+               },
+               "lastModified":{
+                  "$ref":"#/components/schemas/CalendarRes"
+               },
+               "location":{
+                  "type":"string",
+                  "format":"uri"
+               },
+               "resourceType":{
+                  "type":"string"
+               },
+               "version":{
+                  "type":"string"
+               }
+            }
+         },
+         "Name":{
+            "title":"Name",
+            "type":"object",
+            "properties":{
+               "familyName":{
+                  "type":"string",
+                  "example":"Jensen"
+               },
+               "givenName":{
+                  "type":"string",
+                  "example":"Barbara"
+               }
+            }
+         },
+         "ObligationConfig":{
+            "title":"ObligationConfig",
+            "required":[
+               "name",
+               "runAt",
+               "shortName",
+               "sortOrder"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "daeValidation":{
+                  "type":"string"
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the obligation.",
+                  "example":"Policy Violation Notification"
+               },
+               "parameters":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/ParameterConfig"
+                  }
+               },
+               "runAt":{
+                  "pattern":"PEP|PDP",
+                  "type":"string",
+                  "enum":[
+                     "PDP",
+                     "PEP"
+                  ]
+               },
+               "shortName":{
+                  "type":"string",
+                  "description":"The unique code/ identifier of the obligation.",
+                  "example":"notify_violation"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of this obligation in the policy model obligations list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "ObligationConfigDAE":{
+            "title":"ObligationConfigDAE",
+            "required":[
+               "name",
+               "runAt",
+               "shortName",
+               "sortOrder"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "daeValidation":{
+                  "type":"string"
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the obligation.",
+                  "example":"Policy Violation Notification"
+               },
+               "parameterSets":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"array",
+                     "items":{
+                        "$ref":"#/components/schemas/ParameterConfigDAE"
+                     }
+                  }
+               },
+               "parameters":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/ParameterConfig"
+                  }
+               },
+               "parametersList":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/ParameterConfigDAE"
+                  }
+               },
+               "policyModelId":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "runAt":{
+                  "pattern":"PEP|PDP",
+                  "type":"string",
+                  "enum":[
+                     "PDP",
+                     "PEP"
+                  ]
+               },
+               "shortName":{
+                  "type":"string",
+                  "description":"The unique code/ identifier of the obligation.",
+                  "example":"notify_violation"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of this obligation in the policy model obligations list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "ObligationDTO":{
+            "title":"ObligationDTO",
+            "type":"object",
+            "properties":{
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "name":{
+                  "type":"string",
+                  "description":"Name of the obligation.",
+                  "example":"log"
+               },
+               "params":{
+                  "type":"object",
+                  "additionalProperties":{
+                     "type":"string"
+                  },
+                  "description":"A String to String map of parameters for custom obligations. Keys of the map should be valid values defined in Obligation section of Policy Model."
+               },
+               "policyModelId":{
+                  "type":"integer",
+                  "description":"Policy model id for this obligation.",
+                  "format":"int64",
+                  "example":42662
+               }
+            }
+         },
+         "OperatorConfig":{
+            "title":"OperatorConfig",
+            "required":[
+               "key",
+               "label"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "dataType":{
+                  "type":"string",
+                  "description":"The data type of evaluation comparator.",
+                  "enum":[
+                     "COLLECTION",
+                     "DATE",
+                     "MULTIVAL",
+                     "NUMBER",
+                     "STRING",
+                     "TIME_INTERVAL"
+                  ]
+               },
+               "key":{
+                  "type":"string",
+                  "description":"The arithmetic comparator value for the evaluation engine.\nPossible values by data type:\nDATE: <, >=\nSTRING: =, !=\nNUMBER: =, !=, <, <=, >, >=\nMULTIVAL: includes, equals_unordered, =, !=TIME_INTERVAL: within last",
+                  "example":"!=",
+                  "enum":[
+                     "!=",
+                     "<",
+                     "<=",
+                     "=",
+                     ">",
+                     ">=",
+                     "equals_unordered",
+                     "includes",
+                     "within_last"
+                  ]
+               },
+               "label":{
+                  "type":"string",
+                  "description":"The display value of the evaluation comparator.\nPossible values by data type:\nDATE: before, on or after\nSTRING: is, is not\nNUMBER: =, !=, <, <=, >, >=\nMULTIVAL: includes, equals_unordered, =, !=\nTIME_INTERVAL: within last",
+                  "example":"is not",
+                  "enum":[
+                     "!=",
+                     "<",
+                     "<=",
+                     "=",
+                     ">",
+                     ">=",
+                     "before",
+                     "exactly matches",
+                     "includes",
+                     "is",
+                     "is not",
+                     "on or after",
+                     "within last"
+                  ]
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "ParameterConfig":{
+            "title":"ParameterConfig",
+            "required":[
+               "defaultValue",
+               "editable",
+               "hidden",
+               "mandatory",
+               "name",
+               "shortName",
+               "sortOrder",
+               "type"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "defaultValue":{
+                  "type":"string",
+                  "description":"The default value to be populated when the obligation is used.",
+                  "example":"${mail.assigned_to}"
+               },
+               "editable":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter is editable by users when the obligation is enabled.",
+                  "example":true
+               },
+               "hidden":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter is visible to users when the obligation is enabled.",
+                  "example":false
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "listValues":{
+                  "maxLength":1000,
+                  "minLength":0,
+                  "type":"string",
+                  "description":"The allowed values of the parameter when type equals to <i>List</i>.\nValues should be comma separated.",
+                  "example":"Apple, Orange, Pear"
+               },
+               "mandatory":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter value is mandatory when the obligation is enabled.",
+                  "example":true
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the obligation parameter.",
+                  "example":"Assigned To"
+               },
+               "shortName":{
+                  "type":"string",
+                  "description":"The unique code/identifier of the obligation parameter.",
+                  "example":"assigned_to"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of the parameter in the obligation's parameter list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The obligation data type of the parameter.",
+                  "enum":[
+                     "LIST",
+                     "TEXT_MULTIPLE_ROW",
+                     "TEXT_SINGLE_ROW"
+                  ]
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "ParameterConfigDAE":{
+            "title":"ParameterConfigDAE",
+            "required":[
+               "defaultValue",
+               "editable",
+               "hidden",
+               "mandatory",
+               "name",
+               "shortName",
+               "sortOrder",
+               "type"
+            ],
+            "type":"object",
+            "properties":{
+               "createdDate":{
+                  "type":"string",
+                  "description":"The date at which the record was created, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "defaultValue":{
+                  "type":"string",
+                  "description":"The default value to be populated when the obligation is used.",
+                  "example":"${mail.assigned_to}"
+               },
+               "editable":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter is editable by users when the obligation is enabled.",
+                  "example":true
+               },
+               "hidden":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter is visible to users when the obligation is enabled.",
+                  "example":false
+               },
+               "lastUpdatedDate":{
+                  "type":"string",
+                  "description":"The date at which the record was last updated, in the UTC time format.",
+                  "format":"date-time"
+               },
+               "listValues":{
+                  "type":"string",
+                  "description":"The allowed values of the parameter when type equals to <i>List</i>.\nValues should be comma separated.",
+                  "example":"Apple, Orange, Pear"
+               },
+               "mandatory":{
+                  "type":"boolean",
+                  "description":"The flag to indicate whether the parameter value is mandatory when the obligation is enabled.",
+                  "example":true
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the obligation parameter.",
+                  "example":"Assigned To"
+               },
+               "shortName":{
+                  "type":"string",
+                  "description":"The unique code/identifier of the obligation parameter.",
+                  "example":"assigned_to"
+               },
+               "sortOrder":{
+                  "type":"integer",
+                  "description":"The display position of the parameter in the obligation's parameter list.",
+                  "format":"int32",
+                  "example":0
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The obligation data type of the parameter.",
+                  "enum":[
+                     "LIST",
+                     "TEXT_MULTIPLE_ROW",
+                     "TEXT_SINGLE_ROW"
+                  ]
+               },
+               "value":{
+                  "type":"string",
+                  "description":"The allowed values of the parameter when type equals to <i>List</i>.\nValues should be comma separated.",
+                  "example":"Apple, Orange, Pear"
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "ParentPolicyLite":{
+            "title":"ParentPolicyLite",
+            "type":"object",
+            "properties":{
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":86
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the parent policy.",
+                  "example":"Sample Parent Policy"
+               },
+               "policyFullName":{
+                  "type":"string",
+                  "description":"The full name of the parent policy.",
+                  "example":"ROOT_87/Sample Parent Policy"
+               }
+            }
+         },
+         "PatchOperation":{
+            "title":"PatchOperation",
+            "type":"object",
+            "properties":{
+               "path":{
+                  "$ref":"#/components/schemas/Path"
+               },
+               "value":{
+                  "$ref":"#/components/schemas/JsonNode"
+               }
+            },
+            "discriminator":{
+               "propertyName":"op"
+            }
+         },
+         "PatchRequest":{
+            "title":"PatchRequest",
+            "required":[
+               "Operations"
+            ],
+            "type":"object",
+            "properties":{
+               "Operations":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/PatchOperation"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaReq"
+               },
+               "schemas":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "Path":{
+            "title":"Path",
+            "type":"object",
+            "properties":{
+               "schemaUrn":{
+                  "type":"string"
+               }
+            }
+         },
+         "PolicyComponentReq":{
+            "title":"PolicyComponentReq",
+            "type":"object",
+            "properties":{
+               "components":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentDTOReq"
+                  }
+               },
+               "operator":{
+                  "type":"string",
+                  "enum":[
+                     "IN",
+                     "NOT"
+                  ]
+               }
+            }
+         },
+         "PolicyComponentRes":{
+            "title":"PolicyComponentRes",
+            "type":"object",
+            "properties":{
+               "components":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/ComponentDTORes"
+                  }
+               },
+               "operator":{
+                  "type":"string",
+                  "enum":[
+                     "IN",
+                     "NOT"
+                  ]
+               }
+            }
+         },
+         "PolicyDTODAE":{
+            "title":"PolicyDTODAE",
+            "required":[
+               "effectType",
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionComponents":{
+                  "type":"array",
+                  "description":"List of actions associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates whether the the policy is to be deployed or undeployed.\n<ul><li><strong>DE</strong>: Deploy</li><li><strong>UN</strong>: Undeploy</li></ul>",
+                  "example":"DE"
+               },
+               "activeWorkflowRequest":{
+                  "$ref":"#/components/schemas/EntityWorkflowRequestDTO"
+               },
+               "allowObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in allowing access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityReq"
+                  }
+               },
+               "category":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "componentIds":{
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "denyObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in denying access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether the policy is deployed or not.",
+                  "example":true
+               },
+               "deploymentRequest":{
+                  "$ref":"#/components/schemas/DeploymentRequestDTO"
+               },
+               "deploymentTargets":{
+                  "type":"array",
+                  "description":"A List of deployment targets",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/AgentDTO"
+                  }
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the policy.",
+                  "example":"This is a sample policy"
+               },
+               "effectType":{
+                  "pattern":"ALLOW|DENY",
+                  "type":"string",
+                  "description":"The intended consequence of this policy, for example, Allow or Deny.",
+                  "example":"deny"
+               },
+               "environmentConfig":{
+                  "$ref":"#/components/schemas/PolicyEnvironmentConfigDTO"
+               },
+               "expression":{
+                  "type":"string",
+                  "description":"A condition expression that enhances policy evaluation.",
+                  "example":"(resource.sample_resource.created_by != user.user_id AND resource.sample_resource.assigned_to != user.user_id)"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this policy belongs.",
+                  "format":"int64",
+                  "example":1
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this policy belongs.",
+                  "example":"folder/sub-folder"
+               },
+               "fromResourceComponents":{
+                  "type":"array",
+                  "description":"List of resource components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "fullName":{
+                  "type":"string",
+                  "description":"The full name of the policy.",
+                  "example":"ROOT_87/Sample Policy"
+               },
+               "hasParent":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "hasSubPolicies":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy has sub-policies.",
+                  "example":false
+               },
+               "hasToResourceComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has list of target resources.",
+                  "example":false
+               },
+               "hasToSubjectComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has a recipient subject.",
+                  "example":false
+               },
+               "hidden":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "manualDeploy":{
+                  "type":"boolean",
+                  "description":"Flag to indicate manual deployment or not"
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the policy."
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the policy.",
+                  "format":"int64"
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy.",
+                  "example":"Sample Policy Model"
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the policy."
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the policy.",
+                  "format":"int64"
+               },
+               "parentId":{
+                  "type":"integer",
+                  "description":"The ID of the parent policy.",
+                  "format":"int64"
+               },
+               "parentName":{
+                  "type":"string",
+                  "description":"Parent policy's name."
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the policy is deployed.",
+                  "format":"int32",
+                  "example":0
+               },
+               "scheduleConfig":{
+                  "$ref":"#/components/schemas/PolicyScheduleConfigDTO"
+               },
+               "selectedObligationConfigDAE":{
+                  "$ref":"#/components/schemas/ObligationConfigDAE"
+               },
+               "status":{
+                  "pattern":"DRAFT|DEPLOYED",
+                  "type":"string",
+                  "description":"Indicates the current status of the policy.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subPolicy":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "subPolicyRefs":{
+                  "type":"array",
+                  "description":"A list of sub-policy reference",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "subjectComponents":{
+                  "type":"array",
+                  "description":"List of Subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"List of tags associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "toResourceComponents":{
+                  "type":"array",
+                  "description":"List of target resource components(moved, renamed, or copied) associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "toSubjectComponents":{
+                  "type":"array",
+                  "description":"List of recipient subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Version of the Policy model",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyDTOReq":{
+            "title":"PolicyDTOReq",
+            "required":[
+               "effectType",
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionComponents":{
+                  "type":"array",
+                  "description":"List of actions associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates whether the the policy is to be deployed or undeployed.\n<ul><li><strong>DE</strong>: Deploy</li><li><strong>UN</strong>: Undeploy</li></ul>",
+                  "example":"DE"
+               },
+               "activeWorkflowRequest":{
+                  "$ref":"#/components/schemas/EntityWorkflowRequestDTO"
+               },
+               "allowObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in allowing access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityReq"
+                  }
+               },
+               "category":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "componentIds":{
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "denyObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in denying access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether the policy is deployed or not.",
+                  "example":true
+               },
+               "deploymentRequest":{
+                  "$ref":"#/components/schemas/DeploymentRequestDTO"
+               },
+               "deploymentTargets":{
+                  "type":"array",
+                  "description":"A List of deployment targets",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/AgentDTO"
+                  }
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the policy.",
+                  "example":"This is a sample policy"
+               },
+               "effectType":{
+                  "pattern":"ALLOW|DENY",
+                  "type":"string",
+                  "description":"The intended consequence of this policy, for example, Allow or Deny.",
+                  "example":"deny"
+               },
+               "environmentConfig":{
+                  "$ref":"#/components/schemas/PolicyEnvironmentConfigDTO"
+               },
+               "expression":{
+                  "type":"string",
+                  "description":"A condition expression that enhances policy evaluation.",
+                  "example":"(resource.sample_resource.created_by != user.user_id AND resource.sample_resource.assigned_to != user.user_id)"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this policy belongs.",
+                  "format":"int64",
+                  "example":1
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this policy belongs.",
+                  "example":"folder/sub-folder"
+               },
+               "fromResourceComponents":{
+                  "type":"array",
+                  "description":"List of resource components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "fullName":{
+                  "type":"string",
+                  "description":"The full name of the policy.",
+                  "example":"ROOT_87/Sample Policy"
+               },
+               "hasParent":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "hasSubPolicies":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy has sub-policies.",
+                  "example":false
+               },
+               "hasToResourceComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has list of target resources.",
+                  "example":false
+               },
+               "hasToSubjectComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has a recipient subject.",
+                  "example":false
+               },
+               "hidden":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "manualDeploy":{
+                  "type":"boolean",
+                  "description":"Flag to indicate manual deployment or not"
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the policy."
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the policy.",
+                  "format":"int64"
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy.",
+                  "example":"Sample Policy Model"
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the policy."
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the policy.",
+                  "format":"int64"
+               },
+               "parentId":{
+                  "type":"integer",
+                  "description":"The ID of the parent policy.",
+                  "format":"int64"
+               },
+               "parentName":{
+                  "type":"string",
+                  "description":"Parent policy's name."
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the policy is deployed.",
+                  "format":"int32",
+                  "example":0
+               },
+               "scheduleConfig":{
+                  "$ref":"#/components/schemas/PolicyScheduleConfigDTO"
+               },
+               "status":{
+                  "pattern":"DRAFT|DEPLOYED",
+                  "type":"string",
+                  "description":"Indicates the current status of the policy.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subPolicy":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "subPolicyRefs":{
+                  "type":"array",
+                  "description":"A list of sub-policy reference",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "subjectComponents":{
+                  "type":"array",
+                  "description":"List of Subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"List of tags associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "toResourceComponents":{
+                  "type":"array",
+                  "description":"List of target resource components(moved, renamed, or copied) associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "toSubjectComponents":{
+                  "type":"array",
+                  "description":"List of recipient subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentReq"
+                  }
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Version of the Policy model",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyDTORes":{
+            "title":"PolicyDTORes",
+            "required":[
+               "effectType",
+               "name",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionComponents":{
+                  "type":"array",
+                  "description":"List of actions associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentRes"
+                  }
+               },
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates whether the the policy is to be deployed or undeployed.\n<ul><li><strong>DE</strong>: Deploy</li><li><strong>UN</strong>: Undeploy</li></ul>",
+                  "example":"DE"
+               },
+               "activeWorkflowRequest":{
+                  "$ref":"#/components/schemas/EntityWorkflowRequestDTO"
+               },
+               "allowObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in allowing access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityRes"
+                  }
+               },
+               "category":{
+                  "type":"string",
+                  "description":"The category can have the following values: \n<ul><li><strong>FO</strong>: Folder</li><li><strong>PO</strong>: Policy</li><li><strong>CO</strong>: Component</li><li><strong>DP</strong>: Delegation Policy</li><li><strong>DC</strong>: Delegation Component</li></ul>",
+                  "example":"COMPONENT",
+                  "enum":[
+                     "COMPONENT",
+                     "DELEGATION_COMPONENT",
+                     "DELEGATION_POLICY",
+                     "FOLDER",
+                     "LOCATION",
+                     "POLICY",
+                     "XACML_POLICY"
+                  ]
+               },
+               "componentIds":{
+                  "type":"array",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "denyObligations":{
+                  "type":"array",
+                  "description":"Tasks the PEP (Policy Enforcement Point) needs to perform if policy evaluation results in denying access.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationDTO"
+                  }
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether the policy is deployed or not.",
+                  "example":true
+               },
+               "deploymentPending":{
+                  "type":"boolean"
+               },
+               "deploymentRequest":{
+                  "$ref":"#/components/schemas/DeploymentRequestDTO"
+               },
+               "deploymentTargets":{
+                  "type":"array",
+                  "description":"A List of deployment targets",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/AgentDTO"
+                  }
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the policy.",
+                  "example":"This is a sample policy"
+               },
+               "effectType":{
+                  "pattern":"ALLOW|DENY",
+                  "type":"string",
+                  "description":"The intended consequence of this policy, for example, Allow or Deny.",
+                  "example":"deny"
+               },
+               "environmentConfig":{
+                  "$ref":"#/components/schemas/PolicyEnvironmentConfigDTO"
+               },
+               "expression":{
+                  "type":"string",
+                  "description":"A condition expression that enhances policy evaluation.",
+                  "example":"(resource.sample_resource.created_by != user.user_id AND resource.sample_resource.assigned_to != user.user_id)"
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this policy belongs.",
+                  "format":"int64",
+                  "example":1
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this policy belongs.",
+                  "example":"folder/sub-folder"
+               },
+               "fromResourceComponents":{
+                  "type":"array",
+                  "description":"List of resource components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentRes"
+                  }
+               },
+               "fullName":{
+                  "type":"string",
+                  "description":"The full name of the policy.",
+                  "example":"ROOT_87/Sample Policy"
+               },
+               "hasParent":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "hasSubPolicies":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy has sub-policies.",
+                  "example":false
+               },
+               "hasToResourceComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has list of target resources.",
+                  "example":false
+               },
+               "hasToSubjectComponents":{
+                  "type":"boolean",
+                  "description":"Indicates if the policy has a recipient subject.",
+                  "example":false
+               },
+               "hidden":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64"
+               },
+               "manualDeploy":{
+                  "type":"boolean",
+                  "description":"Flag to indicate manual deployment or not"
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the policy."
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the policy.",
+                  "format":"int64"
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy.",
+                  "example":"Sample Policy Model"
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the policy."
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the policy.",
+                  "format":"int64"
+               },
+               "parentId":{
+                  "type":"integer",
+                  "description":"The ID of the parent policy.",
+                  "format":"int64"
+               },
+               "parentName":{
+                  "type":"string",
+                  "description":"Parent policy's name."
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the policy is deployed.",
+                  "format":"int32",
+                  "example":0
+               },
+               "scheduleConfig":{
+                  "$ref":"#/components/schemas/PolicyScheduleConfigDTO"
+               },
+               "status":{
+                  "pattern":"DRAFT|DEPLOYED",
+                  "type":"string",
+                  "description":"Indicates the current status of the policy.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subPolicy":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy.",
+                  "example":false
+               },
+               "subPolicyRefs":{
+                  "type":"array",
+                  "description":"A list of sub-policy reference",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "subjectComponents":{
+                  "type":"array",
+                  "description":"List of Subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentRes"
+                  }
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"List of tags associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "toResourceComponents":{
+                  "type":"array",
+                  "description":"List of target resource components(moved, renamed, or copied) associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentRes"
+                  }
+               },
+               "toSubjectComponents":{
+                  "type":"array",
+                  "description":"List of recipient subject components associated with this policy.",
+                  "example":[
+                     
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/PolicyComponentRes"
+                  }
+               },
+               "type":{
+                  "type":"object",
+                  "properties":{
+                     
+                  }
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Version of the Policy model",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyEnvironmentConfigDTO":{
+            "title":"PolicyEnvironmentConfigDTO",
+            "type":"object",
+            "properties":{
+               "remoteAccess":{
+                  "type":"integer",
+                  "description":"Type of access. Value of remoteAccess for:\n<ul><li><strong>Local</strong>: 0</li><li><strong>Remote</strong>: 1</li>",
+                  "format":"int32",
+                  "example":-1
+               },
+               "timeSinceLastHBSecs":{
+                  "type":"integer",
+                  "description":"Time since last heart beat of PDP, in seconds.",
+                  "format":"int32",
+                  "example":2400
+               }
+            }
+         },
+         "PolicyLite":{
+            "title":"PolicyLite",
+            "required":[
+               "effectType",
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "actionType":{
+                  "type":"string",
+                  "description":"Indicates the last action performed on this policy.\n<ul><li><strong>DE</strong>: Deployed</li><li><strong>N/A</strong>: Undeployed</li></ul>",
+                  "example":"DE"
+               },
+               "activeEntityWorkflowRequestStatus":{
+                  "type":"string",
+                  "description":"The entity workflow request status.",
+                  "enum":[
+                     "APPROVED",
+                     "CANCELLED",
+                     "DEPLOYED",
+                     "PENDING"
+                  ]
+               },
+               "activeWorkflowId":{
+                  "type":"integer",
+                  "description":"The ID of the active policy workflow. This value being null means workflow is not created.",
+                  "format":"int64"
+               },
+               "activeWorkflowRequestLevelStatus":{
+                  "type":"string",
+                  "description":"The workflow request level status.",
+                  "enum":[
+                     "APPROVED",
+                     "PENDING",
+                     "REQUESTED_AMENDMENT"
+                  ]
+               },
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "componentIds":{
+                  "type":"array",
+                  "description":"Component Ids associated with this policy.",
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether the policy is/ was deployed."
+               },
+               "deploymentPending":{
+                  "type":"boolean"
+               },
+               "deploymentTime":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was last deployed. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description of the policy.",
+                  "example":"This is a sample policy"
+               },
+               "effectType":{
+                  "type":"string",
+                  "description":"The intended consequence of this policy, for example, Allow or Deny."
+               },
+               "folderId":{
+                  "type":"integer",
+                  "description":"The id of the folder to which this policy belongs.",
+                  "format":"int64",
+                  "example":2
+               },
+               "folderName":{
+                  "type":"string",
+                  "description":"The name of the folder to which this policy belongs.",
+                  "example":"policy folder name"
+               },
+               "folderPath":{
+                  "type":"string",
+                  "description":"The path of the folder to which this policy belongs.",
+                  "example":"folder/sub-folder"
+               },
+               "hasParent":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy is a sub-policy of another policy."
+               },
+               "hasSubPolicies":{
+                  "type":"boolean",
+                  "description":"Indicates if this policy has sub-policies."
+               },
+               "hideMoreDetails":{
+                  "type":"boolean"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "lowercase_name":{
+                  "type":"string",
+                  "description":"The name of the policy in lowercase.",
+                  "example":"sample policy"
+               },
+               "manualDeploy":{
+                  "type":"boolean"
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the policy.",
+                  "example":"user1"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the policy.",
+                  "format":"int64",
+                  "example":0
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the policy.",
+                  "example":"Sample Policy"
+               },
+               "noOfTags":{
+                  "type":"integer",
+                  "description":"Number of tags associated with this policy.",
+                  "format":"int32"
+               },
+               "obligationModelIds":{
+                  "type":"array",
+                  "description":"Obligation model's Ids associated with this policy's allow or deny obligation.",
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the policy.",
+                  "example":"user1"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the policy.",
+                  "format":"int64",
+                  "example":0
+               },
+               "parentPolicy":{
+                  "$ref":"#/components/schemas/ParentPolicyLite"
+               },
+               "policyFullName":{
+                  "type":"string",
+                  "description":"The full name of the policy.",
+                  "example":"ROOT_87/Sample Policy"
+               },
+               "revisionCount":{
+                  "type":"integer",
+                  "description":"Number of times the policy is deployed.",
+                  "format":"int32"
+               },
+               "rootFolder":{
+                  "type":"string"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the policy.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               },
+               "subPolicies":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/SubPolicyLite"
+                  }
+               },
+               "tags":{
+                  "type":"array",
+                  "description":"Tags associated with this policy.",
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "version":{
+                  "type":"integer",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyModelDTO":{
+            "title":"PolicyModelDTO",
+            "type":"object",
+            "properties":{
+               "actions":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The actions of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ActionConfig"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The attributes of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/AttributeConfig"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "example":[
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     },
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     }
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description for the policy model.",
+                  "example":"This is a sample policy model"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy model.",
+                  "example":"Sample Policy Model"
+               },
+               "obligations":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The obligations of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationConfig"
+                  }
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "shortName":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"Unique code/identifier of the policy model.",
+                  "example":"sample_policy_model"
+               },
+               "status":{
+                  "type":"string",
+                  "example":"Active"
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The tags of the policy model grouping.",
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "type":{
+                  "pattern":"SUBJECT|RESOURCE|DA_SUBJECT|DA_RESOURCE",
+                  "type":"string",
+                  "description":"The type of policy model. This value is not modifiable after the policy model is created.\n<ul><li><strong>SUBJECT</strong>: The subject component for policy.</li><li><strong>RESOURCE</strong>: The resource component for policy.</li><li><strong>DA_SUBJECT</strong>: The delegation subject component for the delegation policy.</li><li><strong>DA_RESOURCE</strong>: The delegation resource component for the delegation policy.</li></ul>",
+                  "example":"RESOURCE"
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Required only in modify request.",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyModelDTOReq":{
+            "title":"PolicyModelDTOReq",
+            "type":"object",
+            "properties":{
+               "actions":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The actions of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ActionConfig"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The attributes of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/AttributeConfig"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "example":[
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     },
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     }
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityReq"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description for the policy model.",
+                  "example":"This is a sample policy model"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy model.",
+                  "example":"Sample Policy Model"
+               },
+               "obligations":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The obligations of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationConfig"
+                  }
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "shortName":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"Unique code/identifier of the policy model.",
+                  "example":"sample_policy_model"
+               },
+               "status":{
+                  "type":"string",
+                  "example":"Active"
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The tags of the policy model grouping.",
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "type":{
+                  "pattern":"SUBJECT|RESOURCE|DA_SUBJECT|DA_RESOURCE",
+                  "type":"string",
+                  "description":"The type of policy model. This value is not modifiable after the policy model is created.\n<ul><li><strong>SUBJECT</strong>: The subject component for policy.</li><li><strong>RESOURCE</strong>: The resource component for policy.</li><li><strong>DA_SUBJECT</strong>: The delegation subject component for the delegation policy.</li><li><strong>DA_RESOURCE</strong>: The delegation resource component for the delegation policy.</li></ul>",
+                  "example":"RESOURCE"
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Required only in modify request.",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyModelDTORes":{
+            "title":"PolicyModelDTORes",
+            "type":"object",
+            "properties":{
+               "actions":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The actions of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ActionConfig"
+                  }
+               },
+               "attributes":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The attributes of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/AttributeConfig"
+                  }
+               },
+               "authorities":{
+                  "type":"array",
+                  "example":[
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     },
+                     {
+                        "authority":"VIEW_POLICY_MODEL"
+                     }
+                  ],
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthorityRes"
+                  }
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "description":{
+                  "type":"string",
+                  "description":"The description for the policy model.",
+                  "example":"This is a sample policy model"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this policy model was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":0
+               },
+               "name":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The name of the policy model.",
+                  "example":"Sample Policy Model"
+               },
+               "obligations":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The obligations of the policy model.",
+                  "items":{
+                     "$ref":"#/components/schemas/ObligationConfig"
+                  }
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "example":"null"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "shortName":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"Unique code/identifier of the policy model.",
+                  "example":"sample_policy_model"
+               },
+               "status":{
+                  "type":"string",
+                  "example":"Active"
+               },
+               "tags":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "description":"The tags of the policy model grouping.",
+                  "items":{
+                     "$ref":"#/components/schemas/TagDTO"
+                  }
+               },
+               "type":{
+                  "pattern":"SUBJECT|RESOURCE|DA_SUBJECT|DA_RESOURCE",
+                  "type":"string",
+                  "description":"The type of policy model. This value is not modifiable after the policy model is created.\n<ul><li><strong>SUBJECT</strong>: The subject component for policy.</li><li><strong>RESOURCE</strong>: The resource component for policy.</li><li><strong>DA_SUBJECT</strong>: The delegation subject component for the delegation policy.</li><li><strong>DA_RESOURCE</strong>: The delegation resource component for the delegation policy.</li></ul>",
+                  "example":"RESOURCE"
+               },
+               "version":{
+                  "type":"integer",
+                  "description":"Required only in modify request.",
+                  "format":"int32",
+                  "example":2
+               }
+            }
+         },
+         "PolicyScheduleConfigDTO":{
+            "title":"PolicyScheduleConfigDTO",
+            "type":"object",
+            "properties":{
+               "endDateTime":{
+                  "type":"string",
+                  "description":"The date on which the policy enforcement should end.",
+                  "example":"Dec 31, 2099 11:59:59 PM"
+               },
+               "friday":{
+                  "type":"boolean"
+               },
+               "monday":{
+                  "type":"boolean"
+               },
+               "recurrenceDateOfMonth":{
+                  "type":"integer",
+                  "description":"Recurrence date in a month. Set value as -1 if it's not recurring.",
+                  "format":"int64",
+                  "example":-1
+               },
+               "recurrenceDayInMonth":{
+                  "type":"integer",
+                  "description":"Recurrence day in a month. Set value as -1 if it's not recurring.",
+                  "format":"int64",
+                  "example":-1
+               },
+               "recurrenceEndTime":{
+                  "type":"string",
+                  "description":"The time at which the policy enforcement should end.",
+                  "example":"11:59:00 PM"
+               },
+               "recurrenceStartTime":{
+                  "type":"string",
+                  "description":"The time at which the policy enforcement should commence.",
+                  "example":"12:00:00 AM"
+               },
+               "saturday":{
+                  "type":"boolean"
+               },
+               "startDateTime":{
+                  "type":"string",
+                  "description":"The date on which the policy enforcement should commence.",
+                  "example":"Jul 6, 2020 12:00:00 AM"
+               },
+               "sunday":{
+                  "type":"boolean"
+               },
+               "thursday":{
+                  "type":"boolean"
+               },
+               "timezone":{
+                  "type":"string",
+                  "description":"The TZ database name of the timezone.",
+                  "example":"America/Los_Angeles"
+               },
+               "tuesday":{
+                  "type":"boolean"
+               },
+               "wednesday":{
+                  "type":"boolean"
+               }
+            },
+            "description":"The configuration at which the policy recurs"
+         },
+         "PostOperation":{
+            "title":"PostOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/BulkOperation"
+               },
+               {
+                  "title":"PostOperation",
+                  "required":[
+                     "data"
+                  ],
+                  "type":"object",
+                  "properties":{
+                     "bulkId":{
+                        "type":"string",
+                        "example":"qwerty"
+                     },
+                     "data":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     },
+                     "method":{
+                        "type":"string",
+                        "example":"POST",
+                        "enum":[
+                           "DELETE",
+                           "PATCH",
+                           "POST",
+                           "PUT"
+                        ]
+                     },
+                     "path":{
+                        "type":"string",
+                        "example":"/Users"
+                     }
+                  }
+               }
+            ]
+         },
+         "PredicateData":{
+            "title":"PredicateData",
+            "type":"object",
+            "properties":{
+               "actions":{
+                  "type":"array",
+                  "description":"List of short names of the actions of the component. Applicable only for Action component group.",
+                  "example":[
+                     "PRINT",
+                     "VIEW"
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "attributes":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Attribute"
+                  }
+               },
+               "referenceIds":{
+                  "type":"array",
+                  "description":"List of IDs of member components.",
+                  "example":[
+                     1008,
+                     1009
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "format":"int64"
+                  }
+               }
+            }
+         },
+         "PushResultDTO":{
+            "title":"PushResultDTO",
+            "type":"object",
+            "properties":{
+               "dpsUrl":{
+                  "type":"string",
+                  "description":"The URL of DPS component.",
+                  "example":"https://cc-prod-01:8443/dps"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The push result message.",
+                  "example":"Push Successful"
+               },
+               "success":{
+                  "type":"boolean",
+                  "description":"The push status.",
+                  "example":true
+               }
+            }
+         },
+         "PutOperation":{
+            "title":"PutOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/BulkOperation"
+               },
+               {
+                  "title":"PutOperation",
+                  "required":[
+                     "data"
+                  ],
+                  "type":"object",
+                  "properties":{
+                     "bulkId":{
+                        "type":"string",
+                        "example":"qwerty"
+                     },
+                     "data":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     },
+                     "method":{
+                        "type":"string",
+                        "example":"POST",
+                        "enum":[
+                           "DELETE",
+                           "PATCH",
+                           "POST",
+                           "PUT"
+                        ]
+                     },
+                     "path":{
+                        "type":"string",
+                        "example":"/Users"
+                     }
+                  }
+               }
+            ]
+         },
+         "RemoveOperation":{
+            "title":"RemoveOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/PatchOperation"
+               },
+               {
+                  "title":"RemoveOperation",
+                  "required":[
+                     "path"
+                  ],
+                  "type":"object",
+                  "properties":{
+                     "path":{
+                        "$ref":"#/components/schemas/Path"
+                     },
+                     "value":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     }
+                  }
+               }
+            ]
+         },
+         "ReplaceOperation":{
+            "title":"ReplaceOperation",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/PatchOperation"
+               },
+               {
+                  "title":"ReplaceOperation",
+                  "required":[
+                     "value"
+                  ],
+                  "type":"object",
+                  "properties":{
+                     "path":{
+                        "$ref":"#/components/schemas/Path"
+                     },
+                     "value":{
+                        "$ref":"#/components/schemas/JsonNode"
+                     }
+                  }
+               }
+            ]
+         },
+         "ResponseDTO":{
+            "title":"ResponseDTO",
+            "type":"object",
+            "properties":{
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SavedSearchDTO":{
+            "title":"SavedSearchDTO",
+            "type":"object",
+            "properties":{
+               "criteria":{
+                  "$ref":"#/components/schemas/SearchCriteria"
+               },
+               "desc":{
+                  "type":"string",
+                  "description":"Description of the saved search.",
+                  "example":"Example saved search"
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "name":{
+                  "type":"string",
+                  "description":"Name of the saved search.",
+                  "example":"Sample search 1"
+               },
+               "sharedMode":{
+                  "type":"string",
+                  "description":"Share mode of the saved search.",
+                  "example":"PUBLIC"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Status of the saved search.",
+                  "example":"ACTIVE"
+               },
+               "type":{
+                  "type":"string",
+                  "description":"Type of the search.",
+                  "example":"POLICY",
+                  "enum":[
+                     "COMPONENT",
+                     "LOCATION",
+                     "POLICY",
+                     "POLICY_MODEL_RESOURCE",
+                     "POLICY_MODEL_SUBJECT",
+                     "PROPERTY"
+                  ]
+               }
+            }
+         },
+         "SearchCriteria":{
+            "title":"SearchCriteria",
+            "type":"object",
+            "properties":{
+               "columns":{
+                  "type":"array",
+                  "description":"Columns to search for.",
+                  "example":[
+                     "title"
+                  ],
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "enableFullList":{
+                  "type":"boolean"
+               },
+               "facetField":{
+                  "type":"string",
+                  "description":"Facet field.",
+                  "example":"type"
+               },
+               "fields":{
+                  "type":"array",
+                  "description":"Search fields.",
+                  "items":{
+                     "$ref":"#/components/schemas/SearchField"
+                  }
+               },
+               "pageNo":{
+                  "minimum":0,
+                  "exclusiveMinimum":false,
+                  "type":"integer",
+                  "description":"Current page number.",
+                  "format":"int32",
+                  "example":0
+               },
+               "pageSize":{
+                  "minimum":0,
+                  "exclusiveMinimum":false,
+                  "type":"integer",
+                  "description":"Count of policies returned.",
+                  "format":"int32",
+                  "example":10
+               },
+               "properties":{
+                  "type":"object",
+                  "additionalProperties":{
+                     "type":"string"
+                  }
+               },
+               "sortFields":{
+                  "type":"array",
+                  "description":"Sort fields.",
+                  "items":{
+                     "$ref":"#/components/schemas/SortField"
+                  }
+               }
+            }
+         },
+         "SearchCriteriaDTO":{
+            "title":"SearchCriteriaDTO",
+            "type":"object",
+            "properties":{
+               "criteria":{
+                  "$ref":"#/components/schemas/SearchCriteria"
+               },
+               "enableFullList":{
+                  "type":"boolean"
+               }
+            }
+         },
+         "SearchField":{
+            "title":"SearchField",
+            "type":"object",
+            "properties":{
+               "field":{
+                  "type":"string",
+                  "description":"Field name to search for. Available field names for search are listed in the API description.",
+                  "example":"tags"
+               },
+               "nestedField":{
+                  "type":"string",
+                  "description":"Nested field key.",
+                  "example":"tags.key"
+               },
+               "type":{
+                  "pattern":"SINGLE|SINGLE_EXACT_MATCH|TEXT|DATE|MULTI|MULTI_EXACT_MATCH|NESTED|NESTED_MULTI",
+                  "type":"string",
+                  "description":"Type of the search field.\n<ul><li><strong>SINGLE</strong>: Match a single value at the beginning of the field.</li><li><strong>SINGLE_EXACT_MATCH</strong>: Match a single value anywhere in the field.</li><li><strong>TEXT</strong>: Match any of the provided list of values anywhere in the field.</li><li><strong>DATE</strong>: Match items between provided dates.</li><li><strong>MULTI</strong>: Match any of the provided list of values anywhere in the field.</li><li><strong>MULTI_EXACT_MATCH</strong>: Match any of the provided list of values anywhere in the field.</li><li><strong>NESTED</strong>: Match nested field (Single value) anywhere in the field.</li><li><strong>NESTED_MULTI</strong>: Match nested field (Any of the provided list of values) anywhere in the field.</li></ul>",
+                  "enum":[
+                     "DATE",
+                     "MULTI",
+                     "MULTI_EXACT_MATCH",
+                     "NESTED",
+                     "NESTED_MULTI",
+                     "SINGLE",
+                     "SINGLE_EXACT_MATCH",
+                     "TEXT"
+                  ]
+               },
+               "value":{
+                  "$ref":"#/components/schemas/FieldValue"
+               }
+            }
+         },
+         "SimpleResponseDTO":{
+            "title":"SimpleResponseDTO",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "type":"object",
+                  "properties":{
+                     
+                  },
+                  "description":"The data of the response.",
+                  "example":1
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SimpleResponseDTO\u00abComponentDTO\u00bb":{
+            "title":"SimpleResponseDTO\u00abComponentDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "$ref":"#/components/schemas/ComponentDTORes"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SimpleResponseDTO\u00abPolicyDTO\u00bb":{
+            "title":"SimpleResponseDTO\u00abPolicyDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "$ref":"#/components/schemas/PolicyDTORes"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SimpleResponseDTO\u00abPolicyModelDTO\u00bb":{
+            "title":"SimpleResponseDTO\u00abPolicyModelDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "$ref":"#/components/schemas/PolicyModelDTORes"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SimpleResponseDTO\u00abSavedSearchDTO\u00bb":{
+            "title":"SimpleResponseDTO\u00abSavedSearchDTO\u00bb",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "$ref":"#/components/schemas/SavedSearchDTO"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SimpleResponseDTO\u00abstring\u00bb":{
+            "title":"SimpleResponseDTO\u00abstring\u00bb",
+            "type":"object",
+            "properties":{
+               "data":{
+                  "type":"string",
+                  "description":"The data of the response.",
+                  "example":"1"
+               },
+               "message":{
+                  "type":"string",
+                  "description":"The description of the status code of the response.",
+                  "example":"Operation completed successfully"
+               },
+               "statusCode":{
+                  "type":"string",
+                  "description":"The status code of the response.",
+                  "example":"1000"
+               }
+            }
+         },
+         "SortField":{
+            "title":"SortField",
+            "type":"object",
+            "properties":{
+               "field":{
+                  "type":"string",
+                  "description":"Key of the field to be sorted.",
+                  "example":"lastUpdatedDate"
+               },
+               "order":{
+                  "type":"string",
+                  "description":"Sort order.",
+                  "enum":[
+                     "ASC",
+                     "DESC"
+                  ]
+               }
+            }
+         },
+         "String":{
+            "title":"String",
+            "description":"String value to search for",
+            "allOf":[
+               {
+                  "$ref":"#/components/schemas/FieldValue"
+               },
+               {
+                  "title":"String",
+                  "type":"object",
+                  "properties":{
+                     "type":{
+                        "type":"string",
+                        "description":"The type of FieldValue.",
+                        "enum":[
+                           "Date",
+                           "String",
+                           "Text"
+                        ]
+                     },
+                     "value":{
+                        "type":"object",
+                        "properties":{
+                           
+                        }
+                     }
+                  },
+                  "description":"String value to search for"
+               }
+            ]
+         },
+         "SubComponentLite":{
+            "title":"SubComponentLite",
+            "required":[
+               "status"
+            ],
+            "type":"object",
+            "properties":{
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this component. Mainly used in CloudAz Console UI.",
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "componentFullName":{
+                  "type":"string",
+                  "description":"The full name of the sub component.",
+                  "example":"SUBJECT/Sample Sub Component"
+               },
+               "deployed":{
+                  "type":"boolean",
+                  "description":"Indicates whether this sub component is deployed or not."
+               },
+               "hasSubComponents":{
+                  "type":"boolean",
+                  "description":"Indicates whether the component have sub components."
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":88
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this sub component was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC (coordinated universal time). For example: November 15, 2019 10:48:49.296 AM is written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the sub component.",
+                  "example":"Sample Sub Component"
+               },
+               "policyModel":{
+                  "type":"string",
+                  "description":"Policy model of the sub component.",
+                  "example":"Printer"
+               },
+               "status":{
+                  "type":"string",
+                  "description":"Indicates the current status of the sub component.",
+                  "example":"DRAFT",
+                  "enum":[
+                     "APPROVED",
+                     "DELETED",
+                     "DRAFT"
+                  ]
+               }
+            }
+         },
+         "SubPolicyLite":{
+            "title":"SubPolicyLite",
+            "type":"object",
+            "properties":{
+               "authorities":{
+                  "type":"array",
+                  "description":"Access management permissions assigned to this policy. Mainly used in CloudAz Console UI.",
+                  "items":{
+                     "$ref":"#/components/schemas/GrantedAuthority"
+                  }
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":88
+               },
+               "name":{
+                  "type":"string",
+                  "description":"The name of the sub policy.",
+                  "example":"Sample Sub Policy"
+               },
+               "policyFullName":{
+                  "type":"string",
+                  "description":"The full name of the sub policy.",
+                  "example":"ROOT_87/Sample Sub Policy"
+               }
+            }
+         },
+         "TagDTO":{
+            "title":"TagDTO",
+            "type":"object",
+            "properties":{
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "key":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The unique key used to identify a tag. The value could be same as the label.",
+                  "example":"sample_tag"
+               },
+               "label":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The display label of the tag.",
+                  "example":"Sample Tag"
+               },
+               "status":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "type":"string",
+                  "description":"The status of the tag.",
+                  "example":"ACTIVE",
+                  "enum":[
+                     "ACTIVE",
+                     "DELETED",
+                     "IN_ACTIVE"
+                  ]
+               },
+               "type":{
+                  "maxLength":255,
+                  "minLength":1,
+                  "pattern":"COMPONENT_TAG|POLICY_MODEL_TAG|POLICY_TAG",
+                  "type":"string",
+                  "description":"The tag type to apply.\nList of possible values:\n<ul><li><strong>COMPONENT_TAG</strong>: Tags created with this type only available for component.</li><li><strong>POLICY_MODEL_TAG</strong>: Tags created with this type only available for policy model.</li><li><strong>POLICY_TAG</strong>: Tags created with this type only available for policy.</li><li><strong>FOLDER_TAG</strong>: Tags created with this type only available for folder.</li></ul>",
+                  "enum":[
+                     "COMPONENT_TAG",
+                     "FOLDER_TAG",
+                     "POLICY_MODEL_TAG",
+                     "POLICY_TAG"
+                  ]
+               }
+            }
+         },
+         "Text":{
+            "title":"Text",
+            "type":"object",
+            "properties":{
+               "fields":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "type":{
+                  "type":"string",
+                  "description":"The type of FieldValue.",
+                  "enum":[
+                     "Date",
+                     "String",
+                     "Text"
+                  ]
+               },
+               "value":{
+                  "type":"string",
+                  "description":"Text string to be searched in policy"
+               }
+            },
+            "description":"Text value to search for"
+         },
+         "TimeZoneReq":{
+            "title":"TimeZoneReq",
+            "type":"object",
+            "properties":{
+               "id":{
+                  "type":"string"
+               },
+               "rawOffset":{
+                  "type":"integer",
+                  "format":"int32"
+               }
+            }
+         },
+         "TimeZoneRes":{
+            "title":"TimeZoneRes",
+            "type":"object",
+            "properties":{
+               "displayName":{
+                  "type":"string"
+               },
+               "dstsavings":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "id":{
+                  "type":"string"
+               },
+               "rawOffset":{
+                  "type":"integer",
+                  "format":"int32"
+               }
+            }
+         },
+         "UserResourceReq":{
+            "title":"UserResourceReq",
+            "type":"object",
+            "properties":{
+               "active":{
+                  "type":"boolean",
+                  "example":true
+               },
+               "displayName":{
+                  "type":"string",
+                  "example":"Barbara Jensen"
+               },
+               "emails":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Email"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "groups":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Group"
+                  }
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaReq"
+               },
+               "name":{
+                  "$ref":"#/components/schemas/Name"
+               },
+               "password":{
+                  "type":"string"
+               },
+               "schemas":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "userName":{
+                  "type":"string",
+                  "example":"bjensen"
+               }
+            }
+         },
+         "UserResourceRes":{
+            "title":"UserResourceRes",
+            "type":"object",
+            "properties":{
+               "active":{
+                  "type":"boolean",
+                  "example":true
+               },
+               "displayName":{
+                  "type":"string",
+                  "example":"Barbara Jensen"
+               },
+               "emails":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Email"
+                  }
+               },
+               "externalId":{
+                  "type":"string"
+               },
+               "groups":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Group"
+                  }
+               },
+               "id":{
+                  "type":"string"
+               },
+               "meta":{
+                  "$ref":"#/components/schemas/MetaRes"
+               },
+               "name":{
+                  "$ref":"#/components/schemas/Name"
+               },
+               "password":{
+                  "type":"string"
+               },
+               "schemas":{
+                  "uniqueItems":true,
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "userName":{
+                  "type":"string",
+                  "example":"bjensen"
+               }
+            }
+         },
+         "WorkflowRequestLevelDTO":{
+            "title":"WorkflowRequestLevelDTO",
+            "type":"object",
+            "properties":{
+               "approvedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who approved the workflow request level.",
+                  "example":"John"
+               },
+               "approvedById":{
+                  "type":"integer",
+                  "description":"ID of the user who approved the workflow request level.",
+                  "format":"int64",
+                  "example":3
+               },
+               "approvedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this workflow request level was approved. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "createdDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this workflow request level was created. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "id":{
+                  "type":"integer",
+                  "format":"int64",
+                  "example":87
+               },
+               "lastUpdatedDate":{
+                  "type":"integer",
+                  "description":"Indicates the date at which this workflow request level was last modified. The value is measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time). For example, November 15, 2019 10:48:49.296 AM will be written as 1573786129296.",
+                  "format":"int64",
+                  "example":1573786129296
+               },
+               "levelOrder":{
+                  "type":"integer",
+                  "description":"The rank of the level. The value is used to determine the order of the workflow level when there are multiple workflow levels configured. The value starts at 1.",
+                  "format":"int32",
+                  "example":1
+               },
+               "modifiedBy":{
+                  "type":"string",
+                  "description":"Display name of the user who last modified the workflow request level.",
+                  "example":"John"
+               },
+               "modifiedById":{
+                  "type":"integer",
+                  "description":"ID of the user who last modified the workflow request level.",
+                  "format":"int64",
+                  "example":3
+               },
+               "ownerDisplayName":{
+                  "type":"string",
+                  "description":"Display name of the user who created the workflow request level.",
+                  "example":"Stuart"
+               },
+               "ownerId":{
+                  "type":"integer",
+                  "description":"ID of the user who created the workflow request level.",
+                  "format":"int64",
+                  "example":1
+               },
+               "status":{
+                  "type":"string",
+                  "description":"The status of the workflow request level.",
+                  "enum":[
+                     "APPROVED",
+                     "PENDING",
+                     "REQUESTED_AMENDMENT"
+                  ]
+               },
+               "workflowLevelDescription":{
+                  "type":"string",
+                  "description":"The description of the workflow level.",
+                  "example":"Level 1 Approval description"
+               },
+               "workflowLevelName":{
+                  "type":"string",
+                  "description":"The name of the workflow level.",
+                  "example":"Level 1 Approval"
+               }
+            }
+         },
+         "Field":{
+            "type":"object",
+            "properties":{
+               "name":{
+                  "type":"string"
+               },
+               "operator":{
+                  "type":"string"
+               },
+               "value":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "has_multi_value":{
+                  "type":"boolean"
+               },
+               "function":{
+                  "type":"string"
+               }
+            }
+         },
+         "FilterCriteria":{
+            "type":"object",
+            "properties":{
+               "look_up_field":{
+                  "$ref":"#/components/schemas/Field"
+               },
+               "fields":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Field"
+                  }
+               }
+            }
+         },
+         "OrderBy":{
+            "type":"object",
+            "properties":{
+               "col_name":{
+                  "type":"string"
+               },
+               "sort_order":{
+                  "type":"string"
+               }
+            }
+         },
+         "PolicyActivityReportDTO":{
+            "type":"object",
+            "properties":{
+               "criteria":{
+                  "$ref":"#/components/schemas/SavedReportCriteria"
+               },
+               "widgets":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/SavedReportWidget"
+                  }
+               }
+            }
+         },
+         "SaveInfo":{
+            "type":"object",
+            "properties":{
+               "report_name":{
+                  "type":"string"
+               },
+               "report_desc":{
+                  "type":"string"
+               },
+               "report_type":{
+                  "type":"string"
+               },
+               "shared_mode":{
+                  "type":"string"
+               },
+               "user_ids":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "group_ids":{
+                  "type":"array",
+                  "items":{
+                     "type":"integer",
+                     "format":"int32"
+                  }
+               }
+            }
+         },
+         "SavedReportCriteria":{
+            "type":"object",
+            "properties":{
+               "filters":{
+                  "$ref":"#/components/schemas/SavedReportFilter"
+               },
+               "header":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "order_by":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/OrderBy"
+                  }
+               },
+               "pagesize":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "max_rows":{
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "grouping_mode":{
+                  "type":"string"
+               },
+               "group_by":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               },
+               "aggregators":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Field"
+                  }
+               },
+               "save_info":{
+                  "$ref":"#/components/schemas/SaveInfo"
+               }
+            }
+         },
+         "SavedReportFilter":{
+            "type":"object",
+            "properties":{
+               "general":{
+                  "$ref":"#/components/schemas/SavedReportFilterGeneral"
+               },
+               "user_criteria":{
+                  "$ref":"#/components/schemas/FilterCriteria"
+               },
+               "resource_criteria":{
+                  "$ref":"#/components/schemas/FilterCriteria"
+               },
+               "policy_criteria":{
+                  "$ref":"#/components/schemas/FilterCriteria"
+               },
+               "other_criteria":{
+                  "$ref":"#/components/schemas/FilterCriteria"
+               }
+            }
+         },
+         "SavedReportFilterGeneral":{
+            "type":"object",
+            "properties":{
+               "type":{
+                  "type":"string"
+               },
+               "date_mode":{
+                  "type":"string"
+               },
+               "window_mode":{
+                  "type":"string"
+               },
+               "start_date":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+               "end_date":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+               "fields":{
+                  "type":"array",
+                  "items":{
+                     "$ref":"#/components/schemas/Field"
+                  }
+               }
+            }
+         },
+         "SavedReportWidget":{
+            "required":[
+               "attributeName",
+               "chartType",
+               "name",
+               "title"
+            ],
+            "type":"object",
+            "properties":{
+               "id":{
+                  "type":"integer",
+                  "format":"int64"
+               },
+               "name":{
+                  "type":"string"
+               },
+               "title":{
+                  "type":"string"
+               },
+               "enabled":{
+                  "type":"boolean"
+               },
+               "chartType":{
+                  "type":"string"
+               },
+               "attributeName":{
+                  "type":"string"
+               },
+               "maxSize":{
+                  "type":"integer",
+                  "format":"int64"
+               }
+            }
+         },
+         "EnforcementQueryDTO":{
+            "required":[
+               "fieldName",
+               "fieldValue",
+               "policyDecision",
+               "sortBy",
+               "sortOrder"
+            ],
+            "type":"object",
+            "properties":{
+               "page":{
+                  "minimum":0,
+                  "type":"integer",
+                  "description":"The page number for pagination",
+                  "format":"int32",
+                  "example":0
+               },
+               "size":{
+                  "minimum":1,
+                  "type":"integer",
+                  "description":"The number of records per page",
+                  "format":"int32",
+                  "example":10
+               },
+               "sortBy":{
+                  "type":"string",
+                  "description":"The field to sort by",
+                  "example":"time"
+               },
+               "sortOrder":{
+                  "type":"string",
+                  "description":"The order of sorting",
+                  "example":"ascending"
+               },
+               "fromDate":{
+                  "minimum":0,
+                  "type":"integer",
+                  "description":"The from date of the search range",
+                  "format":"int64",
+                  "example":1716825600000
+               },
+               "toDate":{
+                  "minimum":0,
+                  "type":"integer",
+                  "description":"The to date of the search range",
+                  "format":"int64",
+                  "example":1717516799999
+               },
+               "policyDecision":{
+                  "type":"string",
+                  "description":"The policy decision value to filter",
+                  "example":"AD"
+               },
+               "fieldName":{
+                  "type":"string",
+                  "description":"The name of the field to filter (optional)",
+                  "example":"host_name"
+               },
+               "fieldValue":{
+                  "type":"string",
+                  "description":"The value of the field to filter (optional)",
+                  "example":"cloudaz.nextlabs.solutions"
+               },
+               "header":{
+                  "type":"array",
+                  "description":"The list of columns to be returned",
+                  "example":[
+                     "ROW_ID",
+                     "TIME",
+                     "USER_NAME",
+                     "FROM_RESOURCE_NAME",
+                     "POLICY_NAME",
+                     "POLICY_DECISION",
+                     "ACTION"
+                  ],
+                  "items":{
+                     "type":"string",
+                     "description":"The list of columns to be returned",
+                     "example":"[\"ROW_ID\",\"TIME\",\"USER_NAME\",\"FROM_RESOURCE_NAME\",\"POLICY_NAME\",\"POLICY_DECISION\",\"ACTION\"]"
+                  }
+               }
+            },
+            "description":"Policy activity log query parameters"
+         },
+         "PolicyActivityReportDeleteDTO":{
+            "type":"object",
+            "properties":{
+               "title":{
+                  "type":"string",
+                  "description":"The title value to filter",
+                  "example":"Deny policies"
+               },
+               "policyDecision":{
+                  "type":"string",
+                  "description":"The policy decision value to filter",
+                  "example":"AD"
+               },
+               "reportIds":{
+                  "type":"array",
+                  "description":"List of policy activity report ids, if query parameters not provided",
+                  "example":[
+                     5,
+                     10,
+                     15
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "description":"List of policy activity report ids, if query parameters not provided",
+                     "format":"int64"
+                  }
+               },
+               "shared":{
+                  "type":"boolean"
+               }
+            },
+            "description":"Policy activity report delete parameters"
+         },
+         "Pageable":{
+            "type":"object",
+            "properties":{
+               "page":{
+                  "minimum":0,
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "size":{
+                  "minimum":1,
+                  "type":"integer",
+                  "format":"int32"
+               },
+               "sort":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
+                  }
+               }
+            }
+         },
+         "AuditLogsQueryDTO":{
+            "required":[
+               "endDate",
+               "startDate"
+            ],
+            "type":"object",
+            "properties":{
+               "startDate":{
+                  "type":"integer",
+                  "description":"The start date of the search range",
+                  "format":"int64",
+                  "example":1716825600000
+               },
+               "endDate":{
+                  "type":"integer",
+                  "description":"The end date of the search range",
+                  "format":"int64",
+                  "example":1717516799999
+               },
+               "action":{
+                  "type":"string",
+                  "description":"The action performed",
+                  "example":"LOGIN"
+               },
+               "entityType":{
+                  "type":"string",
+                  "description":"The type of entity involved in the action",
+                  "example":"AU"
+               },
+               "usernames":{
+                  "type":"array",
+                  "description":"The username of the actor who performed the action",
+                  "example":[
+                     "Administrator"
+                  ],
+                  "items":{
+                     "type":"string",
+                     "description":"The username of the actor who performed the action",
+                     "example":"[\"Administrator\"]"
+                  }
+               },
+               "entityId":{
+                  "type":"integer",
+                  "description":"The ID of the entity involved in the action",
+                  "format":"int64",
+                  "example":100
+               },
+               "sortBy":{
+                  "type":"string",
+                  "description":"The field to sort by",
+                  "example":"timestamp"
+               },
+               "sortOrder":{
+                  "type":"string",
+                  "description":"The order of sorting",
+                  "example":"ASC"
+               },
+               "pageNumber":{
+                  "type":"integer",
+                  "description":"The page number for pagination",
+                  "format":"int32",
+                  "example":0
+               },
+               "pageSize":{
+                  "type":"integer",
+                  "description":"The number of records per page",
+                  "format":"int32",
+                  "example":10
+               }
+            },
+            "description":"Entity audit log query parameters"
+         },
+         "ExportAuditLogsRequest":{
+            "type":"object",
+            "properties":{
+               "ids":{
+                  "type":"array",
+                  "description":"List of IDs to export Entity Audit Logs, if query parameters not provided",
+                  "example":[
+                     5,
+                     10,
+                     15
+                  ],
+                  "items":{
+                     "type":"integer",
+                     "description":"List of IDs to export Entity Audit Logs, if query parameters not provided",
+                     "format":"int64"
+                  }
+               },
+               "query":{
+                  "$ref":"#/components/schemas/AuditLogsQueryDTO"
+               }
+            },
+            "description":"Entity audit log export parameters"
+         }
+      },
+      "securitySchemes":{
+         "Bearer":{
+            "type":"apiKey",
+            "name":"Authorization",
+            "in":"header"
+         }
+      }
+   }
+}

--- a/tests/_openapi/model_registry.py
+++ b/tests/_openapi/model_registry.py
@@ -1,0 +1,117 @@
+"""Map (path, method, status) triples to the SDK's Pydantic response class.
+
+The registry returns the model for the *inner* ``data`` field of a CloudAz
+response envelope. The round-trip test extracts ``data`` from the envelope
+(see ``CloudAzEnvelope`` in :mod:`tests.test_openapi_roundtrip`) before
+validating it against the model returned here.
+
+PDP responses are not envelope-wrapped; for those, the registered model
+validates the full body.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+class RegistryMiss(Exception):
+    """Raised when no Pydantic model is registered for a given spec triple."""
+
+
+@dataclass(frozen=True)
+class _Entry:
+    pattern: str
+    method: str
+    status: str
+    model: type["BaseModel"]
+
+
+def _entries() -> list[_Entry]:
+    # Import inside the function so the registry remains lazy — importing
+    # the top-level module during test collection must not drag in every
+    # SDK submodule.
+    from nextlabs_sdk._cloudaz._component_models import (
+        Component,
+        ComponentLite,
+        ComponentNameEntry,
+        Dependency,
+        DeploymentResult,
+    )
+    from nextlabs_sdk._cloudaz._component_type_models import ComponentType
+    from nextlabs_sdk._cloudaz._models import Operator, Tag
+    from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyLite
+
+    return [
+        # ── components ───────────────────────────────────────────────
+        _Entry(
+            r"^/console/api/v1/component/mgmt/active/\{id\}$", "get", "200", Component
+        ),
+        _Entry(r"^/console/api/v1/component/mgmt/active$", "post", "200", Component),
+        _Entry(
+            r"^/console/api/v1/component/mgmt/active/\{id\}$", "put", "200", Component
+        ),
+        _Entry(r"^/console/api/v1/component/mgmt/list$", "post", "200", ComponentLite),
+        _Entry(
+            r"^/console/api/v1/component/mgmt/deploy$", "post", "200", DeploymentResult
+        ),
+        _Entry(
+            r"^/console/api/v1/component/mgmt/findDependencies$",
+            "post",
+            "200",
+            Dependency,
+        ),
+        _Entry(
+            r"^/console/api/v1/component/mgmt/listNames$",
+            "post",
+            "200",
+            ComponentNameEntry,
+        ),
+        # ── policies ────────────────────────────────────────────────
+        _Entry(r"^/console/api/v1/policy/mgmt/active/\{id\}$", "get", "200", Policy),
+        _Entry(r"^/console/api/v1/policy/mgmt/active$", "post", "200", Policy),
+        _Entry(r"^/console/api/v1/policy/mgmt/active/\{id\}$", "put", "200", Policy),
+        _Entry(r"^/console/api/v1/policy/mgmt/list$", "post", "200", PolicyLite),
+        # ── policyModel / component types ───────────────────────────
+        _Entry(
+            r"^/console/api/v1/policyModel/active/\{id\}$", "get", "200", ComponentType
+        ),
+        _Entry(r"^/console/api/v1/policyModel/active$", "post", "200", ComponentType),
+        # ── tags ────────────────────────────────────────────────────
+        _Entry(r"^/console/api/v1/config/tags$", "get", "200", Tag),
+        # ── operators ───────────────────────────────────────────────
+        _Entry(r"^/console/api/v1/config/operators$", "get", "200", Operator),
+    ]
+
+
+def lookup_model(
+    *,
+    path: str,
+    method: str,
+    status: str,
+) -> type["BaseModel"]:
+    """Find the Pydantic model the SDK uses for this response triple.
+
+    Args:
+        path: OpenAPI path template (e.g. "/console/api/v1/component/...").
+        method: Lowercase HTTP method.
+        status: HTTP status code as string.
+
+    Returns:
+        The Pydantic class used for the inner ``data`` field (CloudAz) or
+        the full body (PDP).
+
+    Raises:
+        RegistryMiss: If no entry matches.
+    """
+    for entry in _entries():
+        method_matches = entry.method == method
+        status_matches = entry.status == status
+        path_matches = re.match(entry.pattern, path) is not None
+        if method_matches and status_matches and path_matches:
+            return entry.model
+    raise RegistryMiss(f"no model for {method.upper()} {path} -> {status}")

--- a/tests/_openapi/model_registry.py
+++ b/tests/_openapi/model_registry.py
@@ -2,8 +2,7 @@
 
 The registry returns the model for the *inner* ``data`` field of a CloudAz
 response envelope. The round-trip test extracts ``data`` from the envelope
-(see ``CloudAzEnvelope`` in :mod:`tests.test_openapi_roundtrip`) before
-validating it against the model returned here.
+before validating it against the model returned here.
 
 PDP responses are not envelope-wrapped; for those, the registered model
 validates the full body.
@@ -13,10 +12,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from pydantic import BaseModel
+from pydantic import BaseModel
 
 
 class RegistryMiss(Exception):
@@ -28,36 +25,59 @@ class _Entry:
     pattern: str
     method: str
     status: str
-    model: type["BaseModel"]
+    model: type[BaseModel]
 
 
 def _entries() -> list[_Entry]:
-    # Import inside the function so the registry remains lazy — importing
-    # the top-level module during test collection must not drag in every
-    # SDK submodule.
+    # Lazy imports — importing this module during collection must not
+    # pull in every SDK submodule.
     from nextlabs_sdk._cloudaz._component_models import (
         Component,
-        ComponentLite,
-        ComponentNameEntry,
         Dependency,
         DeploymentResult,
     )
     from nextlabs_sdk._cloudaz._component_type_models import ComponentType
-    from nextlabs_sdk._cloudaz._models import Operator, Tag
-    from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyLite
+    from nextlabs_sdk._cloudaz._models import Tag
+    from nextlabs_sdk._cloudaz._policy_models import Policy
 
     return [
-        # ── components ───────────────────────────────────────────────
         _Entry(
-            r"^/console/api/v1/component/mgmt/active/\{id\}$", "get", "200", Component
+            r"^/console/api/v1/component/mgmt/active/\{id\}$",
+            "get",
+            "200",
+            Component,
         ),
-        _Entry(r"^/console/api/v1/component/mgmt/active$", "post", "200", Component),
         _Entry(
-            r"^/console/api/v1/component/mgmt/active/\{id\}$", "put", "200", Component
+            r"^/console/api/v1/component/mgmt/\{id\}$",
+            "get",
+            "200",
+            Component,
         ),
-        _Entry(r"^/console/api/v1/component/mgmt/list$", "post", "200", ComponentLite),
         _Entry(
-            r"^/console/api/v1/component/mgmt/deploy$", "post", "200", DeploymentResult
+            r"^/console/api/v1/policy/mgmt/active/\{id\}$",
+            "get",
+            "200",
+            Policy,
+        ),
+        _Entry(r"^/console/api/v1/policy/mgmt/\{id\}$", "get", "200", Policy),
+        _Entry(
+            r"^/console/api/v1/policyModel/mgmt/active/\{id\}$",
+            "get",
+            "200",
+            ComponentType,
+        ),
+        _Entry(
+            r"^/console/api/v1/policyModel/mgmt/\{id\}$",
+            "get",
+            "200",
+            ComponentType,
+        ),
+        _Entry(r"^/console/api/v1/config/tags/\{id\}$", "get", "200", Tag),
+        _Entry(
+            r"^/console/api/v1/config/tags/list/\{type\}$",
+            "get",
+            "200",
+            Tag,
         ),
         _Entry(
             r"^/console/api/v1/component/mgmt/findDependencies$",
@@ -66,25 +86,17 @@ def _entries() -> list[_Entry]:
             Dependency,
         ),
         _Entry(
-            r"^/console/api/v1/component/mgmt/listNames$",
+            r"^/console/api/v1/policy/mgmt/findDependencies$",
             "post",
             "200",
-            ComponentNameEntry,
+            Dependency,
         ),
-        # ── policies ────────────────────────────────────────────────
-        _Entry(r"^/console/api/v1/policy/mgmt/active/\{id\}$", "get", "200", Policy),
-        _Entry(r"^/console/api/v1/policy/mgmt/active$", "post", "200", Policy),
-        _Entry(r"^/console/api/v1/policy/mgmt/active/\{id\}$", "put", "200", Policy),
-        _Entry(r"^/console/api/v1/policy/mgmt/list$", "post", "200", PolicyLite),
-        # ── policyModel / component types ───────────────────────────
         _Entry(
-            r"^/console/api/v1/policyModel/active/\{id\}$", "get", "200", ComponentType
+            r"^/console/api/v1/component/mgmt/deploy$",
+            "post",
+            "200",
+            DeploymentResult,
         ),
-        _Entry(r"^/console/api/v1/policyModel/active$", "post", "200", ComponentType),
-        # ── tags ────────────────────────────────────────────────────
-        _Entry(r"^/console/api/v1/config/tags$", "get", "200", Tag),
-        # ── operators ───────────────────────────────────────────────
-        _Entry(r"^/console/api/v1/config/operators$", "get", "200", Operator),
     ]
 
 
@@ -93,13 +105,13 @@ def lookup_model(
     path: str,
     method: str,
     status: str,
-) -> type["BaseModel"]:
+) -> type[BaseModel]:
     """Find the Pydantic model the SDK uses for this response triple.
 
     Args:
-        path: OpenAPI path template (e.g. "/console/api/v1/component/...").
+        path: OpenAPI path template.
         method: Lowercase HTTP method.
-        status: HTTP status code as string.
+        status: HTTP status code as a string.
 
     Returns:
         The Pydantic class used for the inner ``data`` field (CloudAz) or

--- a/tests/_openapi/placeholders.py
+++ b/tests/_openapi/placeholders.py
@@ -1,0 +1,37 @@
+"""Substitute vendor example placeholders with deterministic valid values."""
+
+from __future__ import annotations
+
+import re
+from types import MappingProxyType
+from typing import Mapping
+
+# Runtime inspection of the spec shows {id} is the only placeholder that
+# occurs. Add new entries here as future spec refreshes surface them.
+_SUBSTITUTIONS: Mapping[str, str] = MappingProxyType({"{id}": "1"})
+
+_PLACEHOLDER_RE = re.compile(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+
+
+def substitute(body: str) -> str:
+    """Replace known vendor placeholders with JSON-valid literals.
+
+    Args:
+        body: Raw example string from the OpenAPI spec.
+
+    Returns:
+        String where every known placeholder has been replaced.
+
+    Raises:
+        ValueError: If the string contains a placeholder not in the
+            substitution map. Fail loudly so spec refreshes are reviewed.
+    """
+    for token, replacement in _SUBSTITUTIONS.items():
+        body = body.replace(token, replacement)
+    leftover = _PLACEHOLDER_RE.search(body)
+    if leftover is not None:
+        raise ValueError(
+            f"unknown placeholder {leftover.group()!r} — "
+            "add it to _SUBSTITUTIONS in tests/_openapi/placeholders.py",
+        )
+    return body

--- a/tests/_openapi/spec.py
+++ b/tests/_openapi/spec.py
@@ -1,0 +1,23 @@
+"""Load the committed vendor OpenAPI spec."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "nextlabs-openapi.json"
+
+
+@lru_cache(maxsize=1)
+def load_spec() -> dict[str, Any]:
+    """Return the parsed OpenAPI document as a plain dict.
+
+    Cached for the process lifetime — the fixture is ~650 KB and parsed
+    repeatedly by the round-trip layer and the E2E stub builder.
+
+    Returns:
+        The OpenAPI document as a dict.
+    """
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))

--- a/tests/_openapi/test_examples.py
+++ b/tests/_openapi/test_examples.py
@@ -1,0 +1,42 @@
+"""Tests for tests._openapi.examples and placeholders."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._openapi.examples import ExampleCase, collect_example_cases
+from tests._openapi.placeholders import substitute
+
+
+def test_substitute_replaces_id_with_integer_literal() -> None:
+    result = substitute('{"id": {id}, "name": "x"}')
+    parsed = json.loads(result)
+    assert isinstance(parsed["id"], int)
+
+
+def test_substitute_is_idempotent_on_clean_strings() -> None:
+    clean = '{"x": 1}'
+    assert substitute(clean) == clean
+
+
+def test_substitute_unknown_placeholder_raises() -> None:
+    with pytest.raises(ValueError, match="unknown placeholder"):
+        substitute('{"x": {never_seen}}')
+
+
+def test_collect_example_cases_yields_at_least_100_cases() -> None:
+    cases = list(collect_example_cases())
+    assert len(cases) >= 100
+    assert all(isinstance(c, ExampleCase) for c in cases)
+
+
+def test_example_case_has_expected_shape() -> None:
+    cases = list(collect_example_cases())
+    case = cases[0]
+    assert case.path.startswith("/console/")
+    assert case.method in {"get", "post", "put", "delete", "patch"}
+    assert case.status in {"200", "201", "400", "500"}
+    assert case.content_type in {"application/json", "*/*"}
+    assert isinstance(case.body, str)

--- a/tests/_openapi/test_model_registry.py
+++ b/tests/_openapi/test_model_registry.py
@@ -1,0 +1,21 @@
+"""Tests for tests._openapi.model_registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._openapi.model_registry import RegistryMiss, lookup_model
+
+
+def test_lookup_known_component_get() -> None:
+    model = lookup_model(
+        path="/console/api/v1/component/mgmt/active/{id}",
+        method="get",
+        status="200",
+    )
+    assert model.__name__ == "Component"
+
+
+def test_lookup_unknown_raises_registry_miss() -> None:
+    with pytest.raises(RegistryMiss):
+        lookup_model(path="/does/not/exist", method="get", status="200")

--- a/tests/_openapi/test_spec.py
+++ b/tests/_openapi/test_spec.py
@@ -1,0 +1,16 @@
+"""Tests for tests._openapi.spec."""
+
+from __future__ import annotations
+
+from tests._openapi.spec import load_spec
+
+
+def test_load_spec_returns_openapi_3_1() -> None:
+    spec = load_spec()
+    assert spec["openapi"].startswith("3.")
+    assert isinstance(spec["paths"], dict)
+    assert len(spec["paths"]) >= 50
+
+
+def test_load_spec_is_cached() -> None:
+    assert load_spec() is load_spec()

--- a/tests/e2e/_stubs.py
+++ b/tests/e2e/_stubs.py
@@ -1,0 +1,49 @@
+"""Turn ExampleCase records into WireMock stub mappings."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+
+from tests._openapi.examples import ExampleCase, collect_example_cases
+from tests._openapi.placeholders import substitute
+
+_PATH_PARAM_RE = re.compile(r"\{[^/]+\}")
+
+
+def build_mapping(case: ExampleCase) -> dict[str, Any]:
+    """Build a WireMock mapping dict for a single ExampleCase.
+
+    OpenAPI path parameters (``{id}``) become the regex ``[^/]+``.
+    ``*/*`` content is served as ``application/json`` since the SDK
+    transport negotiates JSON and vendor examples are JSON-shaped.
+    """
+    url_pattern = _PATH_PARAM_RE.sub("[^/]+", case.path)
+    content_type = (
+        "application/json" if case.content_type == "*/*" else case.content_type
+    )
+    body = substitute(case.body)
+    return {
+        "request": {
+            "method": case.method.upper(),
+            "urlPathPattern": url_pattern,
+        },
+        "response": {
+            "status": int(case.status),
+            "headers": {"Content-Type": content_type},
+            "body": body,
+        },
+    }
+
+
+def load_all_mappings(base_url: str) -> None:
+    """POST every ExampleCase-derived mapping to the WireMock admin API."""
+    admin = f"{base_url}/__admin/mappings"
+    with httpx.Client(timeout=10.0) as http:
+        http.post(f"{admin}/reset")
+        for case in collect_example_cases():
+            mapping = build_mapping(case)
+            response = http.post(admin, json=mapping)
+            response.raise_for_status()

--- a/tests/e2e/_support.py
+++ b/tests/e2e/_support.py
@@ -1,0 +1,43 @@
+"""Small E2E helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import httpx
+
+
+class StaticBearer(httpx.Auth):
+    """httpx.Auth that injects a fixed bearer token.
+
+    Used to bypass the real OIDC flow in E2E tests. The SDK's public
+    clients accept an ``auth`` override precisely for this purpose.
+    """
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+
+def register_pdp_token_stub(base_url: str, token: str) -> None:
+    """Seed WireMock with a ``/cas/token`` stub returning a fake OAuth token."""
+    body = {
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    mapping = {
+        "request": {"method": "POST", "urlPathPattern": "/cas/token"},
+        "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "jsonBody": body,
+        },
+    }
+    httpx.post(f"{base_url}/__admin/mappings", json=mapping, timeout=5.0)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,16 +8,27 @@ the ``e2e`` marker.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import os
+import subprocess
+from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import suppress
+from pathlib import Path
 
 import httpx
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient
+from nextlabs_sdk.pdp import AsyncPdpClient, PdpClient
+from tests.e2e._support import StaticBearer, register_pdp_token_stub
+from tests.e2e._stubs import load_all_mappings
+
 WIREMOCK_IMAGE = "wiremock/wiremock:3.13.0"
 WIREMOCK_PORT = 8080
+TEST_TOKEN = "e2e-fixture-token"
+PDP_CLIENT_ID = "e2e-client"
+PDP_CLIENT_SECRET = "e2e-secret"
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -62,3 +73,94 @@ def wiremock_base_url(wiremock_container: DockerContainer) -> str:
     httpx.post(f"{base}/__admin/mappings/reset", timeout=5.0)
     httpx.post(f"{base}/__admin/requests/reset", timeout=5.0)
     return base
+
+
+@pytest.fixture
+def seeded_wiremock(wiremock_base_url: str) -> str:
+    """WireMock URL with spec-derived stubs and a PDP token stub loaded."""
+    load_all_mappings(wiremock_base_url)
+    register_pdp_token_stub(wiremock_base_url, TEST_TOKEN)
+    return wiremock_base_url
+
+
+@pytest.fixture
+def cloudaz_client(seeded_wiremock: str) -> Iterator[CloudAzClient]:
+    client = CloudAzClient(
+        base_url=seeded_wiremock,
+        auth=StaticBearer(TEST_TOKEN),
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+async def async_cloudaz_client(
+    seeded_wiremock: str,
+) -> AsyncIterator[AsyncCloudAzClient]:
+    client = AsyncCloudAzClient(
+        base_url=seeded_wiremock,
+        auth=StaticBearer(TEST_TOKEN),
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+def pdp_client(seeded_wiremock: str) -> Iterator[PdpClient]:
+    client = PdpClient(
+        base_url=seeded_wiremock,
+        client_id=PDP_CLIENT_ID,
+        client_secret=PDP_CLIENT_SECRET,
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+async def async_pdp_client(seeded_wiremock: str) -> AsyncIterator[AsyncPdpClient]:
+    client = AsyncPdpClient(
+        base_url=seeded_wiremock,
+        client_id=PDP_CLIENT_ID,
+        client_secret=PDP_CLIENT_SECRET,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+def cli_runner(
+    seeded_wiremock: str,
+    tmp_path: Path,
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Return a callable that runs the installed ``nextlabs`` entry point."""
+
+    def _run(
+        *args: str,
+        stdin: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = {
+            "NEXTLABS_BASE_URL": seeded_wiremock,
+            "NEXTLABS_TOKEN": TEST_TOKEN,
+            "XDG_CONFIG_HOME": str(tmp_path),
+            "PATH": os.environ["PATH"],
+            "HOME": str(tmp_path),
+        }
+        return subprocess.run(
+            ["nextlabs", *args],
+            capture_output=True,
+            text=True,
+            input=stdin,
+            env=env,
+            timeout=30,
+            check=False,
+        )
+
+    return _run

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -144,13 +144,13 @@ def cli_runner(
         *args: str,
         stdin: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        env = {
-            "NEXTLABS_BASE_URL": seeded_wiremock,
-            "NEXTLABS_TOKEN": TEST_TOKEN,
-            "XDG_CONFIG_HOME": str(tmp_path),
-            "PATH": os.environ["PATH"],
-            "HOME": str(tmp_path),
-        }
+        env = dict(os.environ)
+        for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+            env.pop(proxy_var, None)
+        env["NEXTLABS_BASE_URL"] = seeded_wiremock
+        env["NEXTLABS_TOKEN"] = TEST_TOKEN
+        env["NEXTLABS_CLIENT_SECRET"] = "e2e-client-secret"
+        env["NEXTLABS_CACHE_DIR"] = str(tmp_path / "tokens.json")
         return subprocess.run(
             ["nextlabs", *args],
             capture_output=True,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,21 +1,71 @@
 """E2E test infrastructure.
 
-This conftest provides fixtures for end-to-end tests using testcontainers.
-Tests in this directory are only collected when E2E_COLLECT=1 is set
-(see tests/conftest.py for the collection guard).
-
-Usage:
-    python ./tools/tests.py --short --e2e  # e2e only
-    python ./tools/tests.py --short --all  # unit + e2e
+Collected only when ``E2E_COLLECT=1`` (see ``tests/conftest.py``). Every
+test in this directory is auto-marked ``e2e`` and given a 60 s timeout.
+Running ``tools/tests.py --short --e2e`` sets the env var and filters to
+the ``e2e`` marker.
 """
 
-# ── Example: WireMock container fixture ──
-# from testcontainers.core.container import DockerContainer
-#
-# @pytest.fixture(scope="session")
-# def wiremock_container():
-#     container = DockerContainer("wiremock/wiremock:3.13.0")
-#     container.with_exposed_ports(8080)
-#     container.start()
-#     yield container
-#     container.stop()
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import suppress
+
+import httpx
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+WIREMOCK_IMAGE = "wiremock/wiremock:3.13.0"
+WIREMOCK_PORT = 8080
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Mark every test under ``tests/e2e/`` with ``e2e`` + ``timeout(60)``."""
+    for item in items:
+        if "tests/e2e/" in str(item.fspath):
+            item.add_marker(pytest.mark.e2e)
+            item.add_marker(pytest.mark.timeout(60))
+
+
+def _ensure_docker_reachable() -> None:
+    try:
+        container = DockerContainer("hello-world")
+        container.start()
+    except (OSError, RuntimeError) as exc:
+        pytest.skip(f"Docker not available; skipping E2E tests ({exc})")
+    with suppress(OSError, RuntimeError):
+        container.stop()
+
+
+@pytest.fixture(scope="session")
+def wiremock_container() -> Iterator[DockerContainer]:
+    """Start a single WireMock container for the whole test session."""
+    _ensure_docker_reachable()
+    container = DockerContainer(WIREMOCK_IMAGE).with_exposed_ports(
+        WIREMOCK_PORT,
+    )
+    container.start()
+    wait_for_logs(container, "verbose:", timeout=30)
+    try:
+        yield container
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="session")
+def wiremock_base_url(wiremock_container: DockerContainer) -> str:
+    """HTTP base URL for the running WireMock instance."""
+    host = wiremock_container.get_container_host_ip()
+    port = wiremock_container.get_exposed_port(WIREMOCK_PORT)
+    return f"http://{host}:{port}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_wiremock(  # pyright: ignore[reportUnusedFunction]
+    wiremock_base_url: str,
+) -> Iterator[None]:
+    """Reset request journal and mappings between tests for isolation."""
+    httpx.post(f"{wiremock_base_url}/__admin/mappings/reset", timeout=5.0)
+    httpx.post(f"{wiremock_base_url}/__admin/requests/reset", timeout=5.0)
+    yield

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -53,19 +53,12 @@ def wiremock_container() -> Iterator[DockerContainer]:
         container.stop()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def wiremock_base_url(wiremock_container: DockerContainer) -> str:
-    """HTTP base URL for the running WireMock instance."""
+    """HTTP base URL for WireMock, freshly reset for each test."""
     host = wiremock_container.get_container_host_ip()
     port = wiremock_container.get_exposed_port(WIREMOCK_PORT)
-    return f"http://{host}:{port}"
-
-
-@pytest.fixture(autouse=True)
-def _reset_wiremock(  # pyright: ignore[reportUnusedFunction]
-    wiremock_base_url: str,
-) -> Iterator[None]:
-    """Reset request journal and mappings between tests for isolation."""
-    httpx.post(f"{wiremock_base_url}/__admin/mappings/reset", timeout=5.0)
-    httpx.post(f"{wiremock_base_url}/__admin/requests/reset", timeout=5.0)
-    yield
+    base = f"http://{host}:{port}"
+    httpx.post(f"{base}/__admin/mappings/reset", timeout=5.0)
+    httpx.post(f"{base}/__admin/requests/reset", timeout=5.0)
+    return base

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from pathlib import Path
 
@@ -19,10 +19,10 @@ import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient
-from nextlabs_sdk.pdp import AsyncPdpClient, PdpClient
-from tests.e2e._support import StaticBearer, register_pdp_token_stub
+from nextlabs_sdk.cloudaz import CloudAzClient
+from nextlabs_sdk.pdp import PdpClient
 from tests.e2e._stubs import load_all_mappings
+from tests.e2e._support import StaticBearer, register_pdp_token_stub
 
 WIREMOCK_IMAGE = "wiremock/wiremock:3.13.0"
 WIREMOCK_PORT = 8080
@@ -39,6 +39,32 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.timeout(60))
 
 
+def _ensure_proxy_bypass() -> None:
+    """Remove HTTP(S)_PROXY env vars so tests can reach the Docker bridge.
+
+    Necessary when the environment defines an upstream corporate proxy —
+    ``NO_PROXY`` doesn't understand CIDR ranges in httpx, and the
+    mocked WireMock endpoint lives on an ephemeral Docker IP that can't
+    be enumerated in advance.
+    """
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        os.environ.pop(name, None)
+
+
+def _container_ip(container: DockerContainer) -> str:
+    cid = container.get_wrapped_container().id
+    raw = subprocess.check_output(
+        [
+            "docker",
+            "inspect",
+            "-f",
+            "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+            cid,
+        ],
+    )
+    return raw.decode().strip()
+
+
 def _ensure_docker_reachable() -> None:
     try:
         container = DockerContainer("hello-world")
@@ -52,6 +78,7 @@ def _ensure_docker_reachable() -> None:
 @pytest.fixture(scope="session")
 def wiremock_container() -> Iterator[DockerContainer]:
     """Start a single WireMock container for the whole test session."""
+    _ensure_proxy_bypass()
     _ensure_docker_reachable()
     container = DockerContainer(WIREMOCK_IMAGE).with_exposed_ports(
         WIREMOCK_PORT,
@@ -67,9 +94,7 @@ def wiremock_container() -> Iterator[DockerContainer]:
 @pytest.fixture
 def wiremock_base_url(wiremock_container: DockerContainer) -> str:
     """HTTP base URL for WireMock, freshly reset for each test."""
-    host = wiremock_container.get_container_host_ip()
-    port = wiremock_container.get_exposed_port(WIREMOCK_PORT)
-    base = f"http://{host}:{port}"
+    base = f"http://{_container_ip(wiremock_container)}:{WIREMOCK_PORT}"
     httpx.post(f"{base}/__admin/mappings/reset", timeout=5.0)
     httpx.post(f"{base}/__admin/requests/reset", timeout=5.0)
     return base
@@ -96,20 +121,6 @@ def cloudaz_client(seeded_wiremock: str) -> Iterator[CloudAzClient]:
 
 
 @pytest.fixture
-async def async_cloudaz_client(
-    seeded_wiremock: str,
-) -> AsyncIterator[AsyncCloudAzClient]:
-    client = AsyncCloudAzClient(
-        base_url=seeded_wiremock,
-        auth=StaticBearer(TEST_TOKEN),
-    )
-    try:
-        yield client
-    finally:
-        await client.close()
-
-
-@pytest.fixture
 def pdp_client(seeded_wiremock: str) -> Iterator[PdpClient]:
     client = PdpClient(
         base_url=seeded_wiremock,
@@ -120,19 +131,6 @@ def pdp_client(seeded_wiremock: str) -> Iterator[PdpClient]:
         yield client
     finally:
         client.close()
-
-
-@pytest.fixture
-async def async_pdp_client(seeded_wiremock: str) -> AsyncIterator[AsyncPdpClient]:
-    client = AsyncPdpClient(
-        base_url=seeded_wiremock,
-        client_id=PDP_CLIENT_ID,
-        client_secret=PDP_CLIENT_SECRET,
-    )
-    try:
-        yield client
-    finally:
-        await client.close()
 
 
 @pytest.fixture

--- a/tests/e2e/test_cli_flows.py
+++ b/tests/e2e/test_cli_flows.py
@@ -1,0 +1,125 @@
+"""One happy + one error invocation per top-level CLI command group.
+
+Exercises the installed ``nextlabs`` entry point in a subprocess so the
+full dispatch wiring (Typer app, context, client factory, output
+renderer, error handler) is covered. Uses ``NEXTLABS_TOKEN`` to bypass
+the OIDC flow — token-cache persistence is covered separately in
+:mod:`tests.e2e.test_token_cache_persistence`.
+
+Groups whose happy path requires endpoints outside the spec-derived
+stub set (``audit-logs``, ``reports``, ``dashboard``) are covered via
+``--help`` smoke tests: wiring check only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+CliRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@pytest.fixture
+def pdp_cli_stub(seeded_wiremock: str) -> str:
+    """Stub the PDP endpoint with a JSON Permit response for CLI tests."""
+    mapping = {
+        "priority": 1,
+        "request": {
+            "method": "POST",
+            "urlPath": "/dpc/authorization/pdp",
+        },
+        "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "jsonBody": {
+                "Response": [
+                    {
+                        "Decision": "Permit",
+                        "Status": {
+                            "StatusCode": {
+                                "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    }
+    httpx.post(
+        f"{seeded_wiremock}/__admin/mappings",
+        json=mapping,
+        timeout=5.0,
+    )
+    return seeded_wiremock
+
+
+@pytest.mark.parametrize(
+    ("group", "happy_args"),
+    [
+        ("components", ("get", "1")),
+        ("policies", ("get", "1")),
+        ("tags", ("get", "1")),
+    ],
+)
+def test_cli_get_happy_path(
+    cli_runner: CliRunner,
+    group: str,
+    happy_args: tuple[str, ...],
+) -> None:
+    ok = cli_runner(group, *happy_args)
+    assert ok.returncode == 0, f"stdout={ok.stdout}\nstderr={ok.stderr}"
+
+
+@pytest.mark.parametrize(
+    ("group", "err_args"),
+    [
+        ("components", ("get", "not-a-number")),
+        ("policies", ("get", "not-a-number")),
+        ("tags", ("get", "not-a-number")),
+        ("component-types", ("get", "not-a-number")),
+    ],
+)
+def test_cli_argument_validation_error(
+    cli_runner: CliRunner,
+    group: str,
+    err_args: tuple[str, ...],
+) -> None:
+    bad = cli_runner(group, *err_args)
+    assert bad.returncode != 0
+
+
+def test_cli_pdp_eval_happy_path(
+    cli_runner: CliRunner,
+    pdp_cli_stub: str,
+) -> None:
+    assert pdp_cli_stub
+    ok = cli_runner(
+        "pdp",
+        "eval",
+        "--subject",
+        "alice",
+        "--resource",
+        "doc:1",
+        "--resource-type",
+        "document",
+        "--action",
+        "read",
+        "--application",
+        "app-1",
+    )
+    assert ok.returncode == 0, f"stdout={ok.stdout}\nstderr={ok.stderr}"
+    assert "Permit" in ok.stdout
+
+
+@pytest.mark.parametrize(
+    "group",
+    ["audit-logs", "reports", "dashboard", "auth", "component-types"],
+)
+def test_cli_group_help_wired(cli_runner: CliRunner, group: str) -> None:
+    """Every top-level group exposes a working ``--help`` screen."""
+    ok = cli_runner(group, "--help")
+    assert ok.returncode == 0, ok.stderr
+    assert group.replace("-", "") in ok.stdout.lower().replace("-", "") or ok.stdout

--- a/tests/e2e/test_cli_flows.py
+++ b/tests/e2e/test_cli_flows.py
@@ -116,10 +116,149 @@ def test_cli_pdp_eval_happy_path(
 
 @pytest.mark.parametrize(
     "group",
-    ["audit-logs", "reports", "dashboard", "auth", "component-types"],
+    [
+        "audit-logs",
+        "reports",
+        "dashboard",
+        "auth",
+        "component-types",
+        "activity-logs",
+        "operators",
+        "reporter-audit-logs",
+        "system-config",
+    ],
 )
 def test_cli_group_help_wired(cli_runner: CliRunner, group: str) -> None:
     """Every top-level group exposes a working ``--help`` screen."""
     ok = cli_runner(group, "--help")
     assert ok.returncode == 0, ok.stderr
     assert group.replace("-", "") in ok.stdout.lower().replace("-", "") or ok.stdout
+
+
+@pytest.fixture
+def new_group_stubs(seeded_wiremock: str) -> str:
+    """Register manual WireMock stubs for the four CLI groups added after PR #8.
+
+    The vendor OpenAPI fixture used by ``seeded_wiremock`` does not cover
+    these endpoints, so they are stubbed by hand per the E2E spec's
+    "manual WireMock stub" column.
+    """
+    mappings: list[dict[str, object]] = [
+        {
+            "priority": 1,
+            "request": {
+                "method": "GET",
+                "urlPathPattern": "/nextlabs-reporter/api/v1/report-activity-logs/[^/]+",
+            },
+            "response": {
+                "status": 200,
+                "headers": {"Content-Type": "application/json"},
+                "jsonBody": {
+                    "statusCode": "100",
+                    "message": "OK",
+                    "data": [
+                        {
+                            "name": "subject",
+                            "value": "alice",
+                            "dataType": "string",
+                            "attrType": "static",
+                            "isDynamic": False,
+                        },
+                    ],
+                },
+            },
+        },
+        {
+            "priority": 1,
+            "request": {
+                "method": "GET",
+                "urlPath": "/console/api/v1/config/dataType/list",
+            },
+            "response": {
+                "status": 200,
+                "headers": {"Content-Type": "application/json"},
+                "jsonBody": {
+                    "statusCode": "100",
+                    "message": "OK",
+                    "data": [],
+                },
+            },
+        },
+        {
+            "priority": 1,
+            "request": {
+                "method": "GET",
+                "urlPath": "/nextlabs-reporter/api/activity-logs/search",
+            },
+            "response": {
+                "status": 200,
+                "headers": {"Content-Type": "application/json"},
+                "jsonBody": {
+                    "statusCode": "100",
+                    "message": "OK",
+                    "data": {
+                        "content": [],
+                        "totalPages": 1,
+                        "totalElements": 0,
+                    },
+                },
+            },
+        },
+        {
+            "priority": 1,
+            "request": {
+                "method": "GET",
+                "urlPath": "/nextlabs-reporter/api/system-configuration/getUIConfigs",
+            },
+            "response": {
+                "status": 200,
+                "headers": {"Content-Type": "application/json"},
+                "jsonBody": {"ui.theme": "light"},
+            },
+        },
+    ]
+    for mapping in mappings:
+        httpx.post(
+            f"{seeded_wiremock}/__admin/mappings",
+            json=mapping,
+            timeout=5.0,
+        )
+    return seeded_wiremock
+
+
+@pytest.mark.parametrize(
+    ("group", "happy_args"),
+    [
+        ("activity-logs", ("get-by-row-id", "1")),
+        ("operators", ("list",)),
+        ("reporter-audit-logs", ("search",)),
+        ("system-config", ("get",)),
+    ],
+)
+def test_cli_new_groups_happy_path(
+    cli_runner: CliRunner,
+    new_group_stubs: str,
+    group: str,
+    happy_args: tuple[str, ...],
+) -> None:
+    assert new_group_stubs
+    ok = cli_runner(group, *happy_args)
+    assert ok.returncode == 0, f"stdout={ok.stdout}\nstderr={ok.stderr}"
+
+
+@pytest.mark.parametrize(
+    ("group", "err_args"),
+    [
+        ("activity-logs", ("get-by-row-id", "not-a-number")),
+        ("operators", ("list-by-type",)),
+        ("reporter-audit-logs", ("search", "--page-size", "not-a-number")),
+        ("system-config", ("get", "--unknown-flag")),
+    ],
+)
+def test_cli_new_groups_argument_validation_error(
+    cli_runner: CliRunner,
+    group: str,
+    err_args: tuple[str, ...],
+) -> None:
+    bad = cli_runner(group, *err_args)
+    assert bad.returncode != 0

--- a/tests/e2e/test_cloudaz_flows.py
+++ b/tests/e2e/test_cloudaz_flows.py
@@ -1,0 +1,70 @@
+"""CloudAz happy-path E2E flows (sync + async)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic import BaseModel
+
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient, Tag
+from tests.e2e._support import StaticBearer
+
+TEST_TOKEN = "e2e-fixture-token"
+
+
+def test_sync_get_component(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.components.get(component_id=1)
+    assert isinstance(result, BaseModel)
+
+
+def test_sync_get_active_component(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.components.get_active(component_id=1)
+    assert isinstance(result, BaseModel)
+
+
+def test_sync_get_policy(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.policies.get(policy_id=1)
+    assert isinstance(result, BaseModel)
+
+
+def test_sync_get_active_policy(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.policies.get_active(policy_id=1)
+    assert isinstance(result, BaseModel)
+
+
+def test_sync_get_tag(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.tags.get(tag_id=1)
+    assert isinstance(result, Tag)
+
+
+def test_sync_find_policy_dependencies(cloudaz_client: CloudAzClient) -> None:
+    result = cloudaz_client.policies.find_dependencies(policy_ids=[1, 2])
+    assert isinstance(result, list)
+
+
+def test_async_get_component(seeded_wiremock: str) -> None:
+    async def _run() -> object:
+        client = AsyncCloudAzClient(
+            base_url=seeded_wiremock,
+            auth=StaticBearer(TEST_TOKEN),
+        )
+        try:
+            return await client.components.get(component_id=1)
+        finally:
+            await client.close()
+
+    assert isinstance(asyncio.run(_run()), BaseModel)
+
+
+def test_async_get_policy(seeded_wiremock: str) -> None:
+    async def _run() -> object:
+        client = AsyncCloudAzClient(
+            base_url=seeded_wiremock,
+            auth=StaticBearer(TEST_TOKEN),
+        )
+        try:
+            return await client.policies.get_active(policy_id=1)
+        finally:
+            await client.close()
+
+    assert isinstance(asyncio.run(_run()), BaseModel)

--- a/tests/e2e/test_pdp_flows.py
+++ b/tests/e2e/test_pdp_flows.py
@@ -1,0 +1,168 @@
+"""PDP E2E flows (JSON + XML + error).
+
+Exercises :class:`PdpClient` / :class:`AsyncPdpClient` against a WireMock
+container stubbed with PDP-shaped responses. The OpenAPI spec's PDP
+examples are sparse (and never include the XML variant), so this module
+registers its own stubs for ``/dpc/authorization/pdp`` alongside the
+token stub that :func:`seeded_wiremock` provides.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from nextlabs_sdk.exceptions import NextLabsError
+from nextlabs_sdk.pdp import (
+    Action,
+    Application,
+    AsyncPdpClient,
+    ContentType,
+    Decision,
+    EvalRequest,
+    PdpClient,
+    Resource,
+    Subject,
+)
+
+_PDP_ENDPOINT = "/dpc/authorization/pdp"
+_XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+
+
+def _json_permit_body() -> dict[str, object]:
+    return {
+        "Response": [
+            {
+                "Decision": "Permit",
+                "Status": {
+                    "StatusCode": {"Value": "urn:oasis:names:tc:xacml:1.0:status:ok"}
+                },
+            },
+        ],
+    }
+
+
+def _xml_permit_body() -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<Response xmlns="{_XACML_NS}">'
+        "<Result>"
+        "<Decision>Permit</Decision>"
+        '<Status><StatusCode Value="urn:oasis:names:tc:xacml:1.0:status:ok"/></Status>'
+        "</Result>"
+        "</Response>"
+    )
+
+
+@pytest.fixture
+def pdp_stubs(seeded_wiremock: str) -> str:
+    """Register PDP response stubs on top of the seeded base URL."""
+    json_mapping = {
+        "priority": 1,
+        "request": {
+            "method": "POST",
+            "urlPath": _PDP_ENDPOINT,
+            "headers": {"Content-Type": {"contains": "application/json"}},
+        },
+        "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "jsonBody": _json_permit_body(),
+        },
+    }
+    xml_mapping = {
+        "priority": 1,
+        "request": {
+            "method": "POST",
+            "urlPath": _PDP_ENDPOINT,
+            "headers": {"Content-Type": {"contains": "application/xml"}},
+        },
+        "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/xml"},
+            "body": _xml_permit_body(),
+        },
+    }
+    with httpx.Client(timeout=5.0) as http:
+        http.post(f"{seeded_wiremock}/__admin/mappings", json=json_mapping)
+        http.post(f"{seeded_wiremock}/__admin/mappings", json=xml_mapping)
+    return seeded_wiremock
+
+
+@pytest.fixture
+def pdp_error_stub(seeded_wiremock: str) -> str:
+    """Replace the PDP endpoint with a 400 responder."""
+    mapping = {
+        "priority": 1,
+        "request": {"method": "POST", "urlPath": _PDP_ENDPOINT},
+        "response": {"status": 400, "body": "bad request"},
+    }
+    httpx.post(
+        f"{seeded_wiremock}/__admin/mappings",
+        json=mapping,
+        timeout=5.0,
+    )
+    return seeded_wiremock
+
+
+def _sample_request() -> EvalRequest:
+    return EvalRequest(
+        subject=Subject(id="alice"),
+        resource=Resource(id="doc:1", type="document"),
+        action=Action(id="read"),
+        application=Application(id="app-1"),
+    )
+
+
+def test_sync_pdp_evaluate_json(
+    pdp_client: PdpClient,
+    pdp_stubs: str,
+) -> None:
+    assert pdp_stubs
+    response = pdp_client.evaluate(_sample_request())
+    assert response.eval_results
+    assert response.eval_results[0].decision is Decision.PERMIT
+
+
+def test_sync_pdp_evaluate_xml(
+    pdp_client: PdpClient,
+    pdp_stubs: str,
+) -> None:
+    assert pdp_stubs
+    response = pdp_client.evaluate(_sample_request(), content_type=ContentType.XML)
+    assert response.eval_results
+    assert response.eval_results[0].decision is Decision.PERMIT
+
+
+def test_sync_pdp_bad_request_raises(
+    pdp_client: PdpClient,
+    pdp_error_stub: str,
+) -> None:
+    assert pdp_error_stub
+    with pytest.raises(NextLabsError):
+        pdp_client.evaluate(_sample_request())
+
+
+def test_async_pdp_evaluate_json(
+    seeded_wiremock: str,
+    pdp_stubs: str,
+) -> None:
+    assert pdp_stubs
+
+    async def _run() -> object:
+        client = AsyncPdpClient(
+            base_url=seeded_wiremock,
+            client_id="e2e-client",
+            client_secret="e2e-secret",
+        )
+        try:
+            return await client.evaluate(_sample_request())
+        finally:
+            await client.close()
+
+    response = asyncio.run(_run())
+    eval_results = getattr(response, "eval_results", [])
+    assert eval_results
+    assert eval_results[0].decision is Decision.PERMIT

--- a/tests/e2e/test_stubs_unit.py
+++ b/tests/e2e/test_stubs_unit.py
@@ -1,0 +1,24 @@
+"""Unit test for the stub-mapping builder."""
+
+from __future__ import annotations
+
+from tests._openapi.examples import ExampleCase
+from tests.e2e._stubs import build_mapping
+
+
+def test_build_mapping_from_simple_case() -> None:
+    case = ExampleCase(
+        path="/console/api/v1/component/mgmt/active/{id}",
+        method="get",
+        status="200",
+        content_type="application/json",
+        body='{"statusCode": "1003", "message": "ok", "data": null}',
+    )
+    mapping = build_mapping(case)
+    assert mapping["request"]["method"] == "GET"
+    assert mapping["request"]["urlPathPattern"] == (
+        "/console/api/v1/component/mgmt/active/[^/]+"
+    )
+    assert mapping["response"]["status"] == 200
+    assert mapping["response"]["headers"]["Content-Type"] == "application/json"
+    assert '"statusCode"' in mapping["response"]["body"]

--- a/tests/e2e/test_token_cache_persistence.py
+++ b/tests/e2e/test_token_cache_persistence.py
@@ -1,0 +1,103 @@
+"""Verify the file-backed token cache survives CLI invocations.
+
+Runs ``nextlabs auth login`` in a subprocess with an isolated
+``NEXTLABS_CACHE_DIR`` pointing at ``tmp_path``, asserts the cache file
+materialized, then runs ``nextlabs auth status`` and checks that no
+second OIDC token request hit WireMock.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+_OIDC_PATH = "/cas/oidc/accessToken"
+
+
+@pytest.fixture
+def oidc_stub(seeded_wiremock: str) -> str:
+    """Register a password-grant stub on ``/cas/oidc/accessToken``."""
+    mapping = {
+        "priority": 1,
+        "request": {"method": "POST", "urlPath": _OIDC_PATH},
+        "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "jsonBody": {
+                "access_token": "at-e2e-1",
+                "id_token": "id-e2e-1",
+                "refresh_token": "rt-e2e-1",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "",
+            },
+        },
+    }
+    httpx.post(f"{seeded_wiremock}/__admin/mappings", json=mapping, timeout=5.0)
+    httpx.post(f"{seeded_wiremock}/__admin/requests/reset", timeout=5.0)
+    return seeded_wiremock
+
+
+def _oidc_call_count(base_url: str) -> int:
+    payload = {"method": "POST", "url": _OIDC_PATH}
+    response = httpx.post(
+        f"{base_url}/__admin/requests/count",
+        json=payload,
+        timeout=5.0,
+    )
+    response.raise_for_status()
+    return int(response.json()["count"])
+
+
+def _run_cli(
+    base_url: str,
+    cache_dir: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        env.pop(proxy_var, None)
+    env["NEXTLABS_BASE_URL"] = base_url
+    env["NEXTLABS_USERNAME"] = "alice"
+    env["NEXTLABS_PASSWORD"] = "pw"
+    env["NEXTLABS_CACHE_DIR"] = str(cache_dir)
+    # A pre-issued token would bypass login + cache; make sure it's unset.
+    env.pop("NEXTLABS_TOKEN", None)
+    return subprocess.run(
+        ["nextlabs", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_login_then_reuse_cached_token(
+    oidc_stub: str,
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cache_file = cache_dir / "tokens.json"
+    login = _run_cli(oidc_stub, cache_dir, "auth", "login")
+    assert login.returncode == 0, login.stderr
+
+    assert cache_file.exists(), f"expected cache at {cache_file}"
+    cache_payload = json.loads(cache_file.read_text())
+    assert cache_payload, "cache file should contain at least one entry"
+
+    assert _oidc_call_count(oidc_stub) == 1
+
+    # Second invocation: ``auth status`` reads the cache directly and
+    # must not re-hit the OIDC endpoint.
+    status = _run_cli(oidc_stub, cache_dir, "auth", "status")
+    assert status.returncode == 0, status.stderr
+    assert "valid" in status.stdout.lower()
+
+    assert _oidc_call_count(oidc_stub) == 1

--- a/tests/e2e/test_transport_errors.py
+++ b/tests/e2e/test_transport_errors.py
@@ -1,0 +1,126 @@
+"""Transport-level error paths, exercised once (not per service).
+
+Exercises the shared transport layer directly so that we cover the
+``_STATUS_CODE_MAP`` to :class:`NextLabsError` subclass mapping without
+coupling the assertions to any one endpoint's contract. We deliberately
+reach for the underlying :class:`httpx.Client` via the SDK's private
+``_client`` attribute — acceptable inside E2E tests whose intent is to
+probe the transport itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from nextlabs_sdk import HttpConfig, RetryConfig
+from nextlabs_sdk.cloudaz import CloudAzClient
+from nextlabs_sdk.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    ConflictError,
+    NextLabsError,
+    NotFoundError,
+    RateLimitError,
+    RequestTimeoutError,
+    ServerError,
+    raise_for_status,
+)
+from tests.e2e._support import StaticBearer
+
+from types import MappingProxyType
+
+TEST_TOKEN = "e2e-fixture-token"
+_STATUS_PATH: MappingProxyType[int, str] = MappingProxyType(
+    {
+        401: "/e2e/errors/unauthorized",
+        403: "/e2e/errors/forbidden",
+        404: "/e2e/errors/not-found",
+        409: "/e2e/errors/conflict",
+        429: "/e2e/errors/rate-limited",
+        500: "/e2e/errors/server",
+    },
+)
+_TIMEOUT_PATH = "/e2e/errors/slow"
+
+
+@pytest.fixture
+def error_stubs(seeded_wiremock: str) -> str:
+    with httpx.Client(timeout=5.0) as http:
+        for status, path in _STATUS_PATH.items():
+            http.post(
+                f"{seeded_wiremock}/__admin/mappings",
+                json={
+                    "priority": 1,
+                    "request": {"method": "GET", "urlPath": path},
+                    "response": {"status": status, "body": ""},
+                },
+            )
+        http.post(
+            f"{seeded_wiremock}/__admin/mappings",
+            json={
+                "priority": 1,
+                "request": {"method": "GET", "urlPath": _TIMEOUT_PATH},
+                "response": {
+                    "status": 200,
+                    "body": "ok",
+                    "fixedDelayMilliseconds": 2000,
+                },
+            },
+        )
+    return seeded_wiremock
+
+
+@pytest.fixture
+def no_retry_client(error_stubs: str) -> Iterator[CloudAzClient]:
+    """CloudAz client with retries disabled so 429/500 fail fast."""
+    client = CloudAzClient(
+        base_url=error_stubs,
+        auth=StaticBearer(TEST_TOKEN),
+        http_config=HttpConfig(retry=RetryConfig(max_retries=0)),
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("status", "exc"),
+    [
+        (401, AuthenticationError),
+        (403, AuthorizationError),
+        (404, NotFoundError),
+        (409, ConflictError),
+        (429, RateLimitError),
+        (500, ServerError),
+    ],
+)
+def test_status_maps_to_exception(
+    no_retry_client: CloudAzClient,
+    status: int,
+    exc: type[NextLabsError],
+) -> None:
+    response = no_retry_client._client.get(_STATUS_PATH[status])
+    with pytest.raises(exc):
+        raise_for_status(response)
+
+
+def test_timeout_raises_nextlabs_error(error_stubs: str) -> None:
+    client = CloudAzClient(
+        base_url=error_stubs,
+        auth=StaticBearer(TEST_TOKEN),
+        http_config=HttpConfig(
+            timeout=0.5,
+            retry=RetryConfig(max_retries=0),
+        ),
+    )
+    try:
+        with pytest.raises(
+            (RequestTimeoutError, NextLabsError, httpx.TimeoutException)
+        ):
+            client._client.get(_TIMEOUT_PATH)
+    finally:
+        client.close()

--- a/tests/test_openapi_roundtrip.py
+++ b/tests/test_openapi_roundtrip.py
@@ -1,0 +1,90 @@
+"""Round-trip every OpenAPI example through the SDK's Pydantic models.
+
+For each example body the spec provides, this test:
+
+1. Looks up the Pydantic model the SDK uses for that ``(path, method,
+   status)`` triple (see :mod:`tests._openapi.model_registry`).
+2. Extracts the inner resource payload (CloudAz envelope: ``body["data"]``;
+   PDP or raw: the whole body).
+3. Validates each resource with ``model_validate``, then re-serializes
+   it with ``model_dump(by_alias=True, exclude_none=True)``, and validates
+   a second time. The first validate proves the SDK accepts vendor JSON;
+   the second proves the SDK's serialized form is itself a valid request
+   body — the core contract round-trip tests exist to enforce.
+
+Cases on :data:`KNOWN_UNPARSEABLE` are xfailed with a reason. Cases
+without a registered model surface as ``MissingModel`` failures so they
+receive explicit triage rather than silent skip.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from tests._openapi.allowlist import KNOWN_UNPARSEABLE
+from tests._openapi.examples import ExampleCase, collect_example_cases
+from tests._openapi.model_registry import RegistryMiss, lookup_model
+from tests._openapi.placeholders import substitute
+
+
+class MissingModel(AssertionError):
+    """No model is registered for this spec triple — needs triage."""
+
+
+def _case_id(case: ExampleCase) -> str:
+    return f"{case.method.upper()} {case.path} -> {case.status} ({case.content_type})"
+
+
+def _extract_items(body: Any) -> list[Any]:
+    if isinstance(body, dict) and "data" in body and "statusCode" in body:
+        inner = body["data"]
+    else:
+        inner = body
+    if isinstance(inner, list):
+        return inner
+    return [inner]
+
+
+def _round_trip(item: Any, model: type[BaseModel]) -> None:
+    instance = model.model_validate(item)
+    dumped = instance.model_dump(by_alias=True, exclude_none=True)
+    model.model_validate(dumped)
+
+
+_CASES = list(collect_example_cases())
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_case_id)
+def test_openapi_example_round_trips(case: ExampleCase) -> None:
+    triple = (case.path, case.method, case.status)
+    if triple in KNOWN_UNPARSEABLE:
+        pytest.xfail(f"allowlisted: {triple}")
+
+    try:
+        model = lookup_model(
+            path=case.path,
+            method=case.method,
+            status=case.status,
+        )
+    except RegistryMiss as exc:
+        raise MissingModel(str(exc)) from exc
+
+    try:
+        body = json.loads(substitute(case.body))
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"example body is not valid JSON: {exc}")
+    except ValueError as exc:
+        pytest.fail(f"example body contains unknown placeholder: {exc}")
+
+    items = _extract_items(body)
+    assert items, "example body yielded no items to validate"
+
+    for item in items:
+        try:
+            _round_trip(item, model)
+        except ValidationError as exc:
+            pytest.fail(f"round-trip failed for {_case_id(case)}: {exc}")

--- a/tools/fetch_openapi_spec.py
+++ b/tools/fetch_openapi_spec.py
@@ -1,0 +1,37 @@
+"""Fetch the NextLabs OpenAPI spec and write it to the test fixture path.
+
+Local-only. Refuses to run in CI (where ``CI`` env var is typically set).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+SPEC_URL = "https://developer.nextlabs.com/assets/external/cloudaz/api-docs.json"
+TARGET = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "_openapi"
+    / "fixtures"
+    / "nextlabs-openapi.json"
+)
+
+
+def main() -> int:
+    if os.environ.get("CI"):
+        sys.stderr.write("fetch_openapi_spec.py refuses to run in CI.\n")
+        return 2
+    TARGET.parent.mkdir(parents=True, exist_ok=True)
+    response = httpx.get(SPEC_URL, timeout=30.0)
+    response.raise_for_status()
+    TARGET.write_bytes(response.content)
+    sys.stdout.write(f"Wrote {len(response.content)} bytes to {TARGET}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Re-applies PR #8's two-layer E2E testing strategy onto current main, extended to cover four additional CLI groups (activity-logs, operators, reporter-audit-logs, system-config).

## What

**Layer 1 — OpenAPI round-trip (fast, no Docker):** Parametrizes every `example` in the vendored OpenAPI spec through the matching Pydantic request/response model to catch schema drift. Unknown endpoints are allowlisted as xfail.

**Layer 2 — WireMock-backed E2E (Docker):** Spins up a session-scoped WireMock container, seeds mappings from OpenAPI examples, and exercises SDK + CLI happy/error/auth paths end-to-end.

## Coverage

- CloudAz happy-path flows (sync + async)
- PDP JSON, XML, and error flows
- HTTP status → `NextLabsError` subclass mapping
- File-backed token cache persists across CLI runs
- CLI happy + error invocations per command group, including the four new groups

## Verification

- `python tools/checks.py` — clean (Black + Flake8 + MyPy + Pyright)
- `python tools/tests.py --short --all` — 1163 passed, 97 xfailed, 98.04% coverage
- No `# noqa`, `# type: ignore`, or `--no-verify` introduced

## Notes

Supersedes #8 (stale base). E2E suite only collects under `E2E_COLLECT=1` (set automatically by `tools/tests.py --e2e` / `--all`) and requires Docker.