### PR TITLE
feat(cli)!: add --pdp-auth to pick CloudAz or PDP token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,44 @@ the CLI falls back to the password grant (if `--password` /
 `NEXTLABS_PASSWORD` is set) and otherwise raises `AuthenticationError`
 with a "Run `nextlabs auth login`" hint.
 
+### PDP authentication — CloudAz vs PDP token endpoint
+
+The NextLabs docs describe two legitimate OAuth token endpoints for PDP
+calls:
+
+- **CloudAz endpoint** — `/cas/token` on the CloudAz host.
+- **PDP endpoint** — `/dpc/oauth` on the PDP host.
+
+The CLI exposes both via `--pdp-auth {cloudaz,pdp}` (env
+`NEXTLABS_PDP_AUTH`). The default depends on which hosts you pass:
+
+| Flags set                          | Default flavor | Token URL hit                 |
+| ---------------------------------- | -------------- | ----------------------------- |
+| `--base-url` + `--pdp-url`         | `cloudaz`      | `<base-url>/cas/token`        |
+| `--pdp-url` only                   | `pdp`          | `<pdp-url>/dpc/oauth`         |
+
+Explicit `--pdp-auth` always wins over the derivation. `--pdp-url` is
+required for every PDP command; `--base-url` is required only for the
+`cloudaz` flavor.
+
+```bash
+# CloudAz-hosted auth (default when --base-url is set)
+nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
+  --client-secret "$SECRET" \
+  pdp eval --subject alice --resource doc-42 --resource-type document \
+           --action read
+
+# PDP-hosted auth
+nextlabs --pdp-url https://pdp.example --client-secret "$SECRET" \
+  pdp eval --subject alice --resource doc-42 --resource-type document \
+           --action read
+
+# Force PDP-hosted auth even when a CloudAz host is configured
+nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
+  --pdp-auth pdp --client-secret "$SECRET" \
+  pdp eval ...
+```
+
 **Environment variables**
 
 | Variable                   | Purpose                                                       |
@@ -380,7 +418,8 @@ with a "Run `nextlabs auth login`" hint.
 | `NEXTLABS_PASSWORD`        | CloudAz password                                              |
 | `NEXTLABS_CLIENT_ID`       | OIDC client ID (default: `ControlCenterOIDCClient`)           |
 | `NEXTLABS_CLIENT_SECRET`   | PDP client secret                                             |
-| `NEXTLABS_PDP_URL`         | PDP base URL (defaults to `--base-url`)                       |
+| `NEXTLABS_PDP_URL`         | PDP base URL (host serving `/dpc/authorization/*`)            |
+| `NEXTLABS_PDP_AUTH`        | PDP token endpoint flavor: `cloudaz` or `pdp` (see below)     |
 | `NEXTLABS_TOKEN`           | Pre-issued bearer token; bypasses the login flow and cache    |
 | `NEXTLABS_CACHE_DIR`       | Directory holding `tokens.json` (overrides XDG default)       |
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
 | `NEXTLABS_CLIENT_ID`       | OIDC client ID (default: `ControlCenterOIDCClient`)           |
 | `NEXTLABS_CLIENT_SECRET`   | PDP client secret                                             |
 | `NEXTLABS_PDP_URL`         | PDP base URL (host serving `/dpc/authorization/*`)            |
-| `NEXTLABS_PDP_AUTH`        | PDP token endpoint flavor: `cloudaz` or `pdp` (see below)     |
+| `NEXTLABS_PDP_AUTH`        | PDP token endpoint flavor: `cloudaz` or `pdp` (see above)     |
 | `NEXTLABS_TOKEN`           | Pre-issued bearer token; bypasses the login flow and cache    |
 | `NEXTLABS_CACHE_DIR`       | Directory holding `tokens.json` (overrides XDG default)       |
 

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -12,6 +12,7 @@ from nextlabs_sdk._cli._dashboard_cmd import dashboard_app
 from nextlabs_sdk._cli._logging_setup import configure_cli_logging
 from nextlabs_sdk._cli._operators_cmd import operators_app
 from nextlabs_sdk._cli._output_format import OutputFormat
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cli._pdp_cmd import pdp_app
 from nextlabs_sdk._cli._policies_cmd import policies_app
 from nextlabs_sdk._cli._reports_cmd import reports_app
