### PR TITLE
fix(http): clamp Retry-After and extract RetryPolicy

### DIFF
--- a/src/nextlabs_sdk/_http_transport.py
+++ b/src/nextlabs_sdk/_http_transport.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio as _asyncio
 import logging
-import random
 import time
 
 import httpx
 
 from nextlabs_sdk._config import HttpConfig
+from nextlabs_sdk._retry_policy import RetryPolicy
 from nextlabs_sdk.exceptions import (
     NextLabsError,
     RequestTimeoutError,
@@ -28,11 +28,6 @@ _RETRYABLE_EXCEPTIONS = (
     httpx.ReadTimeout,
 )
 
-_RETRYABLE_STATUS_FLOOR = 500
-_RATE_LIMIT_STATUS = 429
-_RNG = random.SystemRandom()
-_BACKOFF_BASE = 2
-
 
 class RetryTransport(httpx.BaseTransport):
 
@@ -44,45 +39,40 @@ class RetryTransport(httpx.BaseTransport):
         max_delay: float = 30.0,
     ) -> None:
         self._wrapped = wrapped
-        self._max_retries = max_retries
-        self._base_delay = base_delay
-        self._max_delay = max_delay
+        self._policy = RetryPolicy(
+            max_retries=max_retries,
+            base_delay=base_delay,
+            max_delay=max_delay,
+        )
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         last_response: httpx.Response | None = None
         last_exc: BaseException | None = None
+        max_retries = self._policy.max_retries
 
-        for attempt in range(self._max_retries + 1):
+        for attempt in range(max_retries + 1):
             last_response, last_exc = _try_sync_request(self._wrapped, request)
 
-            if last_response is not None and not _needs_retry(last_response, last_exc):
+            if last_response is not None and not self._policy.should_retry(
+                last_response, last_exc
+            ):
                 return last_response
 
-            if attempt < self._max_retries:
-                self._sleep_before_retry(attempt, last_response, last_exc)
+            if attempt < max_retries:
+                delay = self._policy.next_delay(attempt, last_response, last_exc)
+                _log_retry(
+                    max_retries,
+                    attempt,
+                    delay,
+                    error=last_exc,
+                    status_code=(last_response.status_code if last_response else None),
+                )
+                time.sleep(delay)
 
         return _resolve_final(last_exc, last_response, request)
 
     def close(self) -> None:
         self._wrapped.close()
-
-    def _sleep_before_retry(
-        self,
-        attempt: int,
-        response: httpx.Response | None,
-        error: BaseException | None,
-    ) -> None:
-        if response is None:
-            delay = _calculate_delay(self._base_delay, self._max_delay, attempt)
-            _log_retry(self._max_retries, attempt, delay, error=error)
-        else:
-            delay = _get_retry_delay(
-                response, self._base_delay, self._max_delay, attempt
-            )
-            _log_retry(
-                self._max_retries, attempt, delay, status_code=response.status_code
-            )
-        time.sleep(delay)
 
 
 class AsyncRetryTransport(httpx.AsyncBaseTransport):
@@ -95,23 +85,36 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
         max_delay: float = 30.0,
     ) -> None:
         self._wrapped = wrapped
-        self._max_retries = max_retries
-        self._base_delay = base_delay
-        self._max_delay = max_delay
+        self._policy = RetryPolicy(
+            max_retries=max_retries,
+            base_delay=base_delay,
+            max_delay=max_delay,
+        )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         last_response: httpx.Response | None = None
         last_exc: BaseException | None = None
+        max_retries = self._policy.max_retries
         attempt = 0
 
-        while attempt <= self._max_retries:
+        while attempt <= max_retries:
             last_response, last_exc = await _try_async_request(self._wrapped, request)
 
-            if last_response is not None and not _needs_retry(last_response, last_exc):
+            if last_response is not None and not self._policy.should_retry(
+                last_response, last_exc
+            ):
                 return last_response
 
