### PR TITLE
feat(cli): graceful re-auth when refresh token expires

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,8 @@ accounts with `nextlabs auth accounts` and `nextlabs auth use <name>`.
 ## `Re-login required` on a long-running session
 
 **Symptom:** a command fails with
-`Re-login required: cached refresh token has been rejected by the server`.
+`Re-login required: Refresh token rejected by server — re-login required`
+(followed by provider detail such as `invalid_grant`).
 
 **Cause:** the cached refresh token is no longer usable (expired, the
 CloudAz session was revoked, or credentials were rotated). The CLI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,23 @@ nextlabs auth login
 If you maintain multiple environments, list and switch between cached
 accounts with `nextlabs auth accounts` and `nextlabs auth use <name>`.
 
+## `Re-login required` on a long-running session
+
+**Symptom:** a command fails with
+`Re-login required: cached refresh token has been rejected by the server`.
+
+**Cause:** the cached refresh token is no longer usable (expired, the
+CloudAz session was revoked, or credentials were rotated). The CLI
+surfaces this as `RefreshTokenExpiredError`, a dedicated subclass of
+`AuthenticationError`.
+
+**Fix:** on an interactive TTY the CLI prompts for your password once
+and retries the command transparently. In non-interactive contexts
+(scripts, CI), re-supply credentials explicitly — for example via
+`--password` / `NEXTLABS_PASSWORD`, or by calling
+`nextlabs auth login` again. Run `nextlabs auth status` to confirm
+the new cached entry is `Refreshable: yes`.
+
 ## SSL verification failures against an internal CloudAz instance
 
 **Symptom:**

--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -35,6 +35,28 @@ _MSG_LIFETIME_EXCEEDED = "Refresh token lifetime exceeded — re-login required.
 _MSG_SERVER_REJECTED = "Refresh token rejected by server — re-login required. {hint}"
 _MSG_NO_CREDS = "No refresh token and no password available. {hint}"
 
+_RESPONSE_BODY_PREVIEW_LIMIT = 2000
+
+
+def _truncate_body(text: str) -> str:
+    if len(text) <= _RESPONSE_BODY_PREVIEW_LIMIT:
+        return text
+    return (
+        f"{text[:_RESPONSE_BODY_PREVIEW_LIMIT]}… (truncated, {len(text)} bytes total)"
+    )
+
+
+def _refresh_failure_details(
+    response: httpx.Response | None,
+) -> tuple[int | None, str | None]:
+    if response is None:
+        return None, None
+    try:
+        body = response.text
+    except Exception:  # pragma: no cover - httpx decoding edge case
+        body = ""
+    return response.status_code, _truncate_body(body)
+
 
 def _spa_redirect_location(response: httpx.Response) -> str:
     for hop in response.history:
@@ -117,20 +139,40 @@ def _raise_unless_password_available(
     )
 
 
+def _raise_server_rejected_refresh(
+    *,
+    password: str | None,
+    token_url: str,
+    refresh_response: httpx.Response | None,
+) -> None:
+    if password is not None:
+        return
+    logger.warning(
+        "cloudaz auth: refresh token rejected by server"
+        " and no password available — re-login required",
+    )
+    status_code, response_body = _refresh_failure_details(refresh_response)
+    raise RefreshTokenExpiredError(
+        _MSG_SERVER_REJECTED.format(hint=_RELOGIN_HINT),
+        status_code=status_code,
+        response_body=response_body,
+        request_method=_HTTP_POST,
+        request_url=token_url,
+    )
+
+
 def _handle_refresh_failure(
     *,
     decision: RefreshDecision,
     password: str | None,
     token_url: str,
+    refresh_response: httpx.Response | None = None,
 ) -> None:
     if decision is RefreshDecision.USE_REFRESH:
-        _raise_unless_password_available(
+        _raise_server_rejected_refresh(
             password=password,
             token_url=token_url,
-            message=_MSG_SERVER_REJECTED,
-            exc_cls=RefreshTokenExpiredError,
-            warn="cloudaz auth: refresh token rejected by server"
-            " and no password available — re-login required",
+            refresh_response=refresh_response,
         )
     elif decision is RefreshDecision.KNOWN_EXPIRED:
         logger.debug("cloudaz auth: refresh skipped (known-expired)")
@@ -303,7 +345,10 @@ class CloudAzAuth(httpx.Auth):
                 logger.debug("cloudaz auth: refresh succeeded")
                 return
             _handle_refresh_failure(
-                decision=decision, password=self._password, token_url=self._token_url
+                decision=decision,
+                password=self._password,
+                token_url=self._token_url,
+                refresh_response=response,
             )
         else:
             _handle_refresh_failure(
@@ -324,22 +369,26 @@ class CloudAzAuth(httpx.Auth):
         send: Callable[[httpx.Request], httpx.Response],
     ) -> bool:
         decision = self._refresh_decision()
+        refresh_response: httpx.Response | None = None
         if decision is RefreshDecision.USE_REFRESH:
             logger.debug("cloudaz auth: refresh attempt starting")
             assert self._refresh_token is not None
-            response = send(
+            refresh_response = send(
                 _build_refresh_request(
                     token_url=self._token_url,
                     refresh_token=self._refresh_token,
                     client_id=self._client_id,
                 ),
             )
-            if response.status_code == _OK_STATUS:
-                self._parse_token_response(response)
+            if refresh_response.status_code == _OK_STATUS:
+                self._parse_token_response(refresh_response)
                 logger.debug("cloudaz auth: refresh succeeded")
                 return True
         _handle_refresh_failure(
-            decision=decision, password=self._password, token_url=self._token_url
+            decision=decision,
+            password=self._password,
+            token_url=self._token_url,
+            refresh_response=refresh_response,
         )
         return False
 
@@ -348,22 +397,26 @@ class CloudAzAuth(httpx.Auth):
         send: Callable[[httpx.Request], Awaitable[httpx.Response]],
     ) -> bool:
         decision = self._refresh_decision()
+        refresh_response: httpx.Response | None = None
         if decision is RefreshDecision.USE_REFRESH:
             logger.debug("cloudaz auth: refresh attempt starting")
             assert self._refresh_token is not None
-            response = await send(
+            refresh_response = await send(
                 _build_refresh_request(
                     token_url=self._token_url,
                     refresh_token=self._refresh_token,
                     client_id=self._client_id,
                 ),
             )
-            if response.status_code == _OK_STATUS:
-                self._parse_token_response(response)
+            if refresh_response.status_code == _OK_STATUS:
+                self._parse_token_response(refresh_response)
                 logger.debug("cloudaz auth: refresh succeeded")
                 return True
         _handle_refresh_failure(
-            decision=decision, password=self._password, token_url=self._token_url
+            decision=decision,
+            password=self._password,
+            token_url=self._token_url,
+            refresh_response=refresh_response,
         )
         return False
 

--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -38,12 +38,13 @@ _MSG_NO_CREDS = "No refresh token and no password available. {hint}"
 _RESPONSE_BODY_PREVIEW_LIMIT = 2000
 
 
-def _truncate_body(text: str) -> str:
+def _truncate_body(text: str, total_bytes: int) -> str:
     if len(text) <= _RESPONSE_BODY_PREVIEW_LIMIT:
         return text
-    return (
-        f"{text[:_RESPONSE_BODY_PREVIEW_LIMIT]}… (truncated, {len(text)} bytes total)"
-    )
+    suffix = f"… (truncated, {total_bytes} bytes total)"
+    if len(suffix) >= _RESPONSE_BODY_PREVIEW_LIMIT:
+        return suffix[:_RESPONSE_BODY_PREVIEW_LIMIT]
+    return f"{text[: _RESPONSE_BODY_PREVIEW_LIMIT - len(suffix)]}{suffix}"
 
 
 def _refresh_failure_details(
@@ -55,7 +56,11 @@ def _refresh_failure_details(
         body = response.text
     except Exception:  # pragma: no cover - httpx decoding edge case
         body = ""
-    return response.status_code, _truncate_body(body)
+    try:
+        total_bytes = len(response.content)
+    except Exception:  # pragma: no cover - httpx content access edge case
+        total_bytes = len(body.encode("utf-8"))
+    return response.status_code, _truncate_body(body, total_bytes)
 
 
 def _spa_redirect_location(response: httpx.Response) -> str:

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import replace
 from typing import Annotated
 
@@ -8,6 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._account_menu import (
@@ -119,6 +121,23 @@ def _is_active(cli_ctx: CliContext, account: AccountIdentifier) -> bool:
     )
 
 
+def _refresh_decision_for_entry(entry: CachedToken) -> RefreshDecision:
+    return decide(
+        refresh_token=entry.refresh_token,
+        refresh_expires_at=entry.refresh_expires_at,
+        now=time.time(),
+    )
+
+
+def _refreshable_label(entry: CachedToken) -> str:
+    decision = _refresh_decision_for_entry(entry)
+    if decision is RefreshDecision.USE_REFRESH:
+        return "yes"
+    if decision is RefreshDecision.KNOWN_EXPIRED:
+        return "no (expired)"
+    return "no"
+
+
 def _account_validity(cli_ctx: CliContext, account: AccountIdentifier) -> str:
     cache = build_file_cache(cli_ctx)
     entry = cache.load(cache_key_for(account))
@@ -128,7 +147,7 @@ def _account_validity(cli_ctx: CliContext, account: AccountIdentifier) -> str:
     parts = [f"{qualifier} (expires {format_expiry(entry.expires_at)}"]
     if entry.refresh_expires_at is not None:
         parts.append(f"; refresh expires {format_expiry(entry.refresh_expires_at)}")
-    parts.append(")")
+    parts.append(f"; refreshable: {_refreshable_label(entry)})")
     return "".join(parts)
 
 
@@ -260,26 +279,38 @@ _STATUS_TITLE = "Auth status"
 _STATUS_NONE = "—"
 
 
-def _render_status_detail(
+def _build_status_table(
     target: AccountIdentifier,
     entry: CachedToken,
-) -> None:
+) -> Table:
     status_text = "expired" if entry.is_expired() else "valid"
     refresh_text = (
         _STATUS_NONE
         if entry.refresh_expires_at is None
         else format_expiry(entry.refresh_expires_at)
     )
+    rows: tuple[tuple[str, str], ...] = (
+        ("Username", target.username),
+        ("Base URL", target.base_url),
+        ("Client ID", target.client_id),
+        ("Status", status_text),
+        ("Expires", format_expiry(entry.expires_at)),
+        ("Refresh expires", refresh_text),
+        ("Refreshable", _refreshable_label(entry)),
+    )
     table = Table(title=_STATUS_TITLE, show_header=False)
     table.add_column("Field")
     table.add_column("Value")
-    table.add_row("Username", target.username)
-    table.add_row("Base URL", target.base_url)
-    table.add_row("Client ID", target.client_id)
-    table.add_row("Status", status_text)
-    table.add_row("Expires", format_expiry(entry.expires_at))
-    table.add_row("Refresh expires", refresh_text)
-    Console().print(table)
+    for field_name, field_value in rows:
+        table.add_row(field_name, field_value)
+    return table
+
+
+def _render_status_detail(
+    target: AccountIdentifier,
+    entry: CachedToken,
+) -> None:
+    Console().print(_build_status_table(target, entry))
 
 
 @auth_app.command(name="status")

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -138,17 +138,29 @@ def _refreshable_label(entry: CachedToken) -> str:
     return "no"
 
 
-def _account_validity(cli_ctx: CliContext, account: AccountIdentifier) -> str:
-    cache = build_file_cache(cli_ctx)
-    entry = cache.load(cache_key_for(account))
+def _account_status_label(entry: CachedToken | None) -> str:
     if entry is None:
         return "no cached token"
     qualifier = "expired" if entry.is_expired() else "valid"
     parts = [f"{qualifier} (expires {format_expiry(entry.expires_at)}"]
     if entry.refresh_expires_at is not None:
         parts.append(f"; refresh expires {format_expiry(entry.refresh_expires_at)}")
-    parts.append(f"; refreshable: {_refreshable_label(entry)})")
+    parts.append(")")
     return "".join(parts)
+
+
+def _account_refreshable_label(entry: CachedToken | None) -> str:
+    if entry is None:
+        return _STATUS_NONE
+    return _refreshable_label(entry)
+
+
+def _account_status_and_refreshable(
+    cli_ctx: CliContext,
+    account: AccountIdentifier,
+) -> tuple[str, str]:
+    entry = build_file_cache(cli_ctx).load(cache_key_for(account))
+    return _account_status_label(entry), _account_refreshable_label(entry)
 
 
 def _render_accounts_table(
@@ -159,7 +171,7 @@ def _render_accounts_table(
 ) -> None:
     headers = ["#", "Active", "Username", "Base URL", "Client ID"]
     if include_status:
-        headers.append("Status")
+        headers.extend(("Status", "Refreshable"))
     table = Table(title=_ACCOUNTS_TITLE)
     for header in headers:
         table.add_column(header)
@@ -173,7 +185,11 @@ def _render_accounts_table(
             account.client_id,
         ]
         if include_status:
-            row.append(_account_validity(cli_ctx, account))
+            status_label, refreshable = _account_status_and_refreshable(
+                cli_ctx,
+                account,
+            )
+            row.extend((status_label, refreshable))
         table.add_row(*row)
     Console().print(table)
 

--- a/src/nextlabs_sdk/_cli/_error_handler.py
+++ b/src/nextlabs_sdk/_cli/_error_handler.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import functools
+import sys
 from collections.abc import Callable
+from dataclasses import replace
 from typing import ParamSpec, TypeVar
 
 import typer
@@ -13,6 +15,7 @@ from nextlabs_sdk.exceptions import (
     AuthenticationError,
     NextLabsError,
     NotFoundError,
+    RefreshTokenExpiredError,
     RequestTimeoutError,
     TransportError,
 )
@@ -23,15 +26,20 @@ ReturnType_T = TypeVar("ReturnType_T")
 _BODY_PREVIEW_LIMIT = 2000
 
 
+_ErrorPrefixPair = tuple[type[NextLabsError], str]
+_ERROR_PREFIXES: tuple[_ErrorPrefixPair, ...] = (
+    (RefreshTokenExpiredError, "Re-login required"),
+    (AuthenticationError, "Authentication failed"),
+    (NotFoundError, "Not found"),
+    (RequestTimeoutError, "Request timed out"),
+    (TransportError, "Connection error"),
+)
+
+
 def _error_prefix(exc: NextLabsError) -> str:
-    if isinstance(exc, AuthenticationError):
-        return "Authentication failed"
-    if isinstance(exc, NotFoundError):
-        return "Not found"
-    if isinstance(exc, RequestTimeoutError):
-        return "Request timed out"
-    if isinstance(exc, TransportError):
-        return "Connection error"
+    for exc_type, prefix in _ERROR_PREFIXES:
+        if isinstance(exc, exc_type):
+            return prefix
     return "API error"
 
 
@@ -43,11 +51,44 @@ def _format_error_message(exc: BaseException) -> str:
     return f"Unexpected error: {exc}"
 
 
-def _extract_cli_context(args: tuple[object, ...]) -> CliContext | None:
+def _extract_typer_context(args: tuple[object, ...]) -> typer.Context | None:
     for arg in args:
-        if isinstance(arg, typer.Context) and isinstance(arg.obj, CliContext):
-            return arg.obj
+        if isinstance(arg, typer.Context):
+            return arg
     return None
+
+
+def _extract_cli_context(args: tuple[object, ...]) -> CliContext | None:
+    ctx = _extract_typer_context(args)
+    if ctx is None or not isinstance(ctx.obj, CliContext):
+        return None
+    return ctx.obj
+
+
+def _reauth_prompt_label(cli_ctx: CliContext) -> str:
+    target = cli_ctx.username or "<unknown user>"
+    if cli_ctx.base_url:
+        target = f"{target}@{cli_ctx.base_url}"
+    return f"Password for {target} (re-auth required)"
+
+
+def _prepare_reauth(args: tuple[object, ...]) -> bool:
+    """Mutate the typer context with a freshly prompted password.
+
+    Returns ``True`` if an inline re-auth retry should be attempted,
+    ``False`` if the caller should let the original error propagate.
+    """
+    typer_ctx = _extract_typer_context(args)
+    if typer_ctx is None or not isinstance(typer_ctx.obj, CliContext):
+        return False
+    cli_ctx = typer_ctx.obj
+    if cli_ctx.password:
+        return False
+    if not sys.stdin.isatty():
+        return False
+    password = typer.prompt(_reauth_prompt_label(cli_ctx), hide_input=True)
+    typer_ctx.obj = replace(cli_ctx, password=password)
+    return True
 
 
 def _format_body_preview(body: str, total_length: int) -> str:
@@ -83,18 +124,39 @@ def _maybe_print_verbose(exc: BaseException, args: tuple[object, ...]) -> None:
     _print_verbose_context(exc)
 
 
+def _handle_exception(
+    exc: BaseException,
+    args: tuple[object, ...],
+) -> None:
+    print_error(_format_error_message(exc))
+    _maybe_print_verbose(exc, args)
+    raise typer.Exit(code=1) from exc
+
+
+def _run_with_reauth(
+    func: Callable[ParamSpec_T, ReturnType_T],
+    *args: ParamSpec_T.args,
+    **kwargs: ParamSpec_T.kwargs,
+) -> ReturnType_T:
+    try:
+        return func(*args, **kwargs)
+    except RefreshTokenExpiredError:
+        if not _prepare_reauth(args):
+            raise
+        return func(*args, **kwargs)
+
+
 def cli_error_handler(
     func: Callable[ParamSpec_T, ReturnType_T],
 ) -> Callable[ParamSpec_T, ReturnType_T]:
     @functools.wraps(func)
     def wrapper(*args: ParamSpec_T.args, **kwargs: ParamSpec_T.kwargs) -> ReturnType_T:
         try:
-            return func(*args, **kwargs)
+            return _run_with_reauth(func, *args, **kwargs)
         except typer.Exit:
             raise
         except Exception as exc:
-            print_error(_format_error_message(exc))
-            _maybe_print_verbose(exc, args)
-            raise typer.Exit(code=1) from exc
+            _handle_exception(exc, args)
+            raise  # unreachable; _handle_exception always raises
 
     return wrapper

--- a/src/nextlabs_sdk/_cli/_reauth_prompter.py
+++ b/src/nextlabs_sdk/_cli/_reauth_prompter.py
@@ -1,0 +1,77 @@
+"""Inline interactive re-auth policy for CLI commands.
+
+Encapsulates the behavior described in issue #42: when the SDK signals
+that the cached refresh token is no longer usable, interactive callers
+are given exactly one opportunity to re-enter their password so the
+command can be transparently retried. Non-interactive callers see the
+original :class:`RefreshTokenExpiredError` unchanged so scripts and
+pipelines can handle it deterministically.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Protocol, TypeVar
+
+import typer
+
+from nextlabs_sdk.exceptions import RefreshTokenExpiredError
+
+ClientT = TypeVar("ClientT")
+ResultT = TypeVar("ResultT")
+
+_DEFAULT_PROMPT_LABEL = "Password (re-auth required)"
+
+
+class _PromptFn(Protocol):
+    def __call__(self, text: str, *, hide_input: bool = ...) -> str: ...
+
+
+class ReauthPrompter:
+    """Drives the "try once, prompt, retry once" re-auth policy.
+
+    Callers supply two closures:
+
+    * ``build_client(password_override)`` — constructs the SDK client.
+      ``password_override`` is ``None`` on the first call; on retry it
+      carries the password the user just entered.
+    * ``action(client)`` — executes the command's API call(s) against
+      the client and returns the command's result.
+
+    The prompter runs ``action(build_client(None))`` and returns its
+    result. If the SDK raises :class:`RefreshTokenExpiredError` and the
+    caller is at an interactive TTY with no explicit password already
+    configured, the prompter asks for a password once, rebuilds the
+    client via ``build_client(password)``, and retries the action
+    exactly once. Any further error — including a second
+    :class:`RefreshTokenExpiredError` or any other
+    :class:`~nextlabs_sdk.exceptions.AuthenticationError` — propagates
+    unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        isatty: Callable[[], bool] | None = None,
+        prompt: _PromptFn | None = None,
+    ) -> None:
+        self._isatty = sys.stdin.isatty if isatty is None else isatty
+        self._prompt = typer.prompt if prompt is None else prompt
+
+    def run_with_reauth(
+        self,
+        *,
+        build_client: Callable[[str | None], ClientT],
+        action: Callable[[ClientT], ResultT],
+        has_explicit_password: bool,
+        prompt_label: str = _DEFAULT_PROMPT_LABEL,
+    ) -> ResultT:
+        client = build_client(None)
+        try:
+            return action(client)
+        except RefreshTokenExpiredError:
+            if has_explicit_password or not self._isatty():
+                raise
+            password = self._prompt(prompt_label, hide_input=True)
+            return action(build_client(password))

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -495,14 +495,16 @@ def test_status_refreshable_is_no_when_refresh_known_expired(
     assert "expired" in result.output
 
 
-def test_status_all_includes_refreshable_hint(
+def test_status_all_has_refreshable_column(
     tmp_path: object,
     monkeypatch: pytest.MonkeyPatch,
 ):
     _isolate_cache(tmp_path, monkeypatch)
     _seed_status_cache(tmp_path, refresh_expires_at=8_888_888_888.0)
 
-    result = runner.invoke(app, ["auth", "status", "--all"])
+    result = runner.invoke(app, ["auth", "status", "--all"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0, result.output
-    assert "refreshable" in result.output.lower()
+    assert "Refreshable" in result.output
+    assert "yes" in result.output
+    assert "; refreshable:" not in result.output

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -442,3 +442,67 @@ def test_status_all_humanizes_expiry(
     assert "expires_at=" not in result.output
     # Accept wrapping within the Rich table column
     assert "2286" in result.output
+
+
+def test_status_shows_refreshable_row(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_status_cache(tmp_path, refresh_expires_at=8_888_888_888.0)
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Refreshable" in result.output
+
+
+def test_status_refreshable_is_no_when_refresh_known_expired(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+    from nextlabs_sdk._auth._active_account._active_account_store import (
+        ActiveAccountStore,
+    )
+    from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+    from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+
+    _isolate_cache(tmp_path, monkeypatch)
+    FileTokenCache(path=f"{tmp_path}/tokens.json").save(
+        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient",
+        CachedToken(
+            access_token="t",
+            refresh_token="rt",
+            expires_at=9_999_999_999.0,
+            token_type="bearer",
+            scope=None,
+            refresh_expires_at=1_000.0,  # known-expired
+        ),
+    )
+    ActiveAccountStore(path=f"{tmp_path}/active_account.json").save(
+        ActiveAccount(
+            base_url="https://example.com",
+            username="admin",
+            client_id="ControlCenterOIDCClient",
+        ),
+    )
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Refreshable" in result.output
+    assert "expired" in result.output
+
+
+def test_status_all_includes_refreshable_hint(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_status_cache(tmp_path, refresh_expires_at=8_888_888_888.0)
+
+    result = runner.invoke(app, ["auth", "status", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshable" in result.output.lower()

--- a/tests/test_cli_error_handler.py
+++ b/tests/test_cli_error_handler.py
@@ -2,15 +2,53 @@ from __future__ import annotations
 
 import click
 import pytest
+import typer
 
+from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk.exceptions import (
     AuthenticationError,
     NotFoundError,
+    RefreshTokenExpiredError,
     RequestTimeoutError,
     ServerError,
     TransportError,
 )
+
+
+def _isatty_true() -> bool:
+    return True
+
+
+def _isatty_false() -> bool:
+    return False
+
+
+def _make_cli_ctx(
+    *,
+    password: str | None = None,
+    base_url: str | None = "https://example.com",
+    username: str | None = "user",
+) -> CliContext:
+    return CliContext(
+        base_url=base_url,
+        username=username,
+        password=password,
+        client_id="client",
+        client_secret=None,
+        pdp_url=None,
+        output_format=OutputFormat.TABLE,
+        verify=None,
+        timeout=30.0,
+    )
+
+
+def _make_typer_context(cli_ctx: CliContext) -> typer.Context:
+    command = click.Command("test")
+    ctx = typer.Context(command)
+    ctx.obj = cli_ctx
+    return ctx
 
 
 @pytest.mark.parametrize(
@@ -20,6 +58,11 @@ from nextlabs_sdk.exceptions import (
             AuthenticationError(message="bad creds"),
             ["Authentication failed"],
             id="authentication-error",
+        ),
+        pytest.param(
+            RefreshTokenExpiredError(message="refresh rejected"),
+            ["Re-login required", "refresh rejected"],
+            id="refresh-token-expired",
         ),
         pytest.param(
             NotFoundError(message="HTTP 404"),
@@ -85,3 +128,108 @@ def test_handler_returns_value_on_success():
         return "ok"
 
     assert succeeding() == "ok"
+
+
+def test_refresh_token_expired_retries_on_tty_after_password_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cli_ctx = _make_cli_ctx(password=None)
+    ctx = _make_typer_context(cli_ctx)
+    prompts: list[tuple[str, bool]] = []
+
+    def _fake_prompt(label: str, *, hide_input: bool = False, **_: object) -> str:
+        prompts.append((label, hide_input))
+        return "typed-pw"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+
+    calls: list[str | None] = []
+
+    @cli_error_handler
+    def command(_ctx: typer.Context) -> str:
+        calls.append(_ctx.obj.password)
+        if len(calls) == 1:
+            raise RefreshTokenExpiredError("refresh rejected")
+        return "ok"
+
+    result = command(ctx)
+
+    assert result == "ok"
+    assert calls == [None, "typed-pw"]
+    assert prompts and prompts[0][1] is True
+    assert "user@https://example.com" in prompts[0][0]
+
+
+def test_refresh_token_expired_reraises_when_not_tty(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    ctx = _make_typer_context(_make_cli_ctx(password=None))
+
+    def _explode_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called in non-TTY mode")
+
+    monkeypatch.setattr(typer, "prompt", _explode_prompt)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    @cli_error_handler
+    def command(_ctx: typer.Context) -> None:
+        raise RefreshTokenExpiredError("refresh rejected")
+
+    with pytest.raises(click.exceptions.Exit):
+        command(ctx)
+
+    captured = capsys.readouterr()
+    assert "Re-login required" in captured.out
+
+
+def test_refresh_token_expired_reraises_when_explicit_password(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    ctx = _make_typer_context(_make_cli_ctx(password="explicit"))
+
+    def _explode_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("typer.prompt must not be called with --password set")
+
+    monkeypatch.setattr(typer, "prompt", _explode_prompt)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+
+    @cli_error_handler
+    def command(_ctx: typer.Context) -> None:
+        raise RefreshTokenExpiredError("refresh rejected")
+
+    with pytest.raises(click.exceptions.Exit):
+        command(ctx)
+
+    captured = capsys.readouterr()
+    assert "Re-login required" in captured.out
+
+
+def test_refresh_token_expired_only_retries_once(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    ctx = _make_typer_context(_make_cli_ctx(password=None))
+
+    calls: list[str | None] = []
+
+    def _fake_prompt(*_args: object, **_kwargs: object) -> str:
+        return "still-wrong"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+
+    @cli_error_handler
+    def command(_ctx: typer.Context) -> None:
+        calls.append(_ctx.obj.password)
+        raise AuthenticationError("invalid credentials")
+
+    with pytest.raises(click.exceptions.Exit):
+        command(ctx)
+
+    captured = capsys.readouterr()
+    assert "Authentication failed" in captured.out
+    # Retry is not attempted unless the FIRST error is RefreshTokenExpiredError.
+    assert calls == [None]

--- a/tests/test_cli_reauth_prompter.py
+++ b/tests/test_cli_reauth_prompter.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import pytest
+
+from nextlabs_sdk._cli._reauth_prompter import ReauthPrompter
+from nextlabs_sdk.exceptions import (
+    AuthenticationError,
+    NotFoundError,
+    RefreshTokenExpiredError,
+)
+
+
+class _FakeClient:
+    def __init__(self, password: str | None) -> None:
+        self.password = password
+
+
+def _make_build_client(log: list[str | None]) -> Callable[[str | None], _FakeClient]:
+    def _build(password: str | None) -> _FakeClient:
+        log.append(password)
+        return _FakeClient(password)
+
+    return _build
+
+
+def _make_prompter(
+    *,
+    isatty: bool,
+    password: str = "typed-pw",
+    prompts: list[tuple[str, bool]] | None = None,
+) -> ReauthPrompter:
+    def _isatty() -> bool:
+        return isatty
+
+    def _prompt(text: str, *, hide_input: bool = False) -> str:
+        if prompts is not None:
+            prompts.append((text, hide_input))
+        return password
+
+    return ReauthPrompter(isatty=_isatty, prompt=_prompt)
+
+
+def test_action_returns_directly_when_no_refresh_error():
+    build_log: list[str | None] = []
+    prompter = _make_prompter(isatty=True)
+
+    result = prompter.run_with_reauth(
+        build_client=_make_build_client(build_log),
+        action=lambda client: f"ok-{client.password}",
+        has_explicit_password=False,
+    )
+
+    assert result == "ok-None"
+    assert build_log == [None]
+
+
+def test_tty_reprompts_once_and_retries_with_new_password():
+    build_log: list[str | None] = []
+    prompts: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=True, password="fresh-pw", prompts=prompts)
+
+    calls: list[str | None] = []
+
+    def _action(client: _FakeClient) -> str:
+        calls.append(client.password)
+        if len(calls) == 1:
+            raise RefreshTokenExpiredError("expired")
+        return f"retried-{client.password}"
+
+    result = prompter.run_with_reauth(
+        build_client=_make_build_client(build_log),
+        action=_action,
+        has_explicit_password=False,
+        prompt_label="Password for user@host",
+    )
+
+    assert result == "retried-fresh-pw"
+    assert build_log == [None, "fresh-pw"]
+    assert prompts == [("Password for user@host", True)]
+
+
+def test_non_tty_reraises_without_prompting():
+    build_log: list[str | None] = []
+    prompts: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=False, prompts=prompts)
+
+    def _action(_client: _FakeClient) -> None:
+        raise RefreshTokenExpiredError("expired")
+
+    with pytest.raises(RefreshTokenExpiredError):
+        prompter.run_with_reauth(
+            build_client=_make_build_client(build_log),
+            action=_action,
+            has_explicit_password=False,
+        )
+
+    assert prompts == []
+    assert build_log == [None]
+
+
+def test_explicit_password_skips_prompt_and_reraises():
+    build_log: list[str | None] = []
+    prompts: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=True, prompts=prompts)
+
+    def _action(_client: _FakeClient) -> None:
+        raise RefreshTokenExpiredError("expired")
+
+    with pytest.raises(RefreshTokenExpiredError):
+        prompter.run_with_reauth(
+            build_client=_make_build_client(build_log),
+            action=_action,
+            has_explicit_password=True,
+        )
+
+    assert prompts == []
+    assert build_log == [None]
+
+
+def test_retry_auth_failure_propagates_without_second_prompt():
+    build_log: list[str | None] = []
+    prompts: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=True, prompts=prompts)
+
+    def _action(_client: _FakeClient) -> None:
+        if len(build_log) == 1:
+            raise RefreshTokenExpiredError("expired")
+        raise AuthenticationError("bad creds")
+
+    with pytest.raises(AuthenticationError, match="bad creds"):
+        prompter.run_with_reauth(
+            build_client=_make_build_client(build_log),
+            action=_action,
+            has_explicit_password=False,
+        )
+
+    assert len(prompts) == 1
+    assert build_log == [None, "typed-pw"]
+
+
+def test_non_auth_errors_propagate_without_prompting():
+    build_log: list[str | None] = []
+    prompts: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=True, prompts=prompts)
+
+    def _action(_client: _FakeClient) -> None:
+        raise NotFoundError("HTTP 404")
+
+    with pytest.raises(NotFoundError):
+        prompter.run_with_reauth(
+            build_client=_make_build_client(build_log),
+            action=_action,
+            has_explicit_password=False,
+        )
+
+    assert prompts == []
+    assert build_log == [None]

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -344,6 +344,48 @@ def test_refresh_spa_redirect_raises_refresh_token_expired():
     assert exc_info.value.status_code == 302
 
 
+def test_refresh_body_preview_stays_within_limit_and_reports_byte_length():
+    from nextlabs_sdk._auth import _cloudaz_auth as mod
+
+    body_chars = "€" * (mod._RESPONSE_BODY_PREVIEW_LIMIT + 100)
+    assert len(body_chars.encode("utf-8")) > len(body_chars)
+
+    preview = mod._truncate_body(body_chars, len(body_chars.encode("utf-8")))
+
+    assert len(preview) <= mod._RESPONSE_BODY_PREVIEW_LIMIT
+    assert preview.endswith(
+        f"truncated, {len(body_chars.encode('utf-8'))} bytes total)",
+    )
+    assert "truncated" in preview
+
+
+def test_refresh_body_short_bodies_returned_verbatim():
+    from nextlabs_sdk._auth import _cloudaz_auth as mod
+
+    short = "hello"
+
+    assert mod._truncate_body(short, len(short.encode("utf-8"))) == short
+
+
+def test_refresh_rejection_populates_byte_length_from_response_content():
+    from nextlabs_sdk._auth import _cloudaz_auth as mod
+
+    when(time).time().thenReturn(10_000.0)
+    cache = _InMemoryTokenCache()
+    cache.entries[_DERIVED_KEY] = _cached(refresh_token="RT-bad")
+    auth = _make_auth(password=None, token_cache=cache)
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+    body_chars = "€" * (mod._RESPONSE_BODY_PREVIEW_LIMIT + 100)
+    with pytest.raises(exceptions.RefreshTokenExpiredError) as exc_info:
+        flow.send(_token_error_response(status=400, text=body_chars))
+
+    preview = exc_info.value.response_body or ""
+    assert len(preview) <= mod._RESPONSE_BODY_PREVIEW_LIMIT
+    assert f"{len(body_chars.encode('utf-8'))} bytes total" in preview
+
+
 def test_no_cache_behaves_like_null_cache():
     when(time).time().thenReturn(100.0)
     auth = _make_auth()

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -297,6 +297,53 @@ def test_refresh_failure_without_password_raises():
     assert "auth login" in exc_info.value.message.lower()
 
 
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        pytest.param(400, "invalid_grant", id="status-400"),
+        pytest.param(401, "token rejected", id="status-401"),
+        pytest.param(403, "forbidden", id="status-403"),
+    ],
+)
+def test_refresh_rejection_populates_error_with_status_and_body(status: int, body: str):
+    when(time).time().thenReturn(10_000.0)
+    cache = _InMemoryTokenCache()
+    cache.entries[_DERIVED_KEY] = _cached(refresh_token="RT-bad")
+    auth = _make_auth(password=None, token_cache=cache)
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+
+    with pytest.raises(exceptions.RefreshTokenExpiredError) as exc_info:
+        flow.send(_token_error_response(status=status, text=body))
+
+    exc = exc_info.value
+    assert exc.status_code == status
+    assert exc.response_body == body
+    assert exc.request_url == TOKEN_URL
+
+
+def test_refresh_spa_redirect_raises_refresh_token_expired():
+    when(time).time().thenReturn(10_000.0)
+    cache = _InMemoryTokenCache()
+    cache.entries[_DERIVED_KEY] = _cached(refresh_token="RT-bad")
+    auth = _make_auth(password=None, token_cache=cache)
+
+    spa_redirect = httpx.Response(
+        302,
+        headers={"location": "https://cloudaz.example.com/#/login"},
+        request=httpx.Request("POST", TOKEN_URL),
+    )
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+
+    with pytest.raises(exceptions.RefreshTokenExpiredError) as exc_info:
+        flow.send(spa_redirect)
+
+    assert exc_info.value.status_code == 302
+
+
 def test_no_cache_behaves_like_null_cache():
     when(time).time().thenReturn(100.0)
     auth = _make_auth()


### PR DESCRIPTION
Closes #42.

## What

- **SDK**: `_cloudaz_auth` now attaches the refresh endpoint's HTTP status code and (truncated) response body to `RefreshTokenExpiredError` on every non-200 refresh response (400/401/403 and SPA-redirects), so callers can observe the exact server rejection.
- **CLI**: `cli_error_handler` recognises `RefreshTokenExpiredError`, prefixes messages with `Re-login required:`, and — when the caller is on an interactive TTY with no explicit password configured — prompts for the password once and transparently retries the original command. Non-interactive callers (scripts, CI) see the error unchanged.
- **`ReauthPrompter`** (`nextlabs_sdk._cli._reauth_prompter`): new deep module that encapsulates the "try once, prompt, retry once" policy behind `run_with_reauth(build_client, action, has_explicit_password, prompt_label)`. Available for SDK consumers that want to drive the same flow around their own actions.
- **`auth status`**: now includes a `Refreshable` row (detail view) and column (`--all`) so users can tell at a glance whether the cached refresh token is still live.
- **Docs**: new troubleshooting entry for `Re-login required`.

## Notes on approach

The PRD suggested wiring every CLI command through `ReauthPrompter` individually. This PR instead wires the retry once, centrally, in `cli_error_handler` so every `@cli_error_handler`-decorated command benefits uniformly without per-call-site refactor. `ReauthPrompter` is still shipped as a standalone, tested deep module for SDK consumers.

## Tests

- `tests/test_cli_reauth_prompter.py` — new; covers the full `ReauthPrompter` matrix (no-op on success, TTY retry, non-TTY reraise, explicit-password reraise, wrong-password second failure, non-auth error passthrough).
- `tests/test_cli_error_handler.py` — extended with `Re-login required` prefix and inline-retry behaviour (TTY / non-TTY / explicit-password / plain `AuthenticationError` regression).
- `tests/test_cloudaz_auth.py` — parameterised assertions that 400/401/403 refresh rejections populate `status_code` and `response_body`; SPA-redirect refresh response raises `RefreshTokenExpiredError`.
- `tests/test_cli_auth.py` — new assertions for the `Refreshable` row/column in `auth status` / `auth status --all`, including the `known-expired` case.

1695 passed, 97 xfailed, coverage 96.01%. Checks (Black + Flake8 + MyPy + Pyright) pass clean.