@@ -46,7 +47,7 @@ def main(
     base_url: str | None = typer.Option(
         None,
         envvar="NEXTLABS_BASE_URL",
-        help="CloudAz base URL",
+        help="CloudAz base URL (host serving /cas/token).",
     ),
     username: str | None = typer.Option(
         None,
@@ -71,7 +72,19 @@ def main(
     pdp_url: str | None = typer.Option(
         None,
         envvar="NEXTLABS_PDP_URL",
-        help="PDP base URL (defaults to --base-url)",
+        help="PDP base URL (host serving /dpc/authorization/*).",
+    ),
+    pdp_auth: PdpAuthSource | None = typer.Option(
+        None,
+        "--pdp-auth",
+        envvar="NEXTLABS_PDP_AUTH",
+        case_sensitive=False,
+        help=(
+            "Token endpoint PDP commands should use: 'cloudaz' "
+            "(/cas/token on the CloudAz host) or 'pdp' (/dpc/oauth on "
+            "the PDP host). Defaults to 'cloudaz' when --base-url is "
+            "set, else 'pdp'."
+        ),
     ),
     output: OutputFormat = typer.Option(
         OutputFormat.TABLE,
@@ -132,6 +145,7 @@ def main(
         token=token,
         cache_dir=cache_dir,
         verbose=verbose,
+        pdp_auth=pdp_auth,
     )
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -18,6 +18,7 @@ from nextlabs_sdk._cli._account_resolver import (
 )
 from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._config import HttpConfig
 from nextlabs_sdk._pdp._client import PdpClient
@@ -26,7 +27,33 @@ _LOGIN_HINT = "run `nextlabs auth login` or `nextlabs auth use`"
 _BASE_URL_REQUIRED = f"--base-url is required (or {_LOGIN_HINT})"
 _USERNAME_REQUIRED = f"--username is required (or {_LOGIN_HINT})"
 _PASSWORD_REQUIRED = f"--password or NEXTLABS_PASSWORD is required (or {_LOGIN_HINT})"
-_CLIENT_SECRET_REQUIRED = "--client-secret or NEXTLABS_CLIENT_SECRET is required"
+
+_PDP_URL_HELP = "PDP API host serving /dpc/authorization/*"
+_CLOUDAZ_ENDPOINT = "/cas/token on the CloudAz host"
+_PDP_ENDPOINT = "/dpc/oauth on the PDP host"
+
+
+def _client_secret_required(flavor: PdpAuthSource) -> str:
+    endpoint = _CLOUDAZ_ENDPOINT if flavor is PdpAuthSource.CLOUDAZ else _PDP_ENDPOINT
+    return (
+        "--client-secret or NEXTLABS_CLIENT_SECRET is required " f"(used at {endpoint})"
+    )
+
+
+def _base_url_required_for_cloudaz_flavor() -> str:
+    return (
+        "--base-url or NEXTLABS_BASE_URL is required for --pdp-auth=cloudaz "
+        f"(authenticates at {_CLOUDAZ_ENDPOINT})"
+    )
+
+
+def _pdp_url_required(flavor: PdpAuthSource) -> str:
+    if flavor is PdpAuthSource.PDP:
+        return (
+            "--pdp-url or NEXTLABS_PDP_URL is required for --pdp-auth=pdp "
+            f"(authenticates at {_PDP_ENDPOINT})"
+        )
+    return f"--pdp-url or NEXTLABS_PDP_URL is required ({_PDP_URL_HELP})"
 
 
 def _cached_credentials_usable(
@@ -64,6 +91,12 @@ def _prompt_password_if_tty(account: ResolvedAccount) -> str | None:
         f"Password for {account.username}@{account.base_url}",
         hide_input=True,
     )
+
+
+def _prompt_url_if_tty(label: str) -> str | None:
+    if not sys.stdin.isatty():
+        return None
+    return typer.prompt(label)
 
 
 def _persisted_verify(
@@ -140,19 +173,53 @@ def make_cloudaz_client(ctx: CliContext) -> CloudAzClient:
 
 def make_pdp_client(ctx: CliContext) -> PdpClient:
     account = resolve_account(ctx)
-    fallback_base_url = account.base_url if account else None
-    base_url = ctx.base_url or fallback_base_url
     client_id = account.client_id if account else ctx.client_id
 
-    if not base_url:
-        raise typer.BadParameter(_BASE_URL_REQUIRED)
+    flavor = _resolve_flavor(ctx)
+    base_url = _resolve_cloudaz_base_url(ctx, account, flavor)
+    pdp_url = _resolve_pdp_url(ctx, flavor)
+
     if not ctx.client_secret:
-        raise typer.BadParameter(_CLIENT_SECRET_REQUIRED)
+        raise typer.BadParameter(_client_secret_required(flavor))
+
+    auth_base_url = base_url if flavor is PdpAuthSource.CLOUDAZ else None
 
     return PdpClient(
-        base_url=ctx.pdp_url or base_url,
-        auth_base_url=base_url,
+        base_url=pdp_url,
+        auth_base_url=auth_base_url,
         client_id=client_id,
         client_secret=ctx.client_secret,
         http_config=_http_config(ctx, account),
     )
+
+
+def _resolve_flavor(ctx: CliContext) -> PdpAuthSource:
+    if ctx.pdp_auth is not None:
+        return ctx.pdp_auth
+    return PdpAuthSource.CLOUDAZ if ctx.base_url else PdpAuthSource.PDP
+
+
+def _resolve_cloudaz_base_url(
+    ctx: CliContext,
+    account: ResolvedAccount | None,
+    flavor: PdpAuthSource,
+) -> str | None:
+    if flavor is not PdpAuthSource.CLOUDAZ:
+        return None
+    account_base_url = account.base_url if account else None
+    base_url = ctx.base_url or account_base_url
+    if base_url:
+        return base_url
+    prompted = _prompt_url_if_tty("CloudAz base URL")
+    if prompted:
+        return prompted
+    raise typer.BadParameter(_base_url_required_for_cloudaz_flavor())
+
+
+def _resolve_pdp_url(ctx: CliContext, flavor: PdpAuthSource) -> str:
+    if ctx.pdp_url:
+        return ctx.pdp_url
+    prompted = _prompt_url_if_tty("PDP base URL")
+    if prompted:
+        return prompted
+    raise typer.BadParameter(_pdp_url_required(flavor))

--- a/src/nextlabs_sdk/_cli/_context.py
+++ b/src/nextlabs_sdk/_cli/_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from nextlabs_sdk._cli._output_format import OutputFormat
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 
 
 @dataclass(frozen=True)
@@ -21,3 +22,4 @@ class CliContext:
     token: str | None = None
     cache_dir: str | None = None
     verbose: int = 0
+    pdp_auth: PdpAuthSource | None = None

--- a/src/nextlabs_sdk/_cli/_pdp_auth_source.py
+++ b/src/nextlabs_sdk/_cli/_pdp_auth_source.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class PdpAuthSource(str, Enum):
+    """Which OAuth token endpoint the PDP CLI commands should target.
+
+    - ``CLOUDAZ``: authenticate at ``/cas/token`` on the CloudAz host
+      (``--base-url``).
+    - ``PDP``: authenticate at ``/dpc/oauth`` on the PDP host
+      (``--pdp-url``).
+    """
+
+    CLOUDAZ = "cloudaz"
+    PDP = "pdp"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -149,6 +149,7 @@ def cli_runner(
         for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
             env.pop(proxy_var, None)
         env["NEXTLABS_BASE_URL"] = seeded_wiremock
+        env["NEXTLABS_PDP_URL"] = seeded_wiremock
         env["NEXTLABS_TOKEN"] = TEST_TOKEN
         env["NEXTLABS_CLIENT_SECRET"] = "e2e-client-secret"
         env["NEXTLABS_CACHE_DIR"] = str(tmp_path / "tokens.json")

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -15,6 +15,7 @@ from nextlabs_sdk._cli._account_resolver import ResolvedAccount
 from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output_format import OutputFormat
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._pdp._client import PdpClient
 
@@ -28,6 +29,8 @@ def _make_ctx(
     client_secret: str | None = "secret",
     verify: bool | None = None,
     cache_dir: str | None = None,
+    pdp_url: str | None = "https://pdp.example.com",
+    pdp_auth: PdpAuthSource | None = None,
 ) -> CliContext:
     return CliContext(
         base_url=base_url,
@@ -35,11 +38,12 @@ def _make_ctx(
         password=password,
         client_id=client_id,
         client_secret=client_secret,
-        pdp_url=None,
+        pdp_url=pdp_url,
         output_format=OutputFormat.TABLE,
         verify=verify,
         timeout=30.0,
         cache_dir=cache_dir,
+        pdp_auth=pdp_auth,
     )
 
 
@@ -66,19 +70,34 @@ def _make_ctx(
         ),
         pytest.param(
             _client_factory.make_pdp_client,
-            {"base_url": None},
-            "base-url",
-            id="pdp-base-url",
-        ),
-        pytest.param(
-            _client_factory.make_pdp_client,
             {"client_secret": None},
             "client-secret",
             id="pdp-client-secret",
         ),
+        pytest.param(
+            _client_factory.make_pdp_client,
+            {"pdp_url": None},
+            "pdp-url",
+            id="pdp-pdp-url",
+        ),
+        pytest.param(
+            _client_factory.make_pdp_client,
+            {"base_url": None, "pdp_url": None},
+            "pdp-url",
+            id="pdp-pdp-url-default-flavor-pdp",
+        ),
+        pytest.param(
+            _client_factory.make_pdp_client,
+            {"base_url": None, "pdp_auth": PdpAuthSource.CLOUDAZ},
+            "base-url",
+            id="pdp-cloudaz-flavor-needs-base-url",
+        ),
     ],
 )
-def test_factory_raises_when_required_field_missing(factory, kwargs, match):
+def test_factory_raises_when_required_field_missing(
+    factory, kwargs, match, monkeypatch
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
     with pytest.raises(typer.BadParameter, match=match):
         factory(_make_ctx(**kwargs))
 
@@ -436,3 +455,131 @@ def test_empty_password_falls_back_to_cached_refresh_token(
     _client_factory.make_cloudaz_client(ctx)
 
     assert captured["password"] is None
+
+
+# ─── PDP auth flavor (--pdp-auth) ──────────────────────────────────────────
+
+
+def _capture_pdp_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> PdpClient:
+        captured.update(kwargs)
+        return cast(PdpClient, object())
+
+    monkeypatch.setattr(_client_factory, "PdpClient", _capture)
+    return captured
+
+
+def test_pdp_default_flavor_is_cloudaz_when_base_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured = _capture_pdp_kwargs(monkeypatch)
+    _client_factory.make_pdp_client(_make_ctx())
+    assert captured["base_url"] == "https://pdp.example.com"
+    assert captured["auth_base_url"] == "https://example.com"
+
+
+def test_pdp_default_flavor_is_pdp_when_base_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured = _capture_pdp_kwargs(monkeypatch)
+    _client_factory.make_pdp_client(_make_ctx(base_url=None))
+    assert captured["base_url"] == "https://pdp.example.com"
+    assert captured["auth_base_url"] is None
+
+
+def test_pdp_explicit_flavor_pdp_overrides_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured = _capture_pdp_kwargs(monkeypatch)
+    _client_factory.make_pdp_client(_make_ctx(pdp_auth=PdpAuthSource.PDP))
+    assert captured["auth_base_url"] is None
+
+
+def test_pdp_explicit_flavor_cloudaz_requires_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+    with pytest.raises(typer.BadParameter, match="/cas/token"):
+        _client_factory.make_pdp_client(
+            _make_ctx(base_url=None, pdp_auth=PdpAuthSource.CLOUDAZ),
+        )
+
+
+def test_pdp_flavor_pdp_missing_pdp_url_mentions_dpc_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+    with pytest.raises(typer.BadParameter, match="/dpc/oauth"):
+        _client_factory.make_pdp_client(
+            _make_ctx(base_url=None, pdp_url=None),
+        )
+
+
+def test_pdp_flavor_cloudaz_missing_client_secret_mentions_cas_token(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+    with pytest.raises(typer.BadParameter, match="/cas/token"):
+        _client_factory.make_pdp_client(_make_ctx(client_secret=None))
+
+
+def test_pdp_flavor_pdp_missing_client_secret_mentions_dpc_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+    with pytest.raises(typer.BadParameter, match="/dpc/oauth"):
+        _client_factory.make_pdp_client(
+            _make_ctx(base_url=None, client_secret=None),
+        )
+
+
+def test_pdp_prompts_for_pdp_url_in_tty(monkeypatch: pytest.MonkeyPatch):
+    captured = _capture_pdp_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+    prompts: list[str] = []
+
+    def _fake_prompt(text: str, **_: object) -> str:
+        prompts.append(text)
+        return "https://prompted-pdp.example.com"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    _client_factory.make_pdp_client(_make_ctx(pdp_url=None))
+
+    assert captured["base_url"] == "https://prompted-pdp.example.com"
+    assert any("PDP" in p for p in prompts)
+
+
+def test_pdp_prompts_for_base_url_in_tty_when_cloudaz_flavor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured = _capture_pdp_kwargs(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+    prompts: list[str] = []
+
+    def _fake_prompt(text: str, **_: object) -> str:
+        prompts.append(text)
+        return "https://prompted-cloudaz.example.com"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    _client_factory.make_pdp_client(
+        _make_ctx(base_url=None, pdp_auth=PdpAuthSource.CLOUDAZ),
+    )
+
+    assert captured["auth_base_url"] == "https://prompted-cloudaz.example.com"
+    assert any("CloudAz" in p for p in prompts)
+
+
+def test_pdp_explicit_flavor_pdp_reaches_factory_via_cli(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """--pdp-auth pdp propagates into CliContext and make_pdp_client."""
+    captured = _capture_pdp_kwargs(monkeypatch)
+    ctx = _make_ctx(pdp_auth=PdpAuthSource.PDP)
+    _client_factory.make_pdp_client(ctx)
+    # With --pdp-auth pdp, base_url is ignored even when set.
+    assert captured["auth_base_url"] is None
+    assert captured["base_url"] == "https://pdp.example.com"

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -27,6 +27,8 @@ runner = CliRunner()
 _GLOBAL_OPTS = (
     "--base-url",
     "https://example.com",
+    "--pdp-url",
+    "https://pdp.example.com",
     "--client-secret",
     "my-secret",
 )
@@ -188,6 +190,8 @@ def test_pdp_eval_missing_credentials() -> None:
         [
             "--base-url",
             "https://example.com",
+            "--pdp-url",
+            "https://pdp.example.com",
             "pdp",
             "eval",
             "--subject",


### PR DESCRIPTION
Closes #52.

PDP commands (`nextlabs pdp eval`, `nextlabs pdp permissions`) now accept `--pdp-auth {cloudaz,pdp}` (env `NEXTLABS_PDP_AUTH`) to select the OAuth token endpoint:

- `cloudaz` → `/cas/token` on the CloudAz host (`--base-url`)
- `pdp` → `/dpc/oauth` on the PDP host (`--pdp-url`)

Default flavor: `cloudaz` when `--base-url` is set, else `pdp`. Explicit flag always wins.

Missing required URLs prompt in a TTY (mirroring the existing password prompt) and error in non-TTY sessions; the error names the exact endpoint the misconfiguration would have targeted.

**Breaking:** `--pdp-url` / `NEXTLABS_PDP_URL` is now always required for PDP commands. Previously it silently defaulted to `--base-url`. The new error message spells out what to set.

Help text for `--base-url` and `--pdp-url` clarified; README gains a PDP authentication section and the env table lists `NEXTLABS_PDP_AUTH`.

Builds on #51 (SDK-side `resolve_pdp_token_url`).

### Tests

- 10 new CLI factory tests covering: default flavors, explicit overrides, endpoint-aware errors for missing client-secret / base-url / pdp-url, and TTY prompt paths for both URLs.
- Existing CLI tests retrofitted to include `--pdp-url`.
- Full unit suite: 1769 passed, coverage 96.12%. All pre-commit hooks green.