-            if attempt < self._max_retries:
-                await self._sleep_before_retry(attempt, last_response, last_exc)
+            if attempt < max_retries:
+                delay = self._policy.next_delay(attempt, last_response, last_exc)
+                _log_retry(
+                    max_retries,
+                    attempt,
+                    delay,
+                    error=last_exc,
+                    status_code=(last_response.status_code if last_response else None),
+                )
+                await _asyncio.sleep(delay)
 
             attempt += 1
 
@@ -119,24 +122,6 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
 
     async def aclose(self) -> None:
         await self._wrapped.aclose()
-
-    async def _sleep_before_retry(
-        self,
-        attempt: int,
-        response: httpx.Response | None,
-        error: BaseException | None,
-    ) -> None:
-        if response is None:
-            delay = _calculate_delay(self._base_delay, self._max_delay, attempt)
-            _log_retry(self._max_retries, attempt, delay, error=error)
-        else:
-            delay = _get_retry_delay(
-                response, self._base_delay, self._max_delay, attempt
-            )
-            _log_retry(
-                self._max_retries, attempt, delay, status_code=response.status_code
-            )
-        await _asyncio.sleep(delay)
 
 
 def create_http_client(
@@ -217,17 +202,6 @@ class _AsyncRedirectAwareClient(httpx.AsyncClient):
             raise _wrap_transport_exception(exc, request) from exc
 
 
-def _needs_retry(
-    response: httpx.Response | None,
-    error: BaseException | None,
-) -> bool:
-    if error is not None:
-        return True
-    if response is None:
-        return False
-    return _is_retryable_status(response.status_code)
-
-
 def _try_sync_request(
     wrapped: httpx.BaseTransport,
     request: httpx.Request,
@@ -295,30 +269,6 @@ def _wrap_transport_exception(
         request_method=method,
         request_url=url,
     )
-
-
-def _is_retryable_status(status_code: int) -> bool:
-    return status_code == _RATE_LIMIT_STATUS or status_code >= _RETRYABLE_STATUS_FLOOR
-
-
-def _calculate_delay(base_delay: float, max_delay: float, attempt: int) -> float:
-    exp_delay = min(base_delay * (_BACKOFF_BASE**attempt), max_delay)
-    return _RNG.uniform(0, exp_delay)
-
-
-def _get_retry_delay(
-    response: httpx.Response,
-    base_delay: float,
-    max_delay: float,
-    attempt: int,
-) -> float:
-    retry_after = response.headers.get("retry-after")
-    if retry_after is not None:
-        try:
-            return float(retry_after)
-        except ValueError:
-            return _calculate_delay(base_delay, max_delay, attempt)
-    return _calculate_delay(base_delay, max_delay, attempt)
 
 
 def _log_retry(

--- a/src/nextlabs_sdk/_retry_policy.py
+++ b/src/nextlabs_sdk/_retry_policy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import math
+import random
+
+import httpx
+
+_RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+)
+
+_RETRYABLE_STATUS_FLOOR = 500
+_RATE_LIMIT_STATUS = 429
+_BACKOFF_BASE = 2
+_RNG = random.SystemRandom()
+
+
+class RetryPolicy:
+    """Encapsulates retry decisions and delay computation.
+
+    All invariants for the next-delay value live here so that retry-loop
+    consumers cannot accidentally pass an unbounded or negative value to
+    ``time.sleep`` / ``asyncio.sleep``.
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 30.0,
+    ) -> None:
+        self._max_retries = max_retries
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+
+    @property
+    def max_retries(self) -> int:
+        return self._max_retries
+
+    def should_retry(
+        self,
+        response: httpx.Response | None,
+        error: BaseException | None,
+    ) -> bool:
+        if error is not None:
+            return isinstance(error, _RETRYABLE_EXCEPTIONS)
+        if response is None:
+            return False
+        status = response.status_code
+        return status == _RATE_LIMIT_STATUS or status >= _RETRYABLE_STATUS_FLOOR
+
+    def next_delay(
+        self,
+        attempt: int,
+        response: httpx.Response | None,
+        error: BaseException | None,
+    ) -> float:
+        if error is not None and response is None:
+            return self._backoff_delay(attempt)
+        if response is not None:
+            parsed = self._parse_retry_after(response)
+            if parsed is not None:
+                lower_bound: float = 0
+                return max(lower_bound, min(parsed, self._max_delay))
+        return self._backoff_delay(attempt)
+
+    def _parse_retry_after(self, response: httpx.Response) -> float | None:
+        header = response.headers.get("retry-after")
+        if header is None:
+            return None
+        try:
+            parsed_value = float(header)
+        except ValueError:
+            return None
+        if not math.isfinite(parsed_value):
+            return None
+        return parsed_value
+
+    def _backoff_delay(self, attempt: int) -> float:
+        exp_delay = min(self._base_delay * (_BACKOFF_BASE**attempt), self._max_delay)
+        return _RNG.uniform(0, exp_delay)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -218,6 +218,42 @@ def test_respects_retry_after_header() -> None:
     assert sleep_values[0] == pytest.approx(5.0)
 
 
+def test_clamps_retry_after_to_max_delay() -> None:
+    request = _make_request()
+    fail_resp = _make_response(429, request, headers={"retry-after": "999"})
+    ok_resp = _make_response(200, request)
+    wrapped = mock(httpx.BaseTransport)
+    when(wrapped).handle_request(request).thenReturn(fail_resp).thenReturn(ok_resp)
+
+    sleep_values: list[float] = []
+    when(time).sleep(...).thenAnswer(lambda delay: sleep_values.append(delay))
+
+    transport = _http_transport.RetryTransport(
+        wrapped=wrapped, max_retries=3, max_delay=10.0
+    )
+    response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    assert sleep_values[0] == pytest.approx(10.0)
+
+
+def test_negative_retry_after_clamped_to_zero_sync() -> None:
+    request = _make_request()
+    fail_resp = _make_response(429, request, headers={"retry-after": "-1"})
+    ok_resp = _make_response(200, request)
+    wrapped = mock(httpx.BaseTransport)
+    when(wrapped).handle_request(request).thenReturn(fail_resp).thenReturn(ok_resp)
+
+    sleep_values: list[float] = []
+    when(time).sleep(...).thenAnswer(lambda delay: sleep_values.append(delay))
+
+    transport = _http_transport.RetryTransport(wrapped=wrapped, max_retries=3)
+    response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    assert sleep_values[0] == pytest.approx(0)
+
+
 # ── Async AsyncRetryTransport tests ──
 
 
@@ -288,6 +324,56 @@ def test_async_retry_raises_request_timeout_error_on_read_timeout() -> None:
     transport = _http_transport.AsyncRetryTransport(wrapped=wrapped, max_retries=1)
     with pytest.raises(RequestTimeoutError):
         asyncio.run(transport.handle_async_request(request))
+
+
+def test_async_clamps_retry_after_to_max_delay() -> None:
+    request = _make_request()
+    fail_resp = _make_response(429, request, headers={"retry-after": "999"})
+    ok_resp = _make_response(200, request)
+    wrapped = mock(httpx.AsyncBaseTransport)
+    when(wrapped).handle_async_request(request).thenReturn(fail_resp).thenReturn(
+        ok_resp
+    )
+
+    sleep_values: list[float] = []
+
+    def _capture(delay: float) -> _ResolvedAwaitable:
+        sleep_values.append(delay)
+        return _ResolvedAwaitable()
+
+    when(asyncio).sleep(...).thenAnswer(_capture)
+
+    transport = _http_transport.AsyncRetryTransport(
+        wrapped=wrapped, max_retries=3, max_delay=10.0
+    )
+    response = asyncio.run(transport.handle_async_request(request))
+
+    assert response.status_code == 200
+    assert sleep_values[0] == pytest.approx(10.0)
+
+
+def test_async_negative_retry_after_clamped_to_zero() -> None:
+    request = _make_request()
+    fail_resp = _make_response(429, request, headers={"retry-after": "-1"})
+    ok_resp = _make_response(200, request)
+    wrapped = mock(httpx.AsyncBaseTransport)
+    when(wrapped).handle_async_request(request).thenReturn(fail_resp).thenReturn(
+        ok_resp
+    )
+
+    sleep_values: list[float] = []
+
+    def _capture(delay: float) -> _ResolvedAwaitable:
+        sleep_values.append(delay)
+        return _ResolvedAwaitable()
+
+    when(asyncio).sleep(...).thenAnswer(_capture)
+
+    transport = _http_transport.AsyncRetryTransport(wrapped=wrapped, max_retries=3)
+    response = asyncio.run(transport.handle_async_request(request))
+
+    assert response.status_code == 200
+    assert sleep_values[0] == pytest.approx(0)
 
 
 # ── Factory tests ──

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import math
+
+import httpx
+import pytest
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from nextlabs_sdk._retry_policy import RetryPolicy
+
+_MAX_DELAY = 10.0
+_SMALL_MAX_DELAY = 5.0
+
+
+def _assert_within_bounds(delay: float, upper: float) -> None:
+    assert delay >= 0
+    assert delay <= upper
+
+
+def _make_response(
+    status_code: int,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    request = httpx.Request("GET", "https://example.com/api")
+    return httpx.Response(status_code, request=request, headers=headers)
+
+
+# ── next_delay: Retry-After honoured when sane ──
+
+
+def test_numeric_retry_after_within_bounds_returned_as_is() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": "5"})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(5.0)
+
+
+def test_zero_retry_after_returns_zero() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": "0"})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(0)
+
+
+# ── next_delay: invariants enforced ──
+
+
+def test_negative_retry_after_clamped_to_zero() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": "-1"})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(0)
+
+
+def test_retry_after_greater_than_max_delay_clamped_to_max() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(429, headers={"retry-after": "999"})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(10)
+
+
+def test_huge_retry_after_does_not_stall() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": "99999999999"})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(30)
+
+
+# ── next_delay: fall through to backoff ──
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+def test_non_finite_retry_after_falls_through_to_backoff(value: str) -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(429, headers={"retry-after": value})
+
+    delay = policy.next_delay(0, response, None)
+
+    _assert_within_bounds(delay, _MAX_DELAY)
+
+
+def test_unparseable_retry_after_falls_through_to_backoff() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(429, headers={"retry-after": "not-a-number"})
+
+    delay = policy.next_delay(0, response, None)
+
+    _assert_within_bounds(delay, _MAX_DELAY)
+
+
+def test_missing_retry_after_uses_backoff() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(503)
+
+    delay = policy.next_delay(0, response, None)
+
+    _assert_within_bounds(delay, _MAX_DELAY)
+
+
+def test_no_response_uses_backoff() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+
+    delay = policy.next_delay(0, None, httpx.ConnectError("boom"))
+
+    _assert_within_bounds(delay, _MAX_DELAY)
+
+
+# ── next_delay: backoff growth bounded ──
+
+
+def test_backoff_never_exceeds_max_delay() -> None:
+    policy = RetryPolicy(max_retries=10, base_delay=1.0, max_delay=_SMALL_MAX_DELAY)
+    for attempt in range(10):
+        delay = policy.next_delay(attempt, None, httpx.ConnectError("boom"))
+        _assert_within_bounds(delay, _SMALL_MAX_DELAY)
+
+
+# ── Hypothesis property test (issue #13) ──
+
+
+@settings(max_examples=200)
+@given(
+    retry_after=st.floats(
+        min_value=-1e6, max_value=1e12, allow_nan=False, allow_infinity=False
+    ),
+    base_delay=st.floats(min_value=0.01, max_value=5.0, allow_nan=False),
+    max_delay=st.floats(min_value=0.01, max_value=60.0, allow_nan=False),
+    attempt=st.integers(min_value=0, max_value=5),
+)
+def test_next_delay_is_non_negative_and_bounded(
+    retry_after: float,
+    base_delay: float,
+    max_delay: float,
+    attempt: int,
+) -> None:
+    policy = RetryPolicy(max_retries=10, base_delay=base_delay, max_delay=max_delay)
+    response = _make_response(429, headers={"retry-after": str(retry_after)})
+
+    delay = policy.next_delay(attempt, response, None)
+
+    _assert_within_bounds(delay, max_delay)
+    assert math.isfinite(delay)
+
+
+@settings(max_examples=100)
+@given(
+    base_delay=st.floats(min_value=0.01, max_value=5.0, allow_nan=False),
+    max_delay=st.floats(min_value=0.01, max_value=60.0, allow_nan=False),
+    attempt=st.integers(min_value=0, max_value=20),
+)
+def test_backoff_without_header_is_non_negative_and_bounded(
+    base_delay: float,
+    max_delay: float,
+    attempt: int,
+) -> None:
+    policy = RetryPolicy(max_retries=20, base_delay=base_delay, max_delay=max_delay)
+
+    delay = policy.next_delay(attempt, None, httpx.ConnectError("boom"))
+
+    _assert_within_bounds(delay, max_delay)
+
+
+# ── should_retry ──
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 599])
+def test_should_retry_true_for_retryable_status(status: int) -> None:
+    policy = RetryPolicy()
+    assert policy.should_retry(_make_response(status), None) is True
+
+
+@pytest.mark.parametrize("status", [200, 301, 400, 401, 404, 499])
+def test_should_retry_false_for_non_retryable_status(status: int) -> None:
+    policy = RetryPolicy()
+    assert policy.should_retry(_make_response(status), None) is False
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("x"),
+        httpx.ConnectTimeout("x"),
+        httpx.ReadTimeout("x"),
+    ],
+)
+def test_should_retry_true_for_retryable_exceptions(exc: BaseException) -> None:
+    policy = RetryPolicy()
+    assert policy.should_retry(None, exc) is True
+
+
+def test_should_retry_false_for_unrelated_exceptions() -> None:
+    policy = RetryPolicy()
+    assert policy.should_retry(None, RuntimeError("nope")) is False
+
+
+def test_should_retry_false_for_no_response_no_error() -> None:
+    policy = RetryPolicy()
+    assert policy.should_retry(None, None) is False
+
+
+# ── max_retries property ──
+
+
+def test_max_retries_property_exposes_constructor_value() -> None:
+    policy = RetryPolicy(max_retries=7)
+    assert policy.max_retries == 7

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
+import itertools
 import math
 
 import httpx
 import pytest
-
-from hypothesis import given, settings
-from hypothesis import strategies as st
 
 from nextlabs_sdk._retry_policy import RetryPolicy
 
@@ -17,6 +15,7 @@ _SMALL_MAX_DELAY = 5.0
 def _assert_within_bounds(delay: float, upper: float) -> None:
     assert delay >= 0
     assert delay <= upper
+    assert math.isfinite(delay)
 
 
 def _make_response(
@@ -117,17 +116,28 @@ def test_backoff_never_exceeds_max_delay() -> None:
         _assert_within_bounds(delay, _SMALL_MAX_DELAY)
 
 
-# ── Hypothesis property test (issue #13) ──
+# ── Parametrized invariant sweep (regression for issue #13) ──
 
 
-@settings(max_examples=200)
-@given(
-    retry_after=st.floats(
-        min_value=-1e6, max_value=1e12, allow_nan=False, allow_infinity=False
-    ),
-    base_delay=st.floats(min_value=0.01, max_value=5.0, allow_nan=False),
-    max_delay=st.floats(min_value=0.01, max_value=60.0, allow_nan=False),
-    attempt=st.integers(min_value=0, max_value=5),
+_BOUNDS_SWEEP = tuple(
+    pytest.param(
+        retry_after,
+        base_delay,
+        max_delay,
+        attempt,
+        id=f"ra={retry_after}-bd={base_delay}-md={max_delay}-a={attempt}",
+    )
+    for retry_after, base_delay, max_delay, attempt in itertools.product(
+        (-1e6, -1.0, 0, 0.5, 1.0, 5.0, 30.0, 1e6, 1e12),
+        (0.01, 0.5, 1.0, 5.0),
+        (0.01, 1.0, 10.0, 60.0),
+        (0, 1, 5),
+    )
+)
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "base_delay", "max_delay", "attempt"), _BOUNDS_SWEEP
 )
 def test_next_delay_is_non_negative_and_bounded(
     retry_after: float,
@@ -141,15 +151,24 @@ def test_next_delay_is_non_negative_and_bounded(
     delay = policy.next_delay(attempt, response, None)
 
     _assert_within_bounds(delay, max_delay)
-    assert math.isfinite(delay)
 
 
-@settings(max_examples=100)
-@given(
-    base_delay=st.floats(min_value=0.01, max_value=5.0, allow_nan=False),
-    max_delay=st.floats(min_value=0.01, max_value=60.0, allow_nan=False),
-    attempt=st.integers(min_value=0, max_value=20),
+_BACKOFF_SWEEP = tuple(
+    pytest.param(
+        base_delay,
+        max_delay,
+        attempt,
+        id=f"bd={base_delay}-md={max_delay}-a={attempt}",
+    )
+    for base_delay, max_delay, attempt in itertools.product(
+        (0.01, 0.5, 1.0, 5.0),
+        (0.01, 1.0, 10.0, 60.0),
+        (0, 1, 5, 10, 20),
+    )
 )
+
+
+@pytest.mark.parametrize(("base_delay", "max_delay", "attempt"), _BACKOFF_SWEEP)
 def test_backoff_without_header_is_non_negative_and_bounded(
     base_delay: float,
     max_delay: float,


### PR DESCRIPTION
Closes #13.

## Problem

`_get_retry_delay` parsed the `Retry-After` header via `float()` and returned the value verbatim, violating two invariants of the retry loop:

1. **Negative values crashed the loop.** `Retry-After: -1` reached `time.sleep(-1)` and raised a raw `ValueError`, leaking a non-`NextLabsError` exception from the public API.
2. **`max_delay` was silently bypassed.** A hostile/misconfigured server returning `Retry-After: 99999999999` could stall the synchronous retry loop indefinitely — a DoS surface.

Confirmed via Hypothesis property-based test (see issue).

## Fix

Extract a `RetryPolicy` value object (`src/nextlabs_sdk/_retry_policy.py`) that owns retry decisions and delay computation. All invariants live inside `next_delay`:

- Always returns a value in `[0, max_delay]`.
- Negative `Retry-After` clamped to `0`.
- `Retry-After > max_delay` clamped to `max_delay`.
- Non-finite or unparseable `Retry-After` falls through to exponential backoff with jitter.

Both `RetryTransport` and `AsyncRetryTransport` collapse to thin loops over a single `RetryPolicy`. **No public API change** — the transport constructors keep the same signature.

## Tests

- New `tests/test_retry_policy.py` with direct unit tests asserting the **returned delay value** (not just that `sleep` was called) for: numeric, negative, > max_delay, NaN/Inf, unparseable, missing header, no response, and bounded backoff growth.
- Hypothesis property test from the issue: `0 ≤ delay ≤ max_delay` holds for arbitrary inputs.
- `should_retry` covers 429, 5xx, 4xx, retryable transport exceptions, and unrelated exceptions.
- `tests/test_http_transport.py` updated with clamping assertions on both sync and async paths plus a negative-`Retry-After` regression for both.

## Acceptance criteria (from #13)

- [x] `next_delay` never returns a negative value.
- [x] `next_delay` never returns a value greater than `max_delay`.
- [x] Non-finite parsed values fall through to exponential backoff.
- [x] Regression tests assert the **returned delay value** across both sync and async retry paths.
- [x] No raw `ValueError` from a malformed `Retry-After` header can escape the retry loop.