### PR TITLE
chore(lint): clean up 6 setup.cfg suppressions (#47)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,15 +74,18 @@ per-file-ignores =
   src/nextlabs_sdk/_cloudaz/_search.py: WPS214
   # Component service: 10 API endpoints require many methods
   src/nextlabs_sdk/_cloudaz/_components.py: WPS214
-  # Policy service: 19 management endpoints require many methods + parse_data calls
-  src/nextlabs_sdk/_cloudaz/_policies.py: WPS214, WPS204, WPS110
+  # Policy service: 19 management endpoints require many methods; parse_data(response)
+  # reused in most of them (WPS204).
+  src/nextlabs_sdk/_cloudaz/_policies.py: WPS214, WPS204
   # Component search service: search + saved-search + list-names endpoints
-  src/nextlabs_sdk/_cloudaz/_component_search.py: WPS214, WPS204
+  src/nextlabs_sdk/_cloudaz/_component_search.py: WPS214
   # Policy search service: search + saved-search + list-names endpoints
-  src/nextlabs_sdk/_cloudaz/_policy_search.py: WPS214, WPS204
-  # Report service: 17 API endpoints + 3 pagination callbacks require many methods
-  src/nextlabs_sdk/_cloudaz/_reports.py: WPS214, WPS204, WPS110, WPS211, WPS226, WPS235
-  # Dashboard service: 5 endpoints × 2 classes (sync + async) = 10 parse_data calls
+  src/nextlabs_sdk/_cloudaz/_policy_search.py: WPS214
+  # Report service: 17 API endpoints + 3 pagination callbacks require many methods;
+  # parse_data(response) reused across endpoints (WPS204).
+  src/nextlabs_sdk/_cloudaz/_reports.py: WPS214, WPS211, WPS235, WPS204
+  # Dashboard service: 5 endpoints × 2 classes (sync + async) = 10 endpoint methods;
+  # parse_data(response) reused in every endpoint (WPS204).
   src/nextlabs_sdk/_cloudaz/_dashboard.py: WPS214, WPS204
   # Client classes: delegate to many services (properties for 6 service pairs);
   # ctor accepts both token_cache + auth injection (pluggable auth/cache feature).
@@ -94,7 +97,7 @@ per-file-ignores =
 
   # CLI app callback: typer requires all global options as individual parameters,
   # and typer.Option(...) as default values is the standard typer API pattern
-  src/nextlabs_sdk/_cli/_app.py: WPS211, WPS404, WPS432
+  src/nextlabs_sdk/_cli/_app.py: WPS211, WPS404
   # CLI component types: search command has 6 typer Option parameters (standard API pattern)
   src/nextlabs_sdk/_cli/_component_types_cmd.py: WPS211
   # CLI components: search command has 7 typer Option parameters (standard API pattern)

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -19,6 +19,8 @@ from nextlabs_sdk._cli._reporter_audit_logs_cmd import reporter_audit_logs_app
 from nextlabs_sdk._cli._system_config_cmd import system_config_app
 from nextlabs_sdk._cli._tags_cmd import tags_app
 
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+
 app = typer.Typer(
     name="nextlabs",
     help="NextLabs CloudAz SDK CLI",
@@ -93,7 +95,7 @@ def main(
         ),
     ),
     timeout: float = typer.Option(
-        30.0,
+        _DEFAULT_TIMEOUT_SECONDS,
         help="Request timeout in seconds",
     ),
     token: str | None = typer.Option(

--- a/src/nextlabs_sdk/_cloudaz/_component_search.py
+++ b/src/nextlabs_sdk/_cloudaz/_component_search.py
@@ -8,7 +8,7 @@ from nextlabs_sdk._cloudaz._component_models import (
     ComponentLite,
     ComponentNameEntry,
 )
-from nextlabs_sdk._cloudaz._response import parse_data, parse_paginated
+from nextlabs_sdk._cloudaz._response import build_page, parse_data
 from nextlabs_sdk._cloudaz._search import SavedSearch, SearchCriteria
 from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
@@ -76,6 +76,9 @@ class ComponentSearchService:
             ),
         )
 
