### PR TITLE
fix(cli): use cached refresh token before demanding password

### DIFF
--- a/src/nextlabs_sdk/_cli/_account_menu.py
+++ b/src/nextlabs_sdk/_cli/_account_menu.py
@@ -6,8 +6,8 @@ import click
 import typer
 
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
-
-_TOKEN_PATH_SUFFIX = "/cas/oidc/accessToken"
+from nextlabs_sdk._cli._cache_key import cache_key_for as cache_key_for
+from nextlabs_sdk._cli._cache_key import parse_cache_key as _parse_cache_key
 
 
 @dataclass(frozen=True)
@@ -21,26 +21,14 @@ class AccountIdentifier:
 
 def parse_cache_key(key: str) -> AccountIdentifier | None:
     """Parse a token-cache key into account identifiers, or ``None`` if malformed."""
-    parts = key.split("|")
-    if len(parts) != 3:
+    parsed = _parse_cache_key(key)
+    if parsed is None:
         return None
-    base_part, username, client_id = parts
-    if not base_part.endswith(_TOKEN_PATH_SUFFIX):
-        return None
-    base_url = base_part[: -len(_TOKEN_PATH_SUFFIX)]
-    if not (base_url and username and client_id):
-        return None
+    base_url, username, client_id = parsed
     return AccountIdentifier(
         base_url=base_url,
         username=username,
         client_id=client_id,
-    )
-
-
-def cache_key_for(account: AccountIdentifier) -> str:
-    return (
-        f"{account.base_url}{_TOKEN_PATH_SUFFIX}"
-        f"|{account.username}|{account.client_id}"
     )
 
 

--- a/src/nextlabs_sdk/_cli/_cache_key.py
+++ b/src/nextlabs_sdk/_cli/_cache_key.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+_TOKEN_PATH_SUFFIX = "/cas/oidc/accessToken"
+
+
+class _AccountKeyFields(Protocol):
+    @property
+    def base_url(self) -> str: ...
+    @property
+    def username(self) -> str: ...
+    @property
+    def client_id(self) -> str: ...
+
+
+def cache_key_for(account: _AccountKeyFields) -> str:
+    """Build the token-cache key for an account.
+
+    Single source of truth for the cache-key format. Accepts any object
+    exposing ``base_url``, ``username``, and ``client_id`` (e.g.
+    ``AccountIdentifier`` from ``_account_menu`` or ``ResolvedAccount``
+    from ``_account_resolver``) so callers don't have to convert between
+    structurally-equivalent dataclasses.
+    """
+    return (
+        f"{account.base_url}{_TOKEN_PATH_SUFFIX}"
+        f"|{account.username}|{account.client_id}"
+    )
+
+
+def parse_cache_key(key: str) -> tuple[str, str, str] | None:
+    """Parse a token-cache key into ``(base_url, username, client_id)``.
+
+    Returns ``None`` when the key does not match the expected format.
+    """
+    parts = key.split("|")
+    if len(parts) != 3:
+        return None
+    base_part, username, client_id = parts
+    if not base_part.endswith(_TOKEN_PATH_SUFFIX):
+        return None
+    base_url = base_part[: -len(_TOKEN_PATH_SUFFIX)]
+    if not (base_url and username and client_id):
+        return None
+    return base_url, username, client_id

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -16,6 +16,7 @@ from nextlabs_sdk._cli._account_resolver import (
     prefs_key_for,
     resolve_account,
 )
+from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._config import HttpConfig
@@ -26,13 +27,6 @@ _BASE_URL_REQUIRED = f"--base-url is required (or {_LOGIN_HINT})"
 _USERNAME_REQUIRED = f"--username is required (or {_LOGIN_HINT})"
 _PASSWORD_REQUIRED = f"--password or NEXTLABS_PASSWORD is required (or {_LOGIN_HINT})"
 _CLIENT_SECRET_REQUIRED = "--client-secret or NEXTLABS_CLIENT_SECRET is required"
