### PR TITLE
fix(cloudaz): send id_token as bearer credential per OIDC docs

### DIFF
--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -202,9 +202,21 @@ def _handle_refresh_failure(
 class CloudAzAuth(httpx.Auth):
     """OIDC password grant auth for the CloudAz Console API.
 
+    The OIDC token endpoint returns both ``access_token`` and
+    ``id_token``; per the CloudAz documentation, the ``id_token`` is the
+    value sent in the ``Authorization: Bearer …`` header. ``CloudAzAuth``
+    uses ``id_token`` as the bearer credential and keeps ``refresh_token``
+    for silent re-auth. When a token response omits ``id_token``
+    (non-conforming server) the SDK logs a warning and falls back to
+    ``access_token`` for transport continuity.
+
     Supports an optional pluggable :class:`TokenCache` backend. Expiry is
     tracked as absolute UTC epoch seconds so that cached tokens survive
-    process restarts.
+    process restarts. Cache entries written by older SDK versions that
+    predate ``id_token`` support are restored without the bearer in
+    memory, so the next call silently refreshes and repopulates the
+    cache — a usable ``refresh_token`` is preserved to avoid an
+    interactive re-login.
 
     When ``refresh_token_lifetime`` is provided, the SDK records the
     refresh token's absolute expiry at every successful token
@@ -235,7 +247,8 @@ class CloudAzAuth(httpx.Auth):
         self._lock = threading.Lock()
         self.refresh_token_lifetime: int | None = None
 
-        self._token: str | None = None
+        self._id_token: str | None = None
+        self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._refresh_expires_at: float | None = None
         self._expires_at: float = _INITIAL_EXPIRY_AT
@@ -244,11 +257,12 @@ class CloudAzAuth(httpx.Auth):
         if cached is not None:
             self._refresh_token = cached.refresh_token
             self._refresh_expires_at = cached.refresh_expires_at
-            if not cached.is_expired(
+            if cached.id_token is not None and not cached.is_expired(
                 now=time.time(),
                 safety_margin=_EXPIRY_SAFETY_MARGIN,
             ):
-                self._token = cached.access_token
+                self._id_token = cached.id_token
+                self._access_token = cached.access_token
                 self._expires_at = cached.expires_at
 
     def auth_flow(
@@ -258,12 +272,12 @@ class CloudAzAuth(httpx.Auth):
         if not self._has_valid_token():
             yield from self._reauthenticate()
 
-        request.headers["Authorization"] = f"Bearer {self._token}"
+        request.headers["Authorization"] = f"Bearer {self._id_token}"
         response = yield request
 
         if response.status_code == _UNAUTHORIZED_STATUS or _is_spa_redirect(response):
             yield from self._reauthenticate()
-            request.headers["Authorization"] = f"Bearer {self._token}"
+            request.headers["Authorization"] = f"Bearer {self._id_token}"
             retried = yield request
             if _is_spa_redirect(retried):
                 raise AuthenticationError(
@@ -333,7 +347,7 @@ class CloudAzAuth(httpx.Auth):
 
     def _has_valid_token(self) -> bool:
         with self._lock:
-            return self._token is not None and time.time() < self._expires_at
+            return self._id_token is not None and time.time() < self._expires_at
 
     def _reauthenticate(self) -> Generator[httpx.Request, httpx.Response, None]:
         decision = self._refresh_decision()
@@ -457,6 +471,16 @@ class CloudAzAuth(httpx.Auth):
             error_cls=AuthenticationError,
             context=" in token response",
         )
+        id_token_raw = body.get("id_token")
+        if isinstance(id_token_raw, str):
+            id_token = id_token_raw
+        else:
+            logger.warning(
+                "cloudaz auth: token response missing id_token;"
+                " falling back to access_token. The server is not"
+                " conforming to the CloudAz OIDC contract.",
+            )
+            id_token = access_token
         refresh_token_raw = body.get("refresh_token")
         refresh_token = (
             refresh_token_raw
@@ -474,7 +498,8 @@ class CloudAzAuth(httpx.Auth):
         )
 
         with self._lock:
-            self._token = access_token
+            self._id_token = id_token
+            self._access_token = access_token
             self._refresh_token = refresh_token
             self._expires_at = expires_at
             self._refresh_expires_at = refresh_expires_at
@@ -487,6 +512,7 @@ class CloudAzAuth(httpx.Auth):
                 expires_at=expires_at,
                 token_type=token_type,
                 scope=scope,
+                id_token=id_token,
                 refresh_expires_at=refresh_expires_at,
             ),
         )

--- a/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
@@ -43,11 +43,17 @@ class CachedToken:
     """A persisted OIDC token.
 
     Attributes:
-        access_token: The OAuth2 access_token used as the bearer credential.
+        access_token: The OAuth2 access_token returned by the token
+            endpoint. Retained for diagnostics and refresh flows;
+            CloudAz requests now authenticate with ``id_token``.
         refresh_token: Optional refresh_token for silent re-auth.
         expires_at: Absolute UTC epoch seconds at which the token expires.
         token_type: OAuth token type (typically ``"bearer"``).
         scope: Optional OAuth scope string.
+        id_token: OIDC ``id_token`` sent as the bearer credential on
+            CloudAz API requests. ``None`` on cache entries written by
+            older SDK versions; callers should treat such entries as
+            expired and trigger a refresh.
         refresh_expires_at: Absolute UTC epoch seconds at which the
             refresh token is considered expired, or ``None`` when the
             SDK has no information (reactive mode).
@@ -58,6 +64,7 @@ class CachedToken:
     expires_at: float
     token_type: str
     scope: str | None
+    id_token: str | None = None
     refresh_expires_at: float | None = None
 
     def is_expired(
@@ -79,6 +86,7 @@ class CachedToken:
             "expires_at": self.expires_at,
             "token_type": self.token_type,
             "scope": self.scope,
+            "id_token": self.id_token,
             "refresh_expires_at": self.refresh_expires_at,
         }
 
@@ -99,6 +107,7 @@ class CachedToken:
             raise TypeError("expires_at must be a number")
         token_type = _require(payload, "token_type", str)
         scope = _optional(payload, "scope", str)
+        id_token = _optional(payload, "id_token", str)
         refresh_expires_at_raw = payload.get("refresh_expires_at")
         refresh_expires_at = _coerce_refresh_expires_at(refresh_expires_at_raw)
 
@@ -106,6 +115,7 @@ class CachedToken:
         assert refresh_token is None or isinstance(refresh_token, str)
         assert isinstance(token_type, str)
         assert scope is None or isinstance(scope, str)
+        assert id_token is None or isinstance(id_token, str)
 
         return cls(
             access_token=access_token,
@@ -113,5 +123,6 @@ class CachedToken:
             expires_at=float(expires_at_raw),
             token_type=token_type,
             scope=scope,
+            id_token=id_token,
             refresh_expires_at=refresh_expires_at,
         )

--- a/tests/e2e/test_token_cache_persistence.py
+++ b/tests/e2e/test_token_cache_persistence.py
@@ -91,6 +91,9 @@ def test_login_then_reuse_cached_token(
     assert cache_file.exists(), f"expected cache at {cache_file}"
     cache_payload = json.loads(cache_file.read_text())
     assert cache_payload, "cache file should contain at least one entry"
+    cache_entry = next(iter(cache_payload.values()))
+    assert cache_entry["id_token"] == "id-e2e-1"
+    assert cache_entry["access_token"] == "at-e2e-1"
 
     assert _oidc_call_count(oidc_stub) == 1
 

--- a/tests/test_cached_token.py
+++ b/tests/test_cached_token.py
@@ -35,6 +35,7 @@ def _make_token(**overrides: Any) -> CachedToken:
         pytest.param(
             {"refresh_expires_at": 1_700_003_600.0}, id="with-refresh-expires"
         ),
+        pytest.param({"id_token": "id-jwt"}, id="with-id-token"),
     ],
 )
 def test_roundtrip_to_dict_and_back(overrides):
