### PR TITLE
fix(cli): show friendly error when CLI extras are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ pip install nextlabs-sdk            # library only
 pip install "nextlabs-sdk[cli]"     # + nextlabs CLI (Typer, Rich)
 ```
 
+If you install the library without the `[cli]` extra, the `nextlabs`
+command is still registered but will print a friendly error pointing at
+`pip install 'nextlabs-sdk[cli]'` and exit with status `1`.
+
 Requires Python **3.11+**.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ cli = [
 ]
 
 [project.scripts]
-nextlabs = "nextlabs_sdk._cli._app:app"
+nextlabs = "nextlabs_sdk._cli._entrypoint:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/nextlabs_sdk/_cli/_entrypoint.py
+++ b/src/nextlabs_sdk/_cli/_entrypoint.py
@@ -1,0 +1,42 @@
+"""Console-script entry point for the ``nextlabs`` CLI.
+
+This shim exists so ``pip install nextlabs-sdk`` (without the ``[cli]``
+extra) still gives a helpful error instead of a raw
+``ModuleNotFoundError`` when the user runs ``nextlabs``. It imports
+nothing from Typer/Rich at module load time and only delegates to the
+real Typer app once we know the optional dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from importlib import util as importlib_util
+
+_CLI_EXTRA_MODULES: tuple[str, ...] = ("typer", "rich")
+_INSTALL_HINT = "pip install 'nextlabs-sdk[cli]'"
+
+
+def _missing_cli_modules() -> list[str]:
+    return [
+        name for name in _CLI_EXTRA_MODULES if importlib_util.find_spec(name) is None
+    ]
+
+
+def _print_missing_deps_message(missing: list[str]) -> None:
+    joined = ", ".join(missing)
+    sys.stderr.write(
+        f"nextlabs CLI dependencies are not installed (missing: {joined}).\n"
+        f"Install them with:\n\n    {_INSTALL_HINT}\n",
+    )
+
+
+def main() -> None:
+    """Entry point registered as the ``nextlabs`` console script."""
+    missing = _missing_cli_modules()
+    if missing:
+        _print_missing_deps_message(missing)
+        sys.exit(1)
+
+    app_module = importlib.import_module("nextlabs_sdk._cli._app")
+    app_module.app()

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+from importlib import util as importlib_util
+
+import pytest
+from mockito import mock, verify, when
+
+from nextlabs_sdk._cli import _entrypoint
+
+
+def _stub_find_spec(typer_present: bool, rich_present: bool) -> None:
+    typer_spec = object() if typer_present else None
+    rich_spec = object() if rich_present else None
+    when(importlib_util).find_spec("typer").thenReturn(typer_spec)
+    when(importlib_util).find_spec("rich").thenReturn(rich_spec)
+
+
+@pytest.mark.parametrize(
+    "typer_present,rich_present,expected_missing",
+    [
+        pytest.param(False, True, "missing: typer", id="typer-missing"),
+        pytest.param(True, False, "missing: rich", id="rich-missing"),
+        pytest.param(False, False, "missing: typer, rich", id="both-missing"),
+    ],
+)
+def test_main_exits_when_deps_missing(
+    capsys: pytest.CaptureFixture[str],
+    typer_present: bool,
+    rich_present: bool,
+    expected_missing: str,
+):
+    _stub_find_spec(typer_present=typer_present, rich_present=rich_present)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _entrypoint.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert expected_missing in captured.err
+    assert "pip install 'nextlabs-sdk[cli]'" in captured.err
+
+
+def test_main_delegates_to_app_when_deps_present(
+    capsys: pytest.CaptureFixture[str],
+):
+    _stub_find_spec(typer_present=True, rich_present=True)
+
+    fake_app_module = mock()
+    when(fake_app_module).app().thenReturn(None)
+    when(importlib).import_module("nextlabs_sdk._cli._app").thenReturn(fake_app_module)
+
+    _entrypoint.main()
+
+    verify(fake_app_module, times=1).app()
+    captured = capsys.readouterr()
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

`pip install nextlabs-sdk` (without the `[cli]` extra) registers the `nextlabs` console script but not typer/rich, so running `nextlabs` crashed with a raw `ModuleNotFoundError: No module named 'typer'`.

## Fix

- New `src/nextlabs_sdk/_cli/_entrypoint.py` shim: imports nothing from Typer/Rich at module load. It uses `importlib.util.find_spec` to detect missing optional deps and prints a friendly message pointing at `pip install 'nextlabs-sdk[cli]'` before exiting with status 1.
- `pyproject.toml`: `[project.scripts]` `nextlabs` now points at `nextlabs_sdk._cli._entrypoint:main` instead of the Typer app directly.
- `tests/test_cli_entrypoint.py`: unit tests for typer missing, rich missing, both missing, and happy-path delegation (mockito).
- README: short note documenting the new behavior.

Spec: `docs/superpowers/specs/2026-04-20-cli-missing-deps-friendly-error-design.md`.