### PR TITLE
fix(pdp)!: default token URL to /dpc/oauth; add auth_base_url kwarg

### DIFF
--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -151,6 +151,7 @@ def make_pdp_client(ctx: CliContext) -> PdpClient:
 
     return PdpClient(
         base_url=ctx.pdp_url or base_url,
+        auth_base_url=base_url,
         client_id=client_id,
         client_secret=ctx.client_secret,
         http_config=_http_config(ctx, account),

--- a/src/nextlabs_sdk/_pdp/_async_client.py
+++ b/src/nextlabs_sdk/_pdp/_async_client.py
@@ -11,6 +11,7 @@ from nextlabs_sdk._pdp._enums import ContentType
 from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
+from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
@@ -20,17 +21,22 @@ _CONTENT_TYPE = "Content-Type"
 class AsyncPdpClient:
     """Asynchronous client for the NextLabs PDP REST API."""
 
-    def __init__(
+    def __init__(  # noqa: WPS211
         self,
         *,
         base_url: str,
         client_id: str,
         client_secret: str,
+        auth_base_url: str | None = None,
         token_url: str | None = None,
         http_config: HttpConfig | None = None,
     ) -> None:
         config = http_config or HttpConfig()
-        effective_token_url = token_url or f"{base_url}/cas/token"
+        effective_token_url = resolve_pdp_token_url(
+            base_url=base_url,
+            auth_base_url=auth_base_url,
+            token_url=token_url,
+        )
         auth = PdpAuth(
             token_url=effective_token_url,
             client_id=client_id,

--- a/src/nextlabs_sdk/_pdp/_client.py
+++ b/src/nextlabs_sdk/_pdp/_client.py
@@ -11,6 +11,7 @@ from nextlabs_sdk._pdp._enums import ContentType
 from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
+from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
@@ -20,17 +21,22 @@ _CONTENT_TYPE = "Content-Type"
 class PdpClient:
     """Synchronous client for the NextLabs PDP REST API."""
 
-    def __init__(
+    def __init__(  # noqa: WPS211
         self,
         *,
         base_url: str,
         client_id: str,
         client_secret: str,
+        auth_base_url: str | None = None,
         token_url: str | None = None,
         http_config: HttpConfig | None = None,
     ) -> None:
         config = http_config or HttpConfig()
-        effective_token_url = token_url or f"{base_url}/cas/token"
+        effective_token_url = resolve_pdp_token_url(
+            base_url=base_url,
+            auth_base_url=auth_base_url,
+            token_url=token_url,
+        )
         auth = PdpAuth(
             token_url=effective_token_url,
             client_id=client_id,

--- a/src/nextlabs_sdk/_pdp/_token_url.py
+++ b/src/nextlabs_sdk/_pdp/_token_url.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+_CLOUDAZ_TOKEN_PATH = "/cas/token"
+_PDP_TOKEN_PATH = "/dpc/oauth"
+
+
+def resolve_pdp_token_url(
+    *,
+    base_url: str,
+    auth_base_url: str | None,
+    token_url: str | None,
+) -> str:
+    """Return the OAuth token URL for a PDP client.
+
+    Precedence (first match wins):
+
+    1. ``token_url`` — used verbatim.
+    2. ``auth_base_url`` — ``{auth_base_url}/cas/token`` (CloudAz host).
+    3. Otherwise — ``{base_url}/dpc/oauth`` (PDP host).
+
+    Trailing slashes on ``base_url`` / ``auth_base_url`` are stripped
+    before path composition; ``token_url`` is returned verbatim.
+
+    Args:
+        base_url: PDP API host.
+        auth_base_url: Optional CloudAz host hosting ``/cas/token``.
+        token_url: Optional full token URL; if set, wins over everything.
+
+    Returns:
+        The resolved OAuth token URL.
+    """
+    if token_url:
+        return token_url
+    if auth_base_url:
+        return f"{auth_base_url.rstrip('/')}{_CLOUDAZ_TOKEN_PATH}"
+    return f"{base_url.rstrip('/')}{_PDP_TOKEN_PATH}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -124,6 +124,7 @@ def cloudaz_client(seeded_wiremock: str) -> Iterator[CloudAzClient]:
 def pdp_client(seeded_wiremock: str) -> Iterator[PdpClient]:
     client = PdpClient(
         base_url=seeded_wiremock,
+        auth_base_url=seeded_wiremock,
         client_id=PDP_CLIENT_ID,
         client_secret=PDP_CLIENT_SECRET,
     )

--- a/tests/e2e/test_pdp_flows.py
+++ b/tests/e2e/test_pdp_flows.py
@@ -154,6 +154,7 @@ def test_async_pdp_evaluate_json(
     async def _run() -> object:
         client = AsyncPdpClient(
             base_url=seeded_wiremock,
+            auth_base_url=seeded_wiremock,
             client_id="e2e-client",
             client_secret="e2e-secret",
         )

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -215,3 +215,62 @@ def test_async_permissions_raises_api_error_on_unexpected_shape():
         assert "Unexpected PDP response shape" in exc_info.value.message
 
     _run_async(run())
+
+
+def test_async_pdp_client_defaults_token_url_to_dpc_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return mock(httpx.AsyncClient)
+
+    monkeypatch.setattr(transport_mod, "create_async_http_client", _capture)
+
+    AsyncPdpClient(base_url=BASE_URL, client_id="c", client_secret="s")
+
+    assert captured["auth"]._token_url == f"{BASE_URL}/dpc/oauth"
+
+
+def test_async_pdp_client_uses_auth_base_url_for_cas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return mock(httpx.AsyncClient)
+
+    monkeypatch.setattr(transport_mod, "create_async_http_client", _capture)
+
+    AsyncPdpClient(
+        base_url=BASE_URL,
+        client_id="c",
+        client_secret="s",
+        auth_base_url="https://cloudaz.example.com",
+    )
+
+    assert captured["auth"]._token_url == "https://cloudaz.example.com/cas/token"
+
+
+def test_async_pdp_client_explicit_token_url_overrides_auth_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return mock(httpx.AsyncClient)
+
+    monkeypatch.setattr(transport_mod, "create_async_http_client", _capture)
+
+    AsyncPdpClient(
+        base_url=BASE_URL,
+        client_id="c",
+        client_secret="s",
+        auth_base_url="https://cloudaz.example.com",
+        token_url="https://override.example.com/oauth",
+    )
+
+    assert captured["auth"]._token_url == "https://override.example.com/oauth"

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -271,3 +271,54 @@ def test_permissions_raises_api_error_on_non_json_response():
 
     with pytest.raises(ApiError):
         _make_pdp().permissions(_make_permissions_request())
+
+
+def test_pdp_client_defaults_token_url_to_dpc_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> httpx.Client:
+        captured.update(kwargs)
+        return cast(httpx.Client, mock(httpx.Client))
+
+    monkeypatch.setattr(transport_mod, "create_http_client", _capture)
+
+    _make_pdp()
+
+    assert captured["auth"]._token_url == f"{BASE_URL}/dpc/oauth"
+
+
+def test_pdp_client_uses_auth_base_url_for_cas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> httpx.Client:
+        captured.update(kwargs)
+        return cast(httpx.Client, mock(httpx.Client))
+
+    monkeypatch.setattr(transport_mod, "create_http_client", _capture)
+
+    _make_pdp(auth_base_url="https://cloudaz.example.com")
+
+    assert captured["auth"]._token_url == "https://cloudaz.example.com/cas/token"
+
+
+def test_pdp_client_explicit_token_url_overrides_auth_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> httpx.Client:
+        captured.update(kwargs)
+        return cast(httpx.Client, mock(httpx.Client))
+
+    monkeypatch.setattr(transport_mod, "create_http_client", _capture)
+
+    _make_pdp(
+        auth_base_url="https://cloudaz.example.com",
+        token_url="https://override.example.com/oauth",
+    )
+
+    assert captured["auth"]._token_url == "https://override.example.com/oauth"

--- a/tests/test_pdp_token_url.py
+++ b/tests/test_pdp_token_url.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
+
+
+class TestResolvePdpTokenUrl:
+    def test_explicit_token_url_wins_over_everything(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url="https://cloudaz.example.com",
+            token_url="https://custom.example.com/oauth",
+        )
+        assert result == "https://custom.example.com/oauth"
+
+    def test_auth_base_url_produces_cas_token(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url="https://cloudaz.example.com",
+            token_url=None,
+        )
+        assert result == "https://cloudaz.example.com/cas/token"
+
+    def test_only_base_url_defaults_to_dpc_oauth(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url=None,
+            token_url=None,
+        )
+        assert result == "https://pdp.example.com/dpc/oauth"
+
+    def test_trailing_slash_on_base_url_is_stripped(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com/",
+            auth_base_url=None,
+            token_url=None,
+        )
+        assert result == "https://pdp.example.com/dpc/oauth"
+
+    def test_trailing_slash_on_auth_base_url_is_stripped(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url="https://cloudaz.example.com/",
+            token_url=None,
+        )
+        assert result == "https://cloudaz.example.com/cas/token"
+
+    def test_token_url_is_returned_verbatim_even_with_trailing_slash(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url=None,
+            token_url="https://custom.example.com/oauth/",
+        )
+        assert result == "https://custom.example.com/oauth/"
+
+    def test_empty_string_token_url_is_treated_as_unset(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url=None,
+            token_url="",
+        )
+        assert result == "https://pdp.example.com/dpc/oauth"
+
+    def test_empty_string_auth_base_url_is_treated_as_unset(self) -> None:
+        result = resolve_pdp_token_url(
+            base_url="https://pdp.example.com",
+            auth_base_url="",
+            token_url=None,
+        )
+        assert result == "https://pdp.example.com/dpc/oauth"


### PR DESCRIPTION
Closes #51.

## Summary

`PdpClient` / `AsyncPdpClient` no longer derive their default OAuth token URL from the PDP `base_url` as `/cas/token` (a CloudAz endpoint). The new default is `{base_url}/dpc/oauth` — the PDP's own OAuth endpoint. Callers whose auth lives on a separate CloudAz host can pass `auth_base_url=<cloudaz_host>` to get `{auth_base_url}/cas/token`. The existing `token_url` kwarg still overrides everything.

## Resolution order (first match wins)

1. `token_url` → used verbatim.
2. `auth_base_url` → `{auth_base_url}/cas/token`.
3. Otherwise → `{base_url}/dpc/oauth`.

Trailing slashes on `base_url` and `auth_base_url` are stripped before composition.

## Breaking change

Callers that relied on the old implicit `{base_url}/cas/token` default must now either set `auth_base_url`, set `token_url` explicitly, or stub `/dpc/oauth` on the PDP host. Acceptable on 0.x.

The CLI's `make_pdp_client` internally passes `auth_base_url=<CloudAz base>` so CLI users see **no behavior change** — tokens continue to be fetched from the CloudAz `/cas/token` endpoint as before. A dedicated CLI flag for selecting the auth flavor is tracked separately.

## Changes

- **New:** `src/nextlabs_sdk/_pdp/_token_url.py` — pure `resolve_pdp_token_url` helper (8 unit tests).
- **Modified:** `PdpClient` and `AsyncPdpClient` — add `auth_base_url` kwarg, delegate to the resolver (3 + 3 integration tests).
- **Modified:** `_cli/_client_factory.make_pdp_client` — pass `auth_base_url` to preserve pre-existing CLI behavior.
- **Modified:** E2E fixtures — pass `auth_base_url=seeded_wiremock` so the existing `/cas/token` WireMock stub keeps working.

## Acceptance criteria

- [x] Default token URL when only a PDP `base_url` is given is `/dpc/oauth`.
- [x] When a CloudAz host is given for auth, token URL is `/cas/token`.
- [x] `token_url` kwarg still overrides everything.
- [x] Sync/async parity preserved.
- [x] Unit tests cover the three cases.
- [x] No change to PDP request URLs.

## Verification

- `python ./tools/checks.py` — Black, Flake8, MyPy, Pyright all green.
- `python ./tools/tests.py --short` — 1757 passed, 96% coverage.
- `python ./tools/tests.py --short --e2e` — 46 passed.