@@ -54,6 +55,15 @@ def test_from_dict_tolerates_missing_optional_fields():
     assert restored.refresh_token is None
     assert restored.scope is None
     assert restored.refresh_expires_at is None
+    assert restored.id_token is None
+
+
+def test_to_dict_includes_id_token():
+    token = _make_token(id_token="id-jwt-value")
+
+    payload = token.to_dict()
+
+    assert payload["id_token"] == "id-jwt-value"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -41,19 +41,27 @@ def _make_auth(
     return auth
 
 
+_UNSET: Any = object()
+
+
 def _make_token_response(
     access_token: str = "test-access-token",
     expires_in: int = 1200,
+    id_token: Any = _UNSET,
+    refresh_token: str = "RT-unused",
+    include_id_token: bool = True,
 ) -> httpx.Response:
+    body: dict[str, Any] = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_in": expires_in,
+        "token_type": "bearer",
+    }
+    if include_id_token:
+        body["id_token"] = access_token if id_token is _UNSET else id_token
     return httpx.Response(
         200,
-        json={
-            "access_token": access_token,
-            "id_token": "ID-unused",
-            "refresh_token": "RT-unused",
-            "expires_in": expires_in,
-            "token_type": "bearer",
-        },
+        json=body,
         request=httpx.Request("POST", TOKEN_URL),
     )
 
