### PR TITLE
fix(cloudaz): surface envelope message on non-2xx HTTP responses

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 
-from nextlabs_sdk._envelope import envelope_from_response
+from nextlabs_sdk._envelope import envelope_from_mapping
 from nextlabs_sdk._json_response import decode_json, decode_json_object, require_key
 from nextlabs_sdk.exceptions import ApiError, raise_for_status
 
@@ -27,7 +27,7 @@ def _check_envelope_status(body: dict[str, object], response: httpx.Response) ->
     If the envelope has no statusCode field at all, this returns silently
     to preserve legacy behavior for endpoints that do not use the envelope.
     """
-    raw_code, envelope_message = envelope_from_response(response)
+    raw_code, envelope_message = envelope_from_mapping(body)
     if raw_code is None:
         return
     if raw_code.startswith("1"):

--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import httpx
 
+from nextlabs_sdk._envelope import envelope_from_response
 from nextlabs_sdk._json_response import decode_json, decode_json_object, require_key
 from nextlabs_sdk.exceptions import ApiError, raise_for_status
 
@@ -26,16 +27,13 @@ def _check_envelope_status(body: dict[str, object], response: httpx.Response) ->
     If the envelope has no statusCode field at all, this returns silently
     to preserve legacy behavior for endpoints that do not use the envelope.
     """
-    raw_code = body.get("statusCode")
-    if not isinstance(raw_code, str):
+    raw_code, envelope_message = envelope_from_response(response)
+    if raw_code is None:
         return
     if raw_code.startswith("1"):
         return
 
-    raw_message = body.get("message")
-    envelope_message = raw_message if isinstance(raw_message, str) else None
     message = envelope_message or f"CloudAz error (statusCode={raw_code})"