-
-
-def _token_cache_key(account: ResolvedAccount) -> str:
-    return (
-        f"{account.base_url}/cas/oidc/accessToken"
-        f"|{account.username}|{account.client_id}"
-    )
 
 
 def _cached_credentials_usable(
@@ -47,7 +41,7 @@ def _cached_credentials_usable(
     and not known to be past its lifetime — in which case ``CloudAzAuth``
     can redeem it silently on the next request.
     """
-    entry = cache.load(_token_cache_key(account))
+    entry = cache.load(cache_key_for(account))
     if entry is None:
         return False
     effective_now = time.time() if now is None else now
@@ -128,7 +122,7 @@ def make_cloudaz_client(ctx: CliContext) -> CloudAzClient:
     account = _resolve_or_raise(ctx)
     cache = build_file_cache(ctx)
 
-    password = ctx.password
+    password = ctx.password or None
     if password is None and not _cached_credentials_usable(cache, account):
         password = _prompt_password_if_tty(account)
         if password is None:

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import sys
+import time
+
 import typer
 
+from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
 from nextlabs_sdk._auth._static_token_auth import StaticTokenAuth
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
@@ -24,16 +28,48 @@ _PASSWORD_REQUIRED = f"--password or NEXTLABS_PASSWORD is required (or {_LOGIN_H
 _CLIENT_SECRET_REQUIRED = "--client-secret or NEXTLABS_CLIENT_SECRET is required"
 
 
-def _has_valid_cached_token_for(
-    cache: FileTokenCache,
-    account: ResolvedAccount,
-) -> bool:
-    key = (
+def _token_cache_key(account: ResolvedAccount) -> str:
+    return (
         f"{account.base_url}/cas/oidc/accessToken"
         f"|{account.username}|{account.client_id}"
     )
-    entry = cache.load(key)
-    return entry is not None and not entry.is_expired()
+
+
+def _cached_credentials_usable(
+    cache: FileTokenCache,
+    account: ResolvedAccount,
+    *,
+    now: float | None = None,
+) -> bool:
+    """Return True when the cache holds a credential that avoids a password.
+
+    Either the access token is still fresh, or a refresh token is present
+    and not known to be past its lifetime — in which case ``CloudAzAuth``
+    can redeem it silently on the next request.
+    """
+    entry = cache.load(_token_cache_key(account))
+    if entry is None:
+        return False
+    effective_now = time.time() if now is None else now
+    if not entry.is_expired(now=effective_now):
+        return True
+    return (
+        decide(
+            refresh_token=entry.refresh_token,
+            refresh_expires_at=entry.refresh_expires_at,
+            now=effective_now,
+        )
+        is RefreshDecision.USE_REFRESH
+    )
+
+
+def _prompt_password_if_tty(account: ResolvedAccount) -> str | None:
+    if not sys.stdin.isatty():
+        return None
+    return typer.prompt(
+        f"Password for {account.username}@{account.base_url}",
+        hide_input=True,
+    )
 
 
 def _persisted_verify(
@@ -91,13 +127,17 @@ def make_cloudaz_client(ctx: CliContext) -> CloudAzClient:
 
     account = _resolve_or_raise(ctx)
     cache = build_file_cache(ctx)
-    if not ctx.password and not _has_valid_cached_token_for(cache, account):
-        raise typer.BadParameter(_PASSWORD_REQUIRED)
+
+    password = ctx.password
+    if password is None and not _cached_credentials_usable(cache, account):
+        password = _prompt_password_if_tty(account)
+        if password is None:
+            raise typer.BadParameter(_PASSWORD_REQUIRED)
 
     return CloudAzClient(
         base_url=account.base_url,
         username=account.username,
-        password=ctx.password,
+        password=password,
         client_id=account.client_id,
         http_config=_http_config(ctx, account),
         token_cache=cache,

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -6,9 +6,12 @@ from typing import cast
 import pytest
 import typer
 
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+from nextlabs_sdk._cli._account_resolver import ResolvedAccount
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cloudaz._client import CloudAzClient
@@ -187,3 +190,213 @@ def test_non_login_cli_flag_does_not_mutate_persisted_preference(
     entry = store.load("https://example.com|user|client")
     assert entry is not None
     assert entry.verify_ssl is False
+
+
+# ─── refresh-token-aware pre-flight gate + TTY prompt ──────────────────────
+
+
+_ACCOUNT = ResolvedAccount(
+    base_url="https://example.com",
+    username="user",
+    client_id="client",
+)
+_CACHE_KEY = "https://example.com/cas/oidc/accessToken|user|client"
+
+
+def _isatty_false() -> bool:
+    return False
+
+
+def _isatty_true() -> bool:
+    return True
+
+
+def _seed_token(
+    cache_dir: Path,
+    *,
+    expires_at: float,
+    refresh_token: str | None,
+    refresh_expires_at: float | None,
+) -> None:
+    cache = FileTokenCache(path=cache_dir / "tokens.json")
+    cache.save(
+        _CACHE_KEY,
+        CachedToken(
+            access_token="at",
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            token_type="bearer",
+            scope=None,
+            refresh_expires_at=refresh_expires_at,
+        ),
+    )
+
+
+def _capture_cloudaz_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> CloudAzClient:
+        captured.update(kwargs)
+        return cast(CloudAzClient, object())
+
+    monkeypatch.setattr(_client_factory, "CloudAzClient", _capture)
+    return captured
+
+
+def test_gate_accepts_cached_refresh_token_when_access_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_token(
+        tmp_path,
+        expires_at=0,
+        refresh_token="rt",
+        refresh_expires_at=10**12,
+    )
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] is None
+
+
+def test_gate_accepts_refresh_token_with_unknown_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_token(
+        tmp_path,
+        expires_at=0,
+        refresh_token="rt",
+        refresh_expires_at=None,
+    )
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] is None
+
+
+def test_gate_rejects_when_refresh_token_known_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_token(
+        tmp_path,
+        expires_at=0,
+        refresh_token="rt",
+        refresh_expires_at=0,
+    )
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    with pytest.raises(typer.BadParameter, match="password"):
+        _client_factory.make_cloudaz_client(ctx)
+
+
+def test_gate_rejects_when_no_refresh_token_and_access_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_token(
+        tmp_path,
+        expires_at=0,
+        refresh_token=None,
+        refresh_expires_at=None,
+    )
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    with pytest.raises(typer.BadParameter, match="password"):
+        _client_factory.make_cloudaz_client(ctx)
+
+
+def test_gate_rejects_when_no_cache_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    with pytest.raises(typer.BadParameter, match="password"):
+        _client_factory.make_cloudaz_client(ctx)
+
+
+def test_tty_prompt_supplies_password_when_cache_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+    prompts: list[tuple[str, bool]] = []
+
+    def _fake_prompt(text: str, *, hide_input: bool = False, **_: object) -> str:
+        prompts.append((text, hide_input))
+        return "typed-pw"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] == "typed-pw"
+    assert prompts and prompts[0][1] is True
+    assert "user@https://example.com" in prompts[0][0]
+
+
+def test_non_tty_raises_bad_parameter_when_cache_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    def _explode(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called in non-TTY mode")
+
+    monkeypatch.setattr(typer, "prompt", _explode)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    with pytest.raises(typer.BadParameter, match="password"):
+        _client_factory.make_cloudaz_client(ctx)
+
+
+def test_explicit_password_bypasses_cache_lookup_and_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+
+    def _explode_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called when --password is set")
+
+    def _explode_cache_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("cache must not be consulted when --password is set")
+
+    monkeypatch.setattr(typer, "prompt", _explode_prompt)
+    monkeypatch.setattr(FileTokenCache, "load", _explode_cache_load)
+
+    ctx = _make_ctx(password="explicit", cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] == "explicit"
+
+
+def test_fresh_access_token_proceeds_without_password(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_token(
+        tmp_path,
+        expires_at=10**12,
+        refresh_token=None,
+        refresh_expires_at=None,
+    )
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    def _explode_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called for fresh token")
+
+    monkeypatch.setattr(typer, "prompt", _explode_prompt)
+
+    ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] is None

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -12,6 +12,7 @@ from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._account_resolver import ResolvedAccount
+from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cloudaz._client import CloudAzClient
@@ -200,7 +201,7 @@ _ACCOUNT = ResolvedAccount(
     username="user",
     client_id="client",
 )
-_CACHE_KEY = "https://example.com/cas/oidc/accessToken|user|client"
+_CACHE_KEY = cache_key_for(_ACCOUNT)
 
 
 def _isatty_false() -> bool:
@@ -397,6 +398,41 @@ def test_fresh_access_token_proceeds_without_password(
     monkeypatch.setattr(typer, "prompt", _explode_prompt)
 
     ctx = _make_ctx(password=None, cache_dir=str(tmp_path))
+    _client_factory.make_cloudaz_client(ctx)
+
+    assert captured["password"] is None
+
+
+def test_empty_password_is_treated_as_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An empty --password / NEXTLABS_PASSWORD must not bypass the gate."""
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    def _explode_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called in non-TTY mode")
+
+    monkeypatch.setattr(typer, "prompt", _explode_prompt)
+
+    ctx = _make_ctx(password="", cache_dir=str(tmp_path))
+    with pytest.raises(typer.BadParameter, match="password"):
+        _client_factory.make_cloudaz_client(ctx)
+
+
+def test_empty_password_falls_back_to_cached_refresh_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Empty password must allow refresh-token fallback rather than bypassing."""
+    _seed_token(
+        tmp_path,
+        expires_at=0,
+        refresh_token="rt",
+        refresh_expires_at=10**12,
+    )
+    captured = _capture_cloudaz_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    ctx = _make_ctx(password="", cache_dir=str(tmp_path))
     _client_factory.make_cloudaz_client(ctx)
 
     assert captured["password"] is None


### PR DESCRIPTION
Closes #33

## Summary

The CloudAz CLI pre-flight gate in `make_cloudaz_client` previously checked only `CachedToken.is_expired()` (access-token-only) and short-circuited with `--password is required` the moment the access token expired — even when a perfectly usable refresh token was sitting next to it in the cache.

`CloudAzAuth` runtime was already capable of redeeming the refresh token silently; the gate never let it.

## Changes

- New `_cached_credentials_usable` predicate in `_client_factory.py` that accepts an entry when **either** the access token is fresh **or** `_refresh_token_policy.decide()` returns `USE_REFRESH` (refresh token present and not known-expired).
- When no usable credential is cached **and** no password was supplied:
  - **TTY**: interactive `typer.prompt(..., hide_input=True)` for the active account password.
  - **Non-TTY** (CI, pipes): preserve existing `BadParameter` so scripted invocations fail fast.
- 9 new unit tests in `tests/test_cli_client_factory.py` covering every gate branch + TTY/non-TTY paths + explicit-password bypass + fresh-token regression.

## Scope

- **CloudAz only.** PDP uses OAuth2 `client_credentials` and has no refresh-token concept.
- **No SDK changes.** `CloudAzAuth._handle_refresh_failure` already handles the runtime case where the server rejects the refresh; the gate just stops pre-empting it.

## Verification

- `python ./tools/checks.py` — black, flake8, mypy, pyright all green.
- `python ./tools/tests.py --short` — 1671 passed, 95.99% coverage.