@@ -208,6 +216,7 @@ def _cached(
     refresh_token: str | None = "RT-1",
     expires_at: float | None = None,
     refresh_expires_at: float | None = None,
+    id_token: Any = _UNSET,
 ) -> CachedToken:
     return CachedToken(
         access_token=access_token,
@@ -215,6 +224,7 @@ def _cached(
         expires_at=float(0) if expires_at is None else expires_at,
         token_type="bearer",
         scope=None,
+        id_token=access_token if id_token is _UNSET else id_token,
         refresh_expires_at=refresh_expires_at,
     )
 
@@ -510,7 +520,7 @@ def test_ensure_token_uses_password_grant_when_no_refresh():
     assert len(sent) == 1
     assert str(sent[0].url) == TOKEN_URL
     assert "grant_type=password" in sent[0].content.decode()
-    assert auth._token == "fresh"
+    assert auth._id_token == "fresh"
 
 
 def test_ensure_token_prefers_refresh_token_when_available():
@@ -524,7 +534,7 @@ def test_ensure_token_prefers_refresh_token_when_available():
     body = sent[0].content.decode()
     assert "grant_type=refresh_token" in body
     assert "refresh_token=RT-cached" in body
-    assert auth._token == "refreshed"
+    assert auth._id_token == "refreshed"
 
 
 def test_ensure_token_falls_back_to_password_when_refresh_fails():
@@ -543,7 +553,7 @@ def test_ensure_token_falls_back_to_password_when_refresh_fails():
     assert len(sent) == 2
     assert "grant_type=refresh_token" in sent[0].content.decode()
     assert "grant_type=password" in sent[1].content.decode()
-    assert auth._token == "pwd-grant"
+    assert auth._id_token == "pwd-grant"
 
 
 def test_ensure_token_raises_when_no_password_and_refresh_fails():
@@ -582,7 +592,7 @@ def test_ensure_token_async_fetches_and_caches():
     asyncio.run(auth.ensure_token_async(send))
 
     assert len(sent) == 1
-    assert auth._token == "async-fresh"
+    assert auth._id_token == "async-fresh"
 
 
 # ─────────────── Proactive refresh-token-lifetime tracking ───────────────
@@ -724,3 +734,77 @@ def test_logs_warning_on_terminal_refresh_failure(caplog: pytest.LogCaptureFixtu
     assert any("refresh token rejected" in r.getMessage().lower() for r in warnings)
     for record in caplog.records:
         assert "RT-dead" not in record.getMessage()
+
+
+# ────────────────────────── id_token bearer (OIDC) ──────────────────────────
+
+
+def test_authorization_header_uses_id_token_not_access_token():
+    when(time).time().thenReturn(float(0))
+    auth = _make_auth()
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+    api_request = flow.send(
+        _make_token_response(access_token="AT-value", id_token="IDT-value"),
+    )
+
+    assert api_request.headers["Authorization"] == "Bearer IDT-value"
+    assert "AT-value" not in api_request.headers["Authorization"]
+
+
+def test_cache_persists_both_access_and_id_token():
+    when(time).time().thenReturn(100.0)
+    cache = _InMemoryTokenCache()
+    auth = _make_auth(token_cache=cache)
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+    flow.send(_make_token_response(access_token="AT-1", id_token="IDT-1"))
+
+    saved = cache.entries[_DERIVED_KEY]
+    assert saved.access_token == "AT-1"
+    assert saved.id_token == "IDT-1"
+
+
+def test_response_missing_id_token_falls_back_to_access_token_with_warning(
+    caplog: pytest.LogCaptureFixture,
+):
+    when(time).time().thenReturn(float(0))
+    auth = _make_auth()
+    caplog.set_level(logging.WARNING, logger="nextlabs_sdk")
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+    api_request = flow.send(
+        _make_token_response(access_token="AT-only", include_id_token=False),
+    )
+
+    assert api_request.headers["Authorization"] == "Bearer AT-only"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("missing id_token" in r.getMessage().lower() for r in warnings)
+
+
+def test_legacy_cache_without_id_token_triggers_silent_refresh_not_relogin():
+    when(time).time().thenReturn(100.0)
+    cache = _InMemoryTokenCache()
+    cache.entries[_DERIVED_KEY] = _cached(
+        access_token="legacy-at",
+        refresh_token="RT-legacy",
+        expires_at=10_000.0,
+        id_token=None,
+    )
+    auth = _make_auth(password=None, token_cache=cache)
+
+    flow = auth.auth_flow(_api_request())
+    token_req = next(flow)
+
+    body = bytes(token_req.content).decode()
+    assert "grant_type=refresh_token" in body
+    assert "refresh_token=RT-legacy" in body
+
+    api_request = flow.send(
+        _make_token_response(access_token="AT-new", id_token="IDT-new"),
+    )
+    assert api_request.headers["Authorization"] == "Bearer IDT-new"
+    assert cache.entries[_DERIVED_KEY].id_token == "IDT-new"


### PR DESCRIPTION
Closes #53.

The CloudAz OIDC docs require the `id_token` (not `access_token`) as the
`Authorization: Bearer …` credential. `CloudAzAuth` now:

- extracts `id_token` from the token endpoint response and uses it on
  all CloudAz API requests;
- persists both `access_token` and `id_token` in the cache (refresh
  flow semantics are unchanged);
- falls back to `access_token` with a warning log when a server
  response omits `id_token` (non-conforming servers still work, but the
  drift is visible).

### Backward compatibility

Cache entries written by older SDK versions load with `id_token=None`.
`CloudAzAuth` treats such entries as needing refresh but preserves the
`refresh_token`. On the next CloudAz call, users will see exactly **one
silent refresh** — no interactive re-login is required.

### Tests

- Updated the token-response fixture to default `id_token` to the
  `access_token` value; existing assertions still hold.
- New unit tests:
  - `Authorization` header uses `id_token`, not `access_token`.
  - Cache persists both `access_token` and `id_token`.
  - Missing `id_token` → warning + lenient fallback to `access_token`.
  - Legacy cache without `id_token` triggers a silent refresh (not
    interactive re-login).
- Extended `CachedToken` round-trip coverage for the new field.
- e2e: asserts `id_token` is written to the persisted cache.

### Sync / async parity

`CloudAzAuth` is a single `httpx.Auth` used by both sync and async
clients; `_parse_token_response` is shared, so one change covers both.

### Out of scope

PDP auth (#51, #52); no server-side changes.