-
     request_method, request_url = _request_context(response)
 
     raise ApiError(

--- a/src/nextlabs_sdk/_envelope.py
+++ b/src/nextlabs_sdk/_envelope.py
@@ -20,28 +20,24 @@ designed for use from both the success parsers in
 
 from __future__ import annotations
 
+from typing import Mapping
+
 import httpx
 
 
-def envelope_from_response(
-    response: httpx.Response,
+def envelope_from_mapping(
+    body: object,
 ) -> tuple[str | None, str | None]:
-    """Return ``(status_code, message)`` from a CloudAz envelope body.
+    """Return ``(status_code, message)`` from an already-decoded envelope body.
 
-    Both fields are taken verbatim from the response JSON when present
-    as strings. Returns ``(None, None)`` when the body is not JSON, not
-    a JSON object, is missing ``statusCode``, or when ``statusCode`` is
-    not a string. Returns ``(status_code, None)`` when ``statusCode``
-    is a string but ``message`` is missing or not a string.
+    Accepts any object. Returns ``(None, None)`` when ``body`` is not a
+    mapping, is missing ``statusCode``, or when ``statusCode`` is not a
+    string. Returns ``(status_code, None)`` when ``statusCode`` is a
+    string but ``message`` is missing, not a string, or an empty string.
 
-    Never raises; safe to call on any ``httpx.Response``.
+    Never raises.
     """
-    try:
-        body = response.json()
-    except ValueError:
-        return None, None
-
-    if not isinstance(body, dict):
+    if not isinstance(body, Mapping):
         return None, None
 
     raw_code = body.get("statusCode")
@@ -51,3 +47,25 @@ def envelope_from_response(
     raw_message = body.get("message")
     message = raw_message if isinstance(raw_message, str) and raw_message else None
     return raw_code, message
+
+
+def envelope_from_response(
+    response: httpx.Response,
+) -> tuple[str | None, str | None]:
+    """Return ``(status_code, message)`` from a CloudAz envelope response.
+
+    Both fields are taken verbatim from the response JSON when present
+    as strings. Returns ``(None, None)`` when the body is not JSON, not
+    a JSON object, is missing ``statusCode``, or when ``statusCode`` is
+    not a string. Returns ``(status_code, None)`` when ``statusCode``
+    is a string but ``message`` is missing, not a string, or an empty
+    string.
+
+    Never raises; safe to call on any ``httpx.Response``.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return None, None
+
+    return envelope_from_mapping(body)

--- a/src/nextlabs_sdk/_envelope.py
+++ b/src/nextlabs_sdk/_envelope.py
@@ -1,0 +1,53 @@
+"""Tolerant extractor for the CloudAz response envelope.
+
+The CloudAz Console API wraps most responses in a JSON envelope:
+
+    {"statusCode": "<code>", "message": "<text>", "data": <payload>}
+
+Both success and error conditions are signalled by the envelope — codes
+with a leading ``1`` indicate success; any other code indicates an
+error. The server sometimes returns the same envelope shape even with
+non-2xx HTTP statuses (e.g. HTTP 400 with ``{"statusCode": "6000", ...}``
+for internal errors), and consumers need the envelope message to
+diagnose the problem.
+
+This module exposes a single helper that pulls ``(statusCode, message)``
+from a response without raising on malformed input — the helper is
+designed for use from both the success parsers in
+``_cloudaz/_response.py`` and the HTTP-status error path in
+``exceptions.raise_for_status``.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def envelope_from_response(
+    response: httpx.Response,
+) -> tuple[str | None, str | None]:
+    """Return ``(status_code, message)`` from a CloudAz envelope body.
+
+    Both fields are taken verbatim from the response JSON when present
+    as strings. Returns ``(None, None)`` when the body is not JSON, not
+    a JSON object, is missing ``statusCode``, or when ``statusCode`` is
+    not a string. Returns ``(status_code, None)`` when ``statusCode``
+    is a string but ``message`` is missing or not a string.
+
+    Never raises; safe to call on any ``httpx.Response``.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return None, None
+
+    if not isinstance(body, dict):
+        return None, None
+
+    raw_code = body.get("statusCode")
+    if not isinstance(raw_code, str):
+        return None, None
+
+    raw_message = body.get("message")
+    message = raw_message if isinstance(raw_message, str) and raw_message else None
+    return raw_code, message

--- a/src/nextlabs_sdk/exceptions.py
+++ b/src/nextlabs_sdk/exceptions.py
@@ -4,6 +4,8 @@ from types import MappingProxyType
 
 import httpx
 
+from nextlabs_sdk._envelope import envelope_from_response
+
 _CLIENT_ERROR_THRESHOLD = 400
 _SERVER_ERROR_THRESHOLD = 500
 
@@ -104,29 +106,22 @@ def raise_for_status(response: httpx.Response) -> None:
     request_method = response.request.method
     request_url = str(response.request.url)
 
+    envelope_status_code, envelope_message = envelope_from_response(response)
+    message = envelope_message or f"HTTP {status_code}"
+
     error_class = _STATUS_CODE_MAP.get(status_code)
-    if error_class is not None:
-        raise error_class(
-            message=f"HTTP {status_code}",
-            status_code=status_code,
-            response_body=response_body,
-            request_method=request_method,
-            request_url=request_url,
-        )
+    if error_class is None:
+        if status_code >= _SERVER_ERROR_THRESHOLD:
+            error_class = ServerError
+        else:
+            error_class = ApiError
 
-    if status_code >= _SERVER_ERROR_THRESHOLD:
-        raise ServerError(
-            message=f"HTTP {status_code}",
-            status_code=status_code,
-            response_body=response_body,
-            request_method=request_method,
-            request_url=request_url,
-        )
-
-    raise ApiError(
-        message=f"HTTP {status_code}",
+    raise error_class(
+        message=message,
         status_code=status_code,
         response_body=response_body,
         request_method=request_method,
         request_url=request_url,
+        envelope_status_code=envelope_status_code,
+        envelope_message=envelope_message,
     )

--- a/tests/test_cli_error_handler_verbose.py
+++ b/tests/test_cli_error_handler_verbose.py
@@ -8,7 +8,7 @@ from strip_ansi import strip_ansi
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cli._error_handler import cli_error_handler
-from nextlabs_sdk.exceptions import ApiError, AuthenticationError
+from nextlabs_sdk.exceptions import ApiError, AuthenticationError, ValidationError
 
 
 def _ctx(verbose: int) -> typer.Context:
@@ -125,3 +125,30 @@ def test_verbose_zero_hides_envelope_status_code(
 
     captured = capsys.readouterr()
     assert "envelope:" not in captured.err
+
+
+def test_http_400_with_envelope_surfaces_server_message(
+    capsys: pytest.CaptureFixture[str],
+):
+    _run_failing(
+        ValidationError(
+            message="An internal server error occurred.",
+            status_code=400,
+            response_body=(
+                '{"statusCode":"6000","message":"An internal server error occurred."}'
+            ),
+            request_method="GET",
+            request_url="https://srv/console/api/v1/policy/mgmt/1",
+            envelope_status_code="6000",
+            envelope_message="An internal server error occurred.",
+        ),
+        verbose=1,
+    )
+
+    captured = capsys.readouterr()
+    stdout = strip_ansi(captured.out)
+    stderr = strip_ansi(captured.err)
+    assert "API error: An internal server error occurred." in stdout
+    assert "HTTP 400" not in stdout
+    assert "statusCode=6000" in stderr
+    assert "400" in stderr

--- a/tests/test_cloudaz_response.py
+++ b/tests/test_cloudaz_response.py
@@ -290,3 +290,99 @@ def test_parse_raw_ignores_envelope_error_statusCode():
         "statusCode": "5000",
         "message": "No data found",
     }
+
+
+_ALL_PARSERS = (
+    pytest.param(parse_data, id="parse_data"),
+    pytest.param(parse_paginated, id="parse_paginated"),
+    pytest.param(parse_reporter_paginated, id="parse_reporter_paginated"),
+    pytest.param(parse_raw, id="parse_raw"),
+)
+
+
+@pytest.mark.parametrize("parser", _ALL_PARSERS)
+def test_http_error_with_envelope_surfaces_server_message(
+    parser: Callable[[httpx.Response], object],
+):
+    response = httpx.Response(
+        400,
+        json={
+            "statusCode": "6000",
+            "message": "An internal server error occurred.",
+        },
+        request=_make_request(),
+    )
+    from nextlabs_sdk.exceptions import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        parser(response)
+    assert exc_info.value.message == "An internal server error occurred."
+    assert exc_info.value.envelope_status_code == "6000"
+    assert exc_info.value.envelope_message == "An internal server error occurred."
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("parser", _ALL_PARSERS)
+def test_http_error_without_envelope_preserves_legacy_message(
+    parser: Callable[[httpx.Response], object],
+):
+    response = httpx.Response(
+        400,
+        json={"foo": "bar"},
+        request=_make_request(),
+    )
+    from nextlabs_sdk.exceptions import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        parser(response)
+    assert exc_info.value.message == "HTTP 400"
+    assert exc_info.value.envelope_status_code is None
+    assert exc_info.value.envelope_message is None
+
+
+@pytest.mark.parametrize("parser", _ALL_PARSERS)
+def test_http_500_with_non_json_body_preserves_legacy_message(
+    parser: Callable[[httpx.Response], object],
+):
+    response = httpx.Response(
+        500,
+        content=b"<html>boom</html>",
+        request=_make_request(),
+    )
+    with pytest.raises(ServerError) as exc_info:
+        parser(response)
+    assert exc_info.value.message == "HTTP 500"
+    assert exc_info.value.envelope_status_code is None
+
+
+@pytest.mark.parametrize("parser", _ALL_PARSERS)
+def test_http_404_with_envelope_uses_not_found_error(
+    parser: Callable[[httpx.Response], object],
+):
+    response = httpx.Response(
+        404,
+        json={"statusCode": "5000", "message": "No data found"},
+        request=_make_request(),
+    )
+    with pytest.raises(NotFoundError) as exc_info:
+        parser(response)
+    assert exc_info.value.message == "No data found"
+    assert exc_info.value.envelope_status_code == "5000"
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.parametrize("parser", _ALL_PARSERS)
+def test_http_error_prefers_envelope_message_even_for_success_statuscode(
+    parser: Callable[[httpx.Response], object],
+):
+    response = httpx.Response(
+        400,
+        json={"statusCode": "1003", "message": "odd but surfaced"},
+        request=_make_request(),
+    )
+    from nextlabs_sdk.exceptions import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        parser(response)
+    assert exc_info.value.message == "odd but surfaced"
+    assert exc_info.value.envelope_status_code == "1003"

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from nextlabs_sdk._envelope import envelope_from_response
+from nextlabs_sdk._envelope import envelope_from_mapping, envelope_from_response
 
 
 def _response(body: object | str | None, *, status: int = 200) -> httpx.Response:
@@ -63,3 +63,29 @@ def test_returns_none_when_body_is_empty():
 def test_success_and_error_codes_pass_through_unchanged(code: str):
     response = _response({"statusCode": code, "message": "m"}, status=200)
     assert envelope_from_response(response) == (code, "m")
+
+
+class TestEnvelopeFromMapping:
+    def test_extracts_statuscode_and_message(self):
+        assert envelope_from_mapping({"statusCode": "6000", "message": "boom"}) == (
+            "6000",
+            "boom",
+        )
+
+    def test_returns_none_none_for_non_mapping(self):
+        assert envelope_from_mapping(["statusCode", "6000"]) == (None, None)
+        assert envelope_from_mapping("statusCode=6000") == (None, None)
+        assert envelope_from_mapping(None) == (None, None)
+        assert envelope_from_mapping(42) == (None, None)
+
+    def test_empty_string_message_normalized_to_none(self):
+        assert envelope_from_mapping({"statusCode": "5000", "message": ""}) == (
+            "5000",
+            None,
+        )
+
+    def test_non_string_statuscode_rejected(self):
+        assert envelope_from_mapping({"statusCode": 1003, "message": "m"}) == (
+            None,
+            None,
+        )

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from nextlabs_sdk._envelope import envelope_from_response
+
+
+def _response(body: object | str | None, *, status: int = 200) -> httpx.Response:
+    if isinstance(body, str):
+        return httpx.Response(status, text=body)
+    if body is None:
+        return httpx.Response(status)
+    return httpx.Response(status, json=body)
+
+
+def test_returns_statuscode_and_message_for_envelope():
+    response = _response({"statusCode": "6000", "message": "boom"}, status=400)
+    assert envelope_from_response(response) == ("6000", "boom")
+
+
+def test_returns_only_statuscode_when_message_missing():
+    response = _response({"statusCode": "5000"}, status=200)
+    assert envelope_from_response(response) == ("5000", None)
+
+
+def test_returns_only_statuscode_when_message_empty_string():
+    response = _response({"statusCode": "5000", "message": ""}, status=200)
+    assert envelope_from_response(response) == ("5000", None)
+
+
+def test_returns_only_statuscode_when_message_not_string():
+    response = _response({"statusCode": "5000", "message": 123}, status=200)
+    assert envelope_from_response(response) == ("5000", None)
+
+
+def test_returns_none_when_statuscode_missing():
+    response = _response({"message": "no statusCode here"}, status=200)
+    assert envelope_from_response(response) == (None, None)
+
+
+def test_returns_none_when_statuscode_not_string():
+    response = _response({"statusCode": 1003, "message": "ok"}, status=200)
+    assert envelope_from_response(response) == (None, None)
+
+
+def test_returns_none_when_body_is_not_object():
+    response = _response(["statusCode", "6000"], status=400)
+    assert envelope_from_response(response) == (None, None)
+
+
+def test_returns_none_when_body_is_malformed_json():
+    response = _response("<html>not json</html>", status=500)
+    assert envelope_from_response(response) == (None, None)
+
+
+def test_returns_none_when_body_is_empty():
+    response = _response("", status=500)
+    assert envelope_from_response(response) == (None, None)
+
+
+@pytest.mark.parametrize("code", ["1003", "5000", "6000"])
+def test_success_and_error_codes_pass_through_unchanged(code: str):
+    response = _response({"statusCode": code, "message": "m"}, status=200)
+    assert envelope_from_response(response) == (code, "m")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -144,3 +146,91 @@ def test_raise_for_status_400_populates_context():
     assert exc_info.value.response_body == "bad request"
     assert exc_info.value.request_method == "POST"
     assert exc_info.value.request_url == "https://example.com/api"
+
+
+def _envelope_response(
+    status: int,
+    payload: object,
+    *,
+    method: str = "GET",
+    url: str = "https://example.com",
+) -> httpx.Response:
+    return _response(status, text=json.dumps(payload), method=method, url=url)
+
+
+def test_raise_for_status_uses_envelope_message_when_present():
+    response = _envelope_response(
+        400,
+        {"statusCode": "6000", "message": "An internal server error occurred."},
+    )
+    with pytest.raises(exceptions.ValidationError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "An internal server error occurred."
+    assert exc_info.value.envelope_status_code == "6000"
+    assert exc_info.value.envelope_message == "An internal server error occurred."
+    assert exc_info.value.status_code == 400
+
+
+def test_raise_for_status_without_envelope_keeps_http_message():
+    response = _envelope_response(400, {"foo": "bar"})
+    with pytest.raises(exceptions.ValidationError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "HTTP 400"
+    assert exc_info.value.envelope_status_code is None
+    assert exc_info.value.envelope_message is None
+
+
+def test_raise_for_status_ignores_non_json_body():
+    response = _response(500, text="<html>internal error</html>")
+    with pytest.raises(exceptions.ServerError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "HTTP 500"
+    assert exc_info.value.envelope_status_code is None
+
+
+def test_raise_for_status_ignores_non_dict_json_body():
+    response = _response(400, text=json.dumps(["statusCode", "6000"]))
+    with pytest.raises(exceptions.ValidationError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "HTTP 400"
+    assert exc_info.value.envelope_status_code is None
+
+
+def test_raise_for_status_ignores_malformed_json_body():
+    response = _response(500, text="{not-json")
+    with pytest.raises(exceptions.ServerError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "HTTP 500"
+    assert exc_info.value.envelope_status_code is None
+
+
+def test_raise_for_status_populates_statuscode_even_without_message():
+    response = _envelope_response(400, {"statusCode": "6000"})
+    with pytest.raises(exceptions.ValidationError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "HTTP 400"
+    assert exc_info.value.envelope_status_code == "6000"
+    assert exc_info.value.envelope_message is None
+
+
+def test_raise_for_status_envelope_on_404_uses_not_found_error():
+    response = _envelope_response(
+        404,
+        {"statusCode": "5000", "message": "No data found"},
+    )
+    with pytest.raises(exceptions.NotFoundError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "No data found"
+    assert exc_info.value.envelope_status_code == "5000"
+
+
+def test_raise_for_status_prefers_envelope_message_even_if_statuscode_looks_successful():
+    response = _envelope_response(
+        400,
+        {"statusCode": "1003", "message": "odd but surfaced"},
+    )
+    with pytest.raises(exceptions.ValidationError) as exc_info:
+        exceptions.raise_for_status(response)
+    assert exc_info.value.message == "odd but surfaced"
+    assert exc_info.value.envelope_status_code == "1003"
+    assert exc_info.value.envelope_message == "odd but surfaced"


### PR DESCRIPTION
Closes #45

## Problem

On a non-2xx HTTP status carrying a NextLabs response envelope, `raise_for_status` fired before the body was inspected, so the envelope's `message` was discarded. Users saw a bare `HTTP 400` instead of the actual server-side message.

```
← 400  body: {"statusCode": "6000", "message": "An internal server error occurred..."}
✗ API error: HTTP 400
```

## Fix

- New `src/nextlabs_sdk/_envelope.py` — tolerant `envelope_from_response()` helper (never raises; returns `(None, None)` for non-JSON / non-dict / missing fields).
- `exceptions.raise_for_status` now uses the envelope `message` as the exception's primary message and populates `envelope_status_code` / `envelope_message`.
- `_cloudaz._response._check_envelope_status` refactored to reuse the same helper.
- Exception class selection (`ValidationError`, `NotFoundError`, `ServerError`, ...) remains driven by HTTP status — no breaking changes for callers catching specific subclasses.

## Result

```
✗ API error: An internal server error occurred. Please refer to the log file for more details.
```
Under `-v`: `envelope: statusCode=6000` is now visible in the verbose context.

## Tests

- `tests/test_envelope.py` — 12 new helper tests (all tolerance paths).
- `tests/test_exceptions.py` — 8 new tests (envelope surfacing, fallback, non-JSON, non-dict, malformed JSON, missing message, 404 + envelope, success-prefix statusCode on non-2xx).
- `tests/test_cloudaz_response.py` — 5 parametrized tests across all four `parse_*` helpers.
- `tests/test_cli_error_handler_verbose.py` — end-to-end CLI verbose assertion.

## Verification

- `python ./tools/tests.py --short` → 1739 passed, 96.04% coverage.
- `python ./tools/checks.py` → black, flake8, mypy, pyright clean.