+    def _page_params(self, page_no: int) -> dict[str, int]:
+        return {_PAGE_NO_PARAM: page_no}
+
     def _fetch_search_page(
         self,
         criteria: SearchCriteria,
@@ -85,15 +88,7 @@ class ComponentSearchService:
             "/console/api/v1/component/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentLite, page_no)
 
     def _fetch_saved_searches_page(
         self,
@@ -101,17 +96,9 @@ class ComponentSearchService:
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             "/console/api/v1/component/search/savedlist",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     def _fetch_find_saved_search_page(
         self,
@@ -120,17 +107,9 @@ class ComponentSearchService:
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             f"/console/api/v1/component/search/savedlist/{name}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     def _fetch_names_page(
         self,
@@ -139,17 +118,9 @@ class ComponentSearchService:
     ) -> PageResult[ComponentNameEntry]:
         response = self._client.get(
             f"/console/api/v1/component/search/listNames/{group}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentNameEntry.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentNameEntry, page_no)
 
     def _fetch_names_by_type_page(
         self,
@@ -159,17 +130,9 @@ class ComponentSearchService:
     ) -> PageResult[ComponentNameEntry]:
         response = self._client.get(
             f"/console/api/v1/component/search/listNames/{group}/{component_type}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentNameEntry.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentNameEntry, page_no)
 
 
 class AsyncComponentSearchService:
@@ -232,6 +195,9 @@ class AsyncComponentSearchService:
             ),
         )
 
+    def _page_params(self, page_no: int) -> dict[str, int]:
+        return {_PAGE_NO_PARAM: page_no}
+
     async def _fetch_search_page(
         self,
         criteria: SearchCriteria,
@@ -241,15 +207,7 @@ class AsyncComponentSearchService:
             "/console/api/v1/component/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentLite, page_no)
 
     async def _fetch_saved_searches_page(
         self,
@@ -257,17 +215,9 @@ class AsyncComponentSearchService:
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             "/console/api/v1/component/search/savedlist",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     async def _fetch_find_saved_search_page(
         self,
@@ -276,17 +226,9 @@ class AsyncComponentSearchService:
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             f"/console/api/v1/component/search/savedlist/{name}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     async def _fetch_names_page(
         self,
@@ -295,17 +237,9 @@ class AsyncComponentSearchService:
     ) -> PageResult[ComponentNameEntry]:
         response = await self._client.get(
             f"/console/api/v1/component/search/listNames/{group}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentNameEntry.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentNameEntry, page_no)
 
     async def _fetch_names_by_type_page(
         self,
@@ -315,14 +249,6 @@ class AsyncComponentSearchService:
     ) -> PageResult[ComponentNameEntry]:
         response = await self._client.get(
             f"/console/api/v1/component/search/listNames/{group}/{component_type}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=self._page_params(page_no),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [ComponentNameEntry.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, ComponentNameEntry, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_policies.py
+++ b/src/nextlabs_sdk/_cloudaz/_policies.py
@@ -180,11 +180,11 @@ class PolicyService:
 
     def import_xacml(
         self,
-        file: tuple[str, bytes, str],
+        policy_file: tuple[str, bytes, str],
     ) -> ImportResult:
         response = self._client.post(
             "/console/api/v1/policy/mgmt/importXacmlPolicy",
-            files={"file": file},
+            files={"file": policy_file},
         )
         return ImportResult.model_validate(parse_data(response))
 
@@ -360,11 +360,11 @@ class AsyncPolicyService:
 
     async def import_xacml(
         self,
-        file: tuple[str, bytes, str],
+        policy_file: tuple[str, bytes, str],
     ) -> ImportResult:
         resp = await self._client.post(
             "/console/api/v1/policy/mgmt/importXacmlPolicy",
-            files={"file": file},
+            files={"file": policy_file},
         )
         return ImportResult.model_validate(parse_data(resp))
 

--- a/src/nextlabs_sdk/_cloudaz/_policy_search.py
+++ b/src/nextlabs_sdk/_cloudaz/_policy_search.py
@@ -5,7 +5,7 @@ import functools
 import httpx
 
 from nextlabs_sdk._cloudaz._policy_models import PolicyLite
-from nextlabs_sdk._cloudaz._response import parse_data, parse_paginated
+from nextlabs_sdk._cloudaz._response import build_page, parse_data
 from nextlabs_sdk._cloudaz._search import SavedSearch, SearchCriteria
 from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
@@ -83,15 +83,7 @@ class PolicySearchService:
             "/console/api/v1/policy/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [PolicyLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, PolicyLite, page_no)
 
     def _fetch_search_named_page(
         self,
@@ -103,15 +95,7 @@ class PolicySearchService:
             f"/console/api/v1/policy/search/{search}",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [PolicyLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, PolicyLite, page_no)
 
     def _fetch_saved_searches_page(
         self,
@@ -121,15 +105,7 @@ class PolicySearchService:
             "/console/api/v1/policy/search/savedlist",
             params={_PAGE_NO_PARAM: page_no},
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     def _fetch_find_saved_search_page(
         self,
@@ -140,15 +116,7 @@ class PolicySearchService:
             f"/console/api/v1/policy/search/savedlist/{name}",
             params={_PAGE_NO_PARAM: page_no},
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
 
 class AsyncPolicySearchService:
@@ -216,15 +184,7 @@ class AsyncPolicySearchService:
             "/console/api/v1/policy/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [PolicyLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, PolicyLite, page_no)
 
     async def _fetch_search_named_page(
         self,
@@ -236,15 +196,7 @@ class AsyncPolicySearchService:
             f"/console/api/v1/policy/search/{search}",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        entries = [PolicyLite.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=entries,
-            page_no=page_no,
-            page_size=len(entries),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, PolicyLite, page_no)
 
     async def _fetch_saved_searches_page(
         self,
@@ -254,15 +206,7 @@ class AsyncPolicySearchService:
             "/console/api/v1/policy/search/savedlist",
             params={_PAGE_NO_PARAM: page_no},
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)
 
     async def _fetch_find_saved_search_page(
         self,
@@ -273,12 +217,4 @@ class AsyncPolicySearchService:
             f"/console/api/v1/policy/search/savedlist/{name}",
             params={_PAGE_NO_PARAM: page_no},
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return build_page(response, SavedSearch, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_reports.py
+++ b/src/nextlabs_sdk/_cloudaz/_reports.py
@@ -4,6 +4,7 @@ import builtins
 import functools
 
 import httpx
+from pydantic import BaseModel
 
 from nextlabs_sdk._cloudaz._report_models import (
     ApplicationUser,
@@ -25,6 +26,14 @@ from nextlabs_sdk.exceptions import raise_for_status
 
 _BASE_PATH = "/nextlabs-reporter/api/v1/policy-activity-reports"
 
+_FIELD_TITLE = "title"
+_FIELD_SORT_BY = "sortBy"
+_FIELD_SORT_ORDER = "sortOrder"
+_FIELD_PAGE = "page"
+_FIELD_SIZE = "size"
+_SORT_ORDER_ASCENDING = "ascending"
+_SORT_FIELD_ROW_ID = "rowId"
+
 
 class PolicyActivityReportService:
 
@@ -39,8 +48,8 @@ class PolicyActivityReportService:
         title: str = "",
         is_shared: bool = True,
         policy_decision: str = "AD",
-        sort_by: str = "title",
-        sort_order: str = "ascending",
+        sort_by: str = _FIELD_TITLE,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> SyncPaginator[PolicyActivityReport]:
         """List policy activity reports."""
@@ -64,7 +73,7 @@ class PolicyActivityReportService:
 
     def create(self, request: PolicyActivityReportRequest) -> PolicyActivityReport:
         """Create a new policy activity report."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = self._client.post(_BASE_PATH, json=payload)
         raw = parse_data(response)
         return PolicyActivityReport.model_validate(raw)
@@ -73,14 +82,14 @@ class PolicyActivityReportService:
         self, report_id: int, request: PolicyActivityReportRequest
     ) -> PolicyActivityReport:
         """Modify an existing policy activity report."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = self._client.put(f"{_BASE_PATH}/{report_id}", json=payload)
         raw = parse_data(response)
         return PolicyActivityReport.model_validate(raw)
 
     def delete(self, request: DeleteReportsRequest) -> None:
         """Delete reports by IDs or query parameters."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = self._client.post(f"{_BASE_PATH}/delete", json=payload)
         raise_for_status(response)
 
@@ -96,8 +105,8 @@ class PolicyActivityReportService:
         self,
         report_id: int,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> SyncPaginator[EnforcementEntry]:
         """Retrieve enforcement logs for a saved report."""
@@ -115,12 +124,14 @@ class PolicyActivityReportService:
         self,
         report_id: int,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
     ) -> bytes:
         """Export enforcement logs for a saved report."""
-        params = {"sortBy": sort_by, "sortOrder": sort_order}
-        response = self._client.post(f"{_BASE_PATH}/{report_id}/export", params=params)
+        query_params = {_FIELD_SORT_BY: sort_by, _FIELD_SORT_ORDER: sort_order}
+        response = self._client.post(
+            f"{_BASE_PATH}/{report_id}/export", params=query_params
+        )
         raise_for_status(response)
         return response.content
 
@@ -128,7 +139,7 @@ class PolicyActivityReportService:
 
     def generate_widgets(self, request: PolicyActivityReportRequest) -> WidgetData:
         """Generate widget data for ad-hoc criteria."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = self._client.post(f"{_BASE_PATH}/generate/widgets", json=payload)
         raw = parse_data(response)
         return WidgetData.model_validate(raw)
@@ -137,8 +148,8 @@ class PolicyActivityReportService:
         self,
         request: PolicyActivityReportRequest,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> SyncPaginator[EnforcementEntry]:
         """Generate enforcement logs for ad-hoc criteria."""
@@ -156,14 +167,14 @@ class PolicyActivityReportService:
         self,
         request: PolicyActivityReportRequest,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
     ) -> bytes:
         """Export enforcement logs for ad-hoc criteria."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
-        params = {"sortBy": sort_by, "sortOrder": sort_order}
+        payload = self._payload(request)
+        query_params = {_FIELD_SORT_BY: sort_by, _FIELD_SORT_ORDER: sort_order}
         response = self._client.post(
-            f"{_BASE_PATH}/generate/export", json=payload, params=params
+            f"{_BASE_PATH}/generate/export", json=payload, params=query_params
         )
         raise_for_status(response)
         return response.content
@@ -210,6 +221,9 @@ class PolicyActivityReportService:
 
     # --- Internal pagination callbacks ---
 
+    def _payload(self, request: BaseModel) -> dict[str, object]:
+        return request.model_dump(by_alias=True, exclude_none=True)
+
     def _fetch_list_page(
         self,
         title: str,
@@ -220,18 +234,20 @@ class PolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[PolicyActivityReport]:
-        params: dict[str, str | int | bool] = {
-            "title": title,
+        query_params: dict[str, str | int | bool] = {
+            _FIELD_TITLE: title,
             "isShared": is_shared,
             "policyDecision": policy_decision,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
-            "size": page_size,
-            "page": page_no,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
+            _FIELD_SIZE: page_size,
+            _FIELD_PAGE: page_no,
         }
-        response = self._client.get(_BASE_PATH, params=params)
+        response = self._client.get(_BASE_PATH, params=query_params)
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
-        reports = [PolicyActivityReport.model_validate(item) for item in raw_items]
+        reports = [
+            PolicyActivityReport.model_validate(raw_item) for raw_item in raw_items
+        ]
         return PageResult(
             entries=reports,
             page_no=page_no,
@@ -248,14 +264,14 @@ class PolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[EnforcementEntry]:
-        params: dict[str, str | int] = {
-            "page": page_no,
-            "size": page_size,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
+        query_params: dict[str, str | int] = {
+            _FIELD_PAGE: page_no,
+            _FIELD_SIZE: page_size,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
         }
         response = self._client.get(
-            f"{_BASE_PATH}/{report_id}/enforcements", params=params
+            f"{_BASE_PATH}/{report_id}/enforcements", params=query_params
         )
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
         entries = [EnforcementEntry.model_validate(entry) for entry in raw_items]
@@ -275,17 +291,17 @@ class PolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[EnforcementEntry]:
-        payload = request.model_dump(by_alias=True, exclude_none=True)
-        params: dict[str, str | int] = {
-            "page": page_no,
-            "size": page_size,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
+        payload = self._payload(request)
+        query_params: dict[str, str | int] = {
+            _FIELD_PAGE: page_no,
+            _FIELD_SIZE: page_size,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
         }
         response = self._client.post(
             f"{_BASE_PATH}/generate/enforcements",
             json=payload,
-            params=params,
+            params=query_params,
         )
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
         entries = [EnforcementEntry.model_validate(entry) for entry in raw_items]
@@ -311,8 +327,8 @@ class AsyncPolicyActivityReportService:
         title: str = "",
         is_shared: bool = True,
         policy_decision: str = "AD",
-        sort_by: str = "title",
-        sort_order: str = "ascending",
+        sort_by: str = _FIELD_TITLE,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> AsyncPaginator[PolicyActivityReport]:
         """List policy activity reports."""
@@ -338,7 +354,7 @@ class AsyncPolicyActivityReportService:
         self, request: PolicyActivityReportRequest
     ) -> PolicyActivityReport:
         """Create a new policy activity report."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = await self._client.post(_BASE_PATH, json=payload)
         raw = parse_data(response)
         return PolicyActivityReport.model_validate(raw)
@@ -347,14 +363,14 @@ class AsyncPolicyActivityReportService:
         self, report_id: int, request: PolicyActivityReportRequest
     ) -> PolicyActivityReport:
         """Modify an existing policy activity report."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = await self._client.put(f"{_BASE_PATH}/{report_id}", json=payload)
         raw = parse_data(response)
         return PolicyActivityReport.model_validate(raw)
 
     async def delete(self, request: DeleteReportsRequest) -> None:
         """Delete reports by IDs or query parameters."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = await self._client.post(f"{_BASE_PATH}/delete", json=payload)
         raise_for_status(response)
 
@@ -370,8 +386,8 @@ class AsyncPolicyActivityReportService:
         self,
         report_id: int,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> AsyncPaginator[EnforcementEntry]:
         """Retrieve enforcement logs for a saved report."""
@@ -389,13 +405,13 @@ class AsyncPolicyActivityReportService:
         self,
         report_id: int,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
     ) -> bytes:
         """Export enforcement logs for a saved report. Returns raw file bytes."""
-        params = {"sortBy": sort_by, "sortOrder": sort_order}
+        query_params = {_FIELD_SORT_BY: sort_by, _FIELD_SORT_ORDER: sort_order}
         response = await self._client.post(
-            f"{_BASE_PATH}/{report_id}/export", params=params
+            f"{_BASE_PATH}/{report_id}/export", params=query_params
         )
         raise_for_status(response)
         return response.content
@@ -406,7 +422,7 @@ class AsyncPolicyActivityReportService:
         self, request: PolicyActivityReportRequest
     ) -> WidgetData:
         """Generate widget data for ad-hoc criteria."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
+        payload = self._payload(request)
         response = await self._client.post(
             f"{_BASE_PATH}/generate/widgets", json=payload
         )
@@ -417,8 +433,8 @@ class AsyncPolicyActivityReportService:
         self,
         request: PolicyActivityReportRequest,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
         page_size: int = 20,
     ) -> AsyncPaginator[EnforcementEntry]:
         """Generate enforcement logs for ad-hoc criteria."""
@@ -436,14 +452,14 @@ class AsyncPolicyActivityReportService:
         self,
         request: PolicyActivityReportRequest,
         *,
-        sort_by: str = "rowId",
-        sort_order: str = "ascending",
+        sort_by: str = _SORT_FIELD_ROW_ID,
+        sort_order: str = _SORT_ORDER_ASCENDING,
     ) -> bytes:
         """Export enforcement logs for ad-hoc criteria. Returns raw file bytes."""
-        payload = request.model_dump(by_alias=True, exclude_none=True)
-        params = {"sortBy": sort_by, "sortOrder": sort_order}
+        payload = self._payload(request)
+        query_params = {_FIELD_SORT_BY: sort_by, _FIELD_SORT_ORDER: sort_order}
         response = await self._client.post(
-            f"{_BASE_PATH}/generate/export", json=payload, params=params
+            f"{_BASE_PATH}/generate/export", json=payload, params=query_params
         )
         raise_for_status(response)
         return response.content
@@ -454,13 +470,13 @@ class AsyncPolicyActivityReportService:
         """Retrieve cached enforcement users."""
         response = await self._client.get(f"{_BASE_PATH}/users")
         raw = parse_data(response)
-        return [CachedUser.model_validate(item) for item in raw]
+        return [CachedUser.model_validate(raw_item) for raw_item in raw]
 
     async def list_cached_policies(self) -> builtins.list[CachedPolicy]:
         """Retrieve cached policies."""
         response = await self._client.get(f"{_BASE_PATH}/policies")
         raw = parse_data(response)
-        return [CachedPolicy.model_validate(item) for item in raw]
+        return [CachedPolicy.model_validate(raw_item) for raw_item in raw]
 
     async def get_resource_actions(self) -> ResourceActions:
         """Retrieve policy models with their available actions."""
@@ -480,15 +496,18 @@ class AsyncPolicyActivityReportService:
         """Retrieve user groups available for report sharing."""
         response = await self._client.get(f"{_BASE_PATH}/share/user-groups")
         raw = parse_data(response)
-        return [UserGroup.model_validate(item) for item in raw]
+        return [UserGroup.model_validate(raw_item) for raw_item in raw]
 
     async def list_application_users(self) -> builtins.list[ApplicationUser]:
         """Retrieve application users available for report sharing."""
         response = await self._client.get(f"{_BASE_PATH}/share/application-users")
         raw = parse_data(response)
-        return [ApplicationUser.model_validate(item) for item in raw]
+        return [ApplicationUser.model_validate(raw_item) for raw_item in raw]
 
     # --- Internal pagination callbacks ---
+
+    def _payload(self, request: BaseModel) -> dict[str, object]:
+        return request.model_dump(by_alias=True, exclude_none=True)
 
     async def _fetch_list_page(
         self,
@@ -500,18 +519,20 @@ class AsyncPolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[PolicyActivityReport]:
-        params: dict[str, str | int | bool] = {
-            "title": title,
+        query_params: dict[str, str | int | bool] = {
+            _FIELD_TITLE: title,
             "isShared": is_shared,
             "policyDecision": policy_decision,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
-            "size": page_size,
-            "page": page_no,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
+            _FIELD_SIZE: page_size,
+            _FIELD_PAGE: page_no,
         }
-        response = await self._client.get(_BASE_PATH, params=params)
+        response = await self._client.get(_BASE_PATH, params=query_params)
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
-        reports = [PolicyActivityReport.model_validate(item) for item in raw_items]
+        reports = [
+            PolicyActivityReport.model_validate(raw_item) for raw_item in raw_items
+        ]
         return PageResult(
             entries=reports,
             page_no=page_no,
@@ -528,17 +549,17 @@ class AsyncPolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[EnforcementEntry]:
-        params: dict[str, str | int | bool] = {
-            "page": page_no,
-            "size": page_size,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
+        query_params: dict[str, str | int | bool] = {
+            _FIELD_PAGE: page_no,
+            _FIELD_SIZE: page_size,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
         }
         response = await self._client.get(
-            f"{_BASE_PATH}/{report_id}/enforcements", params=params
+            f"{_BASE_PATH}/{report_id}/enforcements", params=query_params
         )
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
-        entries = [EnforcementEntry.model_validate(item) for item in raw_items]
+        entries = [EnforcementEntry.model_validate(raw_item) for raw_item in raw_items]
         return PageResult(
             entries=entries,
             page_no=page_no,
@@ -555,20 +576,20 @@ class AsyncPolicyActivityReportService:
         page_size: int,
         page_no: int,
     ) -> PageResult[EnforcementEntry]:
-        payload = request.model_dump(by_alias=True, exclude_none=True)
-        params: dict[str, str | int | bool] = {
-            "page": page_no,
-            "size": page_size,
-            "sortBy": sort_by,
-            "sortOrder": sort_order,
+        payload = self._payload(request)
+        query_params: dict[str, str | int | bool] = {
+            _FIELD_PAGE: page_no,
+            _FIELD_SIZE: page_size,
+            _FIELD_SORT_BY: sort_by,
+            _FIELD_SORT_ORDER: sort_order,
         }
         response = await self._client.post(
             f"{_BASE_PATH}/generate/enforcements",
             json=payload,
-            params=params,
+            params=query_params,
         )
         raw_items, total_pages, total_records = parse_reporter_paginated(response)
-        entries = [EnforcementEntry.model_validate(item) for item in raw_items]
+        entries = [EnforcementEntry.model_validate(raw_item) for raw_item in raw_items]
         return PageResult(
             entries=entries,
             page_no=page_no,

--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar
 
 import httpx
+from pydantic import BaseModel
 
 from nextlabs_sdk._envelope import envelope_from_mapping
 from nextlabs_sdk._json_response import decode_json, decode_json_object, require_key
+from nextlabs_sdk._pagination import PageResult
 from nextlabs_sdk.exceptions import ApiError, raise_for_status
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
 def _request_context(response: httpx.Response) -> tuple[str | None, str | None]:
@@ -98,3 +102,20 @@ def parse_raw(response: httpx.Response) -> Any:
     """Parse a response with no envelope — returns the raw JSON body."""
     raise_for_status(response)
     return decode_json(response)
+
+
+def build_page(
+    response: httpx.Response,
+    model: type[_ModelT],
+    page_no: int,
+) -> PageResult[_ModelT]:
+    """Parse a paginated CloudAz response into a typed ``PageResult``."""
+    raw_items, total_pages, total_records = parse_paginated(response)
+    entries = [model.model_validate(entry) for entry in raw_items]
+    return PageResult(
+        entries=entries,
+        page_no=page_no,
+        page_size=len(entries),
+        total_pages=total_pages,
+        total_records=total_records,
+    )


### PR DESCRIPTION
Closes #47 (partially).

## Summary

Phase B of #47: refactor code so 6 individual flake8 `per-file-ignores` entries in `setup.cfg` are no longer required — without introducing `noqa`, `type: ignore`, or new mypy relaxations.

## Suppressions removed (6)

| File | Removed | How |
|---|---|---|
| `_cli/_app.py` | `WPS432` | Extracted `_DEFAULT_TIMEOUT_SECONDS = 30.0` module constant |
| `_cloudaz/_component_search.py` | `WPS204` | Use new shared `build_page()` helper |
| `_cloudaz/_policy_search.py` | `WPS204` | Use new shared `build_page()` helper |
| `_cloudaz/_policies.py` | `WPS110` | Renamed `file` → `policy_file` in `import_xacml` (sync + async) |
| `_cloudaz/_reports.py` | `WPS110` | Renamed `params` → `query_params`, `item` → `raw_item` |
| `_cloudaz/_reports.py` | `WPS226` | Extracted field-name / sort constants |

New shared `build_page()` in `_cloudaz/_response.py` generic over `BaseModel` collapses the `parse_paginated → PageResult` boilerplate; a `_payload(BaseModel)` helper in `_reports.py` de-duplicates `model_dump(by_alias=True, exclude_none=True)` calls.

## Phase A — investigated and deferred

The 12 mypy `[mypy-…_models]` / `[mypy-…search…]` overrides flagged as "stale" in the issue are **not** stale. Removing them surfaces ~58 `explicit-Any` errors originating from the `pydantic.mypy` plugin's typed `__init__` stubs on `BaseModel` subclasses (e.g. `class Foo(BaseModel):` generates `def __init__(self, **data: Any)`). Reworking models to avoid `Any` is out of scope here; the overrides must remain.

## Not removed — trade-off would be net-neutral

`WPS204` is **retained** on `_policies.py`, `_dashboard.py`, and `_reports.py`. The natural refactor is a `_parse` service method wrapping `parse_data(response)`. But `parse_data` returns `Any`, so `_parse` must either:
- return `Any` → file needs new `disallow_any_explicit = false` mypy override, or
- return `object` → breaks `for entry in raw`, `model_validate`, and `int`/`str` returns downstream.

Keeping one WPS204 suppression per file is cleaner than swapping one suppression for another. Documented in the updated comments.

## Verification

- `python ./tools/checks.py` — black, flake8, mypy, pyright all green
- `python ./tools/tests.py --short` — **1743 passed, 97 xfailed**, 96.04% coverage
- Sync/async parity preserved across all refactors

## Out of scope

- Phase C (`_cloudaz/_search.py` TypedDict refactor)
- Appendix (`_component_models.py` `noqa` / AGENTS.md conflict)
- Phase A reframe (rework Pydantic models to drop `Any`)
