### PR TITLE
feat(cli): auth login --type {cloudaz,pdp} for persistent PDP credentials

### DIFF
--- a/.github/workflows/pr_labeling.yml
+++ b/.github/workflows/pr_labeling.yml
@@ -30,9 +30,8 @@ jobs:
     needs:
       - pr_title_check
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter/autolabeler@v7
         with:
-          disable-releaser: true
           config-name: pr_autolabeling_config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -409,6 +409,30 @@ nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
   pdp eval ...
 ```
 
+#### Register a PDP account once with `auth login --type pdp`
+
+You can also persist the PDP client credentials in the token cache so
+subsequent `nextlabs pdp …` calls do not need `--client-secret`,
+`--pdp-url`, or `--pdp-auth` on every invocation:
+
+```bash
+# One-time login — mints a token, caches it alongside the client_secret,
+# and stores pdp_url / pdp_auth as preferences for this account.
+nextlabs auth login --type pdp \
+  --pdp-url https://pdp.example --client-id my-client \
+  --client-secret "$SECRET" --pdp-auth pdp
+
+# Later commands reuse the cached credentials automatically.
+nextlabs pdp eval --subject alice --resource doc-42 \
+  --resource-type document --action read
+```
+
+PDP entries appear in `nextlabs auth accounts` with kind `pdp` and an
+empty username; target them explicitly with
+`nextlabs auth use "[pdp]@https://pdp.example"`. Running
+`nextlabs auth logout` clears the cached token, preferences, and active
+pointer for the selected account.
+
 **Environment variables**
 
 | Variable                   | Purpose                                                       |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,6 +42,30 @@ and retries the command transparently. In non-interactive contexts
 `nextlabs auth login` again. Run `nextlabs auth status` to confirm
 the new cached entry is `Refreshable: yes`.
 
+## PDP commands keep prompting for `--client-secret` / `--pdp-url`
+
+**Symptom:** every `nextlabs pdp …` call needs `--client-secret`,
+`--pdp-url`, and `--pdp-auth` again, even after a successful run.
+
+**Cause:** PDP commands use OAuth *client-credentials*, not
+username/password. Until the PDP credentials are registered in the
+local cache, the CLI has nowhere to recover them from.
+
+**Fix:** register the account once with `auth login --type pdp`.
+
+```bash
+nextlabs auth login --type pdp \
+  --pdp-url https://pdp.example --client-id my-client \
+  --client-secret "$SECRET" --pdp-auth pdp
+```
+
+The CLI mints a token, caches the `client_secret` alongside it, and
+persists `pdp_url` + `pdp_auth` as account preferences. Subsequent
+`nextlabs pdp …` invocations reuse all three transparently. Rotate
+the secret by re-running `auth login --type pdp` with the new value;
+clear the entry with `nextlabs auth logout` (after
+`nextlabs auth use "[pdp]@<pdp-url>"` if it is not already active).
+
 ## SSL verification failures against an internal CloudAz instance
 
 **Symptom:**

--- a/src/nextlabs_sdk/_auth/_active_account/_active_account.py
+++ b/src/nextlabs_sdk/_auth/_active_account/_active_account.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
+
+_KIND_CLOUDAZ = "cloudaz"
+_KIND_PDP = "pdp"
+_VALID_KINDS = (_KIND_CLOUDAZ, _KIND_PDP)
 
 
 @dataclass(frozen=True)
@@ -10,12 +15,14 @@ class ActiveAccount:
     base_url: str
     username: str
     client_id: str
+    kind: str = _KIND_CLOUDAZ
 
     def to_dict(self) -> dict[str, str]:
         return {
             "base_url": self.base_url,
             "username": self.username,
             "client_id": self.client_id,
+            "kind": self.kind,
         }
 
     @classmethod
@@ -23,12 +30,32 @@ class ActiveAccount:
         base_url = payload["base_url"]
         username = payload["username"]
         client_id = payload["client_id"]
-        if not (
-            isinstance(base_url, str)
-            and isinstance(username, str)
-            and isinstance(client_id, str)
-        ):
+        kind = payload.get("kind", _KIND_CLOUDAZ)
+        _validate_fields(base_url, username, client_id, kind)
+        return cls(
+            base_url=cast(str, base_url),
+            username=cast(str, username),
+            client_id=cast(str, client_id),
+            kind=cast(str, kind),
+        )
+
+
+def _validate_fields(
+    base_url: object,
+    username: object,
+    client_id: object,
+    kind: object,
+) -> None:
+    _require_strings(base_url, username, client_id, kind)
+    if kind not in _VALID_KINDS:
+        raise ValueError(f"ActiveAccount.kind must be one of {_VALID_KINDS}")
+    if not (base_url and client_id):
+        raise ValueError("ActiveAccount base_url and client_id must be non-empty")
+    if kind == _KIND_CLOUDAZ and not username:
+        raise ValueError("ActiveAccount.username must be non-empty for kind=cloudaz")
+
+
+def _require_strings(*fields: object) -> None:
+    for field in fields:
+        if not isinstance(field, str):
             raise ValueError("ActiveAccount fields must be strings")
-        if not (base_url and username and client_id):
-            raise ValueError("ActiveAccount fields must be non-empty")
-        return cls(base_url=base_url, username=username, client_id=client_id)

--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -243,7 +243,7 @@ class CloudAzAuth(httpx.Auth):
         self._password = password
         self._client_id = client_id
         self._cache: TokenCache = token_cache or NullTokenCache()
-        self._cache_key = f"{token_url}|{username}|{client_id}"
+        self._cache_key = f"{token_url}|{username}|{client_id}|cloudaz"
         self._lock = threading.Lock()
         self.refresh_token_lifetime: int | None = None
 

--- a/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from typing import TypeAlias, cast
 
 _DEFAULT_SAFETY_MARGIN = 60
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
+
+_OptStr: TypeAlias = "str | None"
 
 
 def _require(payload: dict[str, object], key: str, expected: type) -> object:
@@ -57,6 +60,10 @@ class CachedToken:
         refresh_expires_at: Absolute UTC epoch seconds at which the
             refresh token is considered expired, or ``None`` when the
             SDK has no information (reactive mode).
+        client_secret: Optional OAuth2 client_secret persisted alongside
+            the token so PDP accounts can mint a fresh token silently
+            without re-prompting. Stored plain in ``tokens.json``
+            (mode 0600), mirroring ``refresh_token``.
     """
 
     access_token: str
@@ -66,6 +73,7 @@ class CachedToken:
     scope: str | None
     id_token: str | None = None
     refresh_expires_at: float | None = None
+    client_secret: str | None = None
 
     def is_expired(
         self,
@@ -88,6 +96,7 @@ class CachedToken:
             "scope": self.scope,
             "id_token": self.id_token,
             "refresh_expires_at": self.refresh_expires_at,
+            "client_secret": self.client_secret,
         }
 
     @classmethod
@@ -110,19 +119,15 @@ class CachedToken:
         id_token = _optional(payload, "id_token", str)
         refresh_expires_at_raw = payload.get("refresh_expires_at")
         refresh_expires_at = _coerce_refresh_expires_at(refresh_expires_at_raw)
-
-        assert isinstance(access_token, str)
-        assert refresh_token is None or isinstance(refresh_token, str)
-        assert isinstance(token_type, str)
-        assert scope is None or isinstance(scope, str)
-        assert id_token is None or isinstance(id_token, str)
+        client_secret = _optional(payload, "client_secret", str)
 
         return cls(
-            access_token=access_token,
-            refresh_token=refresh_token,
+            access_token=cast(str, access_token),
+            refresh_token=cast(_OptStr, refresh_token),
             expires_at=float(expires_at_raw),
-            token_type=token_type,
-            scope=scope,
-            id_token=id_token,
+            token_type=cast(str, token_type),
+            scope=cast(_OptStr, scope),
+            id_token=cast(_OptStr, id_token),
             refresh_expires_at=refresh_expires_at,
+            client_secret=cast(_OptStr, client_secret),
         )

--- a/src/nextlabs_sdk/_cli/_account_menu.py
+++ b/src/nextlabs_sdk/_cli/_account_menu.py
@@ -17,6 +17,7 @@ class AccountIdentifier:
     base_url: str
     username: str
     client_id: str
+    kind: str = "cloudaz"
 
 
 def parse_cache_key(key: str) -> AccountIdentifier | None:
@@ -24,11 +25,12 @@ def parse_cache_key(key: str) -> AccountIdentifier | None:
     parsed = _parse_cache_key(key)
     if parsed is None:
         return None
-    base_url, username, client_id = parsed
+    base_url, username, client_id, kind = parsed
     return AccountIdentifier(
         base_url=base_url,
         username=username,
         client_id=client_id,
+        kind=kind,
     )
 
 
@@ -54,7 +56,8 @@ def select_account(
     """
     typer.echo("Cached accounts:")
     for idx, account in enumerate(accounts, start=1):
-        typer.echo(f"  {idx}) {account.username} @ {account.base_url}")
+        label = _account_label(account)
+        typer.echo(f"  {idx}) {label}")
     if add_new_label:
         add_new_idx = len(accounts) + 1
         typer.echo(f"  {add_new_idx}) {add_new_label}")
@@ -69,3 +72,9 @@ def select_account(
     if add_new_label and choice == len(accounts) + 1:
         return None
     return accounts[choice - 1]
+
+
+def _account_label(account: AccountIdentifier) -> str:
+    if account.kind == "pdp":
+        return f"[pdp] @ {account.base_url}"
+    return f"{account.username} @ {account.base_url}"

--- a/src/nextlabs_sdk/_cli/_account_preferences.py
+++ b/src/nextlabs_sdk/_cli/_account_preferences.py
@@ -14,6 +14,15 @@ def _check_schema_version(payload: dict[str, object]) -> None:
         )
 
 
+def _optional_str(payload: dict[str, object], key: str) -> str | None:
+    entry = payload.get(key)
+    if entry is None:
+        return None
+    if not isinstance(entry, str):
+        raise TypeError(f"{key} must be str or None")
+    return entry
+
+
 @dataclass(frozen=True)
 class AccountPreferences:
     """Per-account CLI preferences persisted alongside the token cache.
@@ -21,14 +30,23 @@ class AccountPreferences:
     Attributes:
         verify_ssl: Whether the CLI should verify TLS certificates for
             this account by default.
+        pdp_url: Optional PDP base URL registered for this account via
+            ``auth login --type pdp``. ``None`` for CloudAz accounts.
+        pdp_auth_source: Optional PDP token-endpoint flavor registered
+            for this account (``"cloudaz"`` or ``"pdp"``). ``None`` for
+            CloudAz accounts.
     """
 
     verify_ssl: bool
+    pdp_url: str | None = None
+    pdp_auth_source: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
             "schema_version": _SCHEMA_VERSION,
             "verify_ssl": self.verify_ssl,
+            "pdp_url": self.pdp_url,
+            "pdp_auth_source": self.pdp_auth_source,
         }
 
     @classmethod
@@ -37,4 +55,8 @@ class AccountPreferences:
         verify_ssl = payload.get("verify_ssl")
         if not isinstance(verify_ssl, bool):
             raise TypeError("verify_ssl must be a bool")
-        return cls(verify_ssl=verify_ssl)
+        return cls(
+            verify_ssl=verify_ssl,
+            pdp_url=_optional_str(payload, "pdp_url"),
+            pdp_auth_source=_optional_str(payload, "pdp_auth_source"),
+        )

--- a/src/nextlabs_sdk/_cli/_account_resolver.py
+++ b/src/nextlabs_sdk/_cli/_account_resolver.py
@@ -7,6 +7,7 @@ from nextlabs_sdk._auth._active_account._active_account_store import (
     ActiveAccountStore,
 )
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._context import CliContext
 
@@ -18,6 +19,7 @@ class ResolvedAccount:
     base_url: str
     username: str
     client_id: str
+    kind: str = "cloudaz"
 
 
 def build_active_store(ctx: CliContext) -> ActiveAccountStore:
@@ -41,7 +43,34 @@ def build_prefs_store(ctx: CliContext) -> AccountPreferencesStore:
 
 
 def prefs_key_for(account: ResolvedAccount) -> str:
+    return f"{account.base_url}|{account.username}|{account.client_id}|{account.kind}"
+
+
+def _legacy_prefs_key_for(account: ResolvedAccount) -> str | None:
+    """Legacy 3-segment prefs key for CloudAz accounts (pre-#58)."""
+    if account.kind != "cloudaz":
+        return None
     return f"{account.base_url}|{account.username}|{account.client_id}"
+
+
+def load_account_prefs(
+    store: AccountPreferencesStore,
+    account: ResolvedAccount,
+) -> AccountPreferences | None:
+    """Load prefs for ``account``, falling back to the legacy 3-segment key.
+
+    Pre-#58 CloudAz installs wrote prefs under a 3-segment key
+    (``<base_url>|<username>|<client_id>``). New writes use the 4-segment
+    key; this helper lets existing users upgrade without losing their
+    persisted ``verify_ssl`` preference.
+    """
+    entry = store.load(prefs_key_for(account))
+    if entry is not None:
+        return entry
+    legacy = _legacy_prefs_key_for(account)
+    if legacy is None:
+        return None
+    return store.load(legacy)
 
 
 def resolve_account(ctx: CliContext) -> ResolvedAccount | None:
@@ -53,10 +82,12 @@ def resolve_account(ctx: CliContext) -> ResolvedAccount | None:
     3. ``None`` when nothing is available — caller surfaces guidance.
 
     When the resolver falls back to the active-account pointer, the
-    pointer's ``client_id`` is used so that non-default client IDs chosen
-    at login time keep working without re-passing ``--client-id`` on every
-    command. When both ``base_url`` and ``username`` are explicit, the
-    resolver returns ``ctx.client_id`` directly.
+    pointer's ``client_id`` and ``kind`` are used so that non-default
+    values chosen at login time keep working without re-passing
+    ``--client-id`` on every command. When both ``base_url`` and
+    ``username`` are explicit, the resolver returns ``ctx.client_id``
+    directly with the default ``kind="cloudaz"`` (explicit CloudAz
+    flags never resolve to a PDP account).
 
     This function does **not** consider ``ctx.token``; callers that honour
     pre-issued tokens should bypass the resolver entirely.
@@ -79,4 +110,5 @@ def resolve_account(ctx: CliContext) -> ResolvedAccount | None:
         base_url=base_url or pointer.base_url,
         username=username or pointer.username,
         client_id=pointer.client_id,
+        kind=pointer.kind,
     )

--- a/src/nextlabs_sdk/_cli/_account_status_label.py
+++ b/src/nextlabs_sdk/_cli/_account_status_label.py
@@ -1,0 +1,45 @@
+"""Labels for cached-token status in the ``auth status`` output."""
+
+from __future__ import annotations
+
+import time
+
+from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._cli._expiry_format import format_expiry
+
+_STATUS_NONE = "—"
+
+
+def account_status_and_refreshable(entry: CachedToken | None) -> tuple[str, str]:
+    return _status_label(entry), _refreshable_label(entry)
+
+
+def _status_label(entry: CachedToken | None) -> str:
+    if entry is None:
+        return "no cached token"
+    qualifier = "expired" if entry.is_expired() else "valid"
+    parts = [f"{qualifier} (expires {format_expiry(entry.expires_at)}"]
+    if entry.refresh_expires_at is not None:
+        parts.append(f"; refresh expires {format_expiry(entry.refresh_expires_at)}")
+    parts.append(")")
+    return "".join(parts)
+
+
+def _refreshable_label(entry: CachedToken | None) -> str:
+    if entry is None:
+        return _STATUS_NONE
+    return _refresh_decision_label(entry)
+
+
+def _refresh_decision_label(entry: CachedToken) -> str:
+    decision = decide(
+        refresh_token=entry.refresh_token,
+        refresh_expires_at=entry.refresh_expires_at,
+        now=time.time(),
+    )
+    if decision is RefreshDecision.USE_REFRESH:
+        return "yes"
+    if decision is RefreshDecision.KNOWN_EXPIRED:
+        return "no (expired)"
+    return "no"

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import time
 from dataclasses import replace
 from typing import Annotated
 
@@ -11,9 +10,8 @@ from rich.console import Console
 from rich.table import Table
 
 from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
-from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
-from nextlabs_sdk._cli import _client_factory
+from nextlabs_sdk._cli import _client_factory, _pdp_login
 from nextlabs_sdk._cli._account_menu import (
     AccountIdentifier,
     cache_key_for,
@@ -26,10 +24,12 @@ from nextlabs_sdk._cli._account_resolver import (
     build_file_cache,
     build_prefs_store,
 )
+from nextlabs_sdk._cli._account_status_label import account_status_and_refreshable
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._expiry_format import format_expiry
 from nextlabs_sdk._cli._output import print_success
+
 
 auth_app = typer.Typer(help="Authentication commands")
 
@@ -71,8 +71,8 @@ def _resolve_kind(type_arg: str | None) -> str:
 
 
 def _login_pdp(cli_ctx: CliContext) -> None:
-    """Register a PDP account (client-credentials flow). Stub — Task 5."""
-    raise NotImplementedError("PDP login not yet implemented")
+    """Thin delegator so tests can patch the PDP login flow."""
+    _pdp_login.login_pdp(cli_ctx)
 
 
 def _apply_menu_defaults(
@@ -152,46 +152,12 @@ def _is_active(cli_ctx: CliContext, account: AccountIdentifier) -> bool:
     )
 
 
-def _refresh_decision_for_entry(entry: CachedToken) -> RefreshDecision:
-    return decide(
-        refresh_token=entry.refresh_token,
-        refresh_expires_at=entry.refresh_expires_at,
-        now=time.time(),
-    )
-
-
-def _refreshable_label(entry: CachedToken) -> str:
-    decision = _refresh_decision_for_entry(entry)
-    if decision is RefreshDecision.USE_REFRESH:
-        return "yes"
-    if decision is RefreshDecision.KNOWN_EXPIRED:
-        return "no (expired)"
-    return "no"
-
-
-def _account_status_label(entry: CachedToken | None) -> str:
-    if entry is None:
-        return "no cached token"
-    qualifier = "expired" if entry.is_expired() else "valid"
-    parts = [f"{qualifier} (expires {format_expiry(entry.expires_at)}"]
-    if entry.refresh_expires_at is not None:
-        parts.append(f"; refresh expires {format_expiry(entry.refresh_expires_at)}")
-    parts.append(")")
-    return "".join(parts)
-
-
-def _account_refreshable_label(entry: CachedToken | None) -> str:
-    if entry is None:
-        return _STATUS_NONE
-    return _refreshable_label(entry)
-
-
 def _account_status_and_refreshable(
     cli_ctx: CliContext,
     account: AccountIdentifier,
 ) -> tuple[str, str]:
     entry = build_file_cache(cli_ctx).load(cache_key_for(account))
-    return _account_status_label(entry), _account_refreshable_label(entry)
+    return account_status_and_refreshable(entry)
 
 
 def _render_accounts_table(
@@ -350,7 +316,7 @@ def _build_status_table(
         ("Status", status_text),
         ("Expires", format_expiry(entry.expires_at)),
         ("Refresh expires", refresh_text),
-        ("Refreshable", _refreshable_label(entry)),
+        ("Refreshable", account_status_and_refreshable(entry)[1]),
     )
     table = Table(title=_STATUS_TITLE, show_header=False)
     table.add_column("Field")

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -88,6 +88,7 @@ def _set_active(cli_ctx: CliContext, account: AccountIdentifier) -> None:
             base_url=account.base_url,
             username=account.username,
             client_id=account.client_id,
+            kind=account.kind,
         ),
     )
 
@@ -107,6 +108,7 @@ def _resolve_active_target(cli_ctx: CliContext) -> AccountIdentifier:
         base_url=pointer.base_url,
         username=pointer.username,
         client_id=pointer.client_id,
+        kind=pointer.kind,
     )
 
 
@@ -118,6 +120,7 @@ def _is_active(cli_ctx: CliContext, account: AccountIdentifier) -> bool:
         pointer.base_url == account.base_url
         and pointer.username == account.username
         and pointer.client_id == account.client_id
+        and pointer.kind == account.kind
     )
 
 
@@ -266,7 +269,7 @@ def login(ctx: typer.Context) -> None:
 
 
 def _prefs_key(account: AccountIdentifier) -> str:
-    return f"{account.base_url}|{account.username}|{account.client_id}"
+    return f"{account.base_url}|{account.username}|{account.client_id}|{account.kind}"
 
 
 def _save_prefs(cli_ctx: CliContext, account: AccountIdentifier) -> None:

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sys
 import time
 from dataclasses import replace
 from typing import Annotated
 
+import click
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -45,6 +47,32 @@ _STATUS_ALL_OPTION = typer.Option(
 _USE_SELECTOR_ARGUMENT = typer.Argument(
     help="1-based index, or username@base_url. Omit for an interactive menu.",
 )
+_LOGIN_TYPE_OPTION = typer.Option(
+    "--type",
+    help="Account type to register: 'cloudaz' (default) or 'pdp'.",
+)
+_KIND_CLOUDAZ = "cloudaz"
+_KIND_PDP = "pdp"
+_VALID_LOGIN_KINDS = (_KIND_CLOUDAZ, _KIND_PDP)
+
+
+def _resolve_kind(type_arg: str | None) -> str:
+    if type_arg in _VALID_LOGIN_KINDS:
+        return type_arg
+    if type_arg is None:
+        if sys.stdin.isatty():
+            return typer.prompt(
+                "Account type",
+                type=click.Choice(list(_VALID_LOGIN_KINDS)),
+                default=_KIND_CLOUDAZ,
+            )
+        return _KIND_CLOUDAZ
+    raise typer.BadParameter("--type must be 'cloudaz' or 'pdp'")
+
+
+def _login_pdp(cli_ctx: CliContext) -> None:
+    """Register a PDP account (client-credentials flow). Stub — Task 5."""
+    raise NotImplementedError("PDP login not yet implemented")
 
 
 def _apply_menu_defaults(
@@ -252,9 +280,16 @@ def test_auth(ctx: typer.Context) -> None:
 
 @auth_app.command(name="login")
 @cli_error_handler
-def login(ctx: typer.Context) -> None:
+def login(
+    ctx: typer.Context,
+    type_: Annotated[str | None, _LOGIN_TYPE_OPTION] = None,
+) -> None:
     """Acquire a token, persist it, and mark this account as active."""
     cli_ctx: CliContext = ctx.obj
+    kind = _resolve_kind(type_)
+    if kind == _KIND_PDP:
+        _login_pdp(cli_ctx)
+        return
     resolved = _resolve_login_context(cli_ctx)
     client = _client_factory.make_cloudaz_client(resolved)
     client.authenticate()

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -166,7 +166,7 @@ def _render_accounts_table(
     *,
     include_status: bool,
 ) -> None:
-    headers = ["#", "Active", "Username", "Base URL", "Client ID"]
+    headers = ["#", "Active", "Kind", "Username", "Base URL", "Client ID"]
     if include_status:
         headers.extend(("Status", "Refreshable"))
     table = Table(title=_ACCOUNTS_TITLE)
@@ -177,6 +177,7 @@ def _render_accounts_table(
         row = [
             str(idx),
             marker,
+            account.kind,
             account.username,
             account.base_url,
             account.client_id,
@@ -206,12 +207,35 @@ def _select_by_user_at_url(
     entries: list[AccountIdentifier],
     selector: str,
 ) -> AccountIdentifier:
-    username, _, base_url = selector.partition("@")
+    prefix, _, base_url = selector.partition("@")
+    kind = _kind_from_prefix(prefix)
+    username = prefix if kind is None else ""
     for entry in entries:
-        if entry.username == username and entry.base_url == base_url:
+        if _matches_entry(entry, kind, username, base_url):
             return entry
     typer.echo(f"No cached account matches `{selector}`.")
     raise _EXIT_FAILURE
+
+
+def _kind_from_prefix(prefix: str) -> str | None:
+    if prefix == "[pdp]":
+        return "pdp"
+    if prefix == "[cloudaz]":
+        return "cloudaz"
+    return None
+
+
+def _matches_entry(
+    entry: AccountIdentifier,
+    kind: str | None,
+    username: str,
+    base_url: str,
+) -> bool:
+    if entry.base_url != base_url:
+        return False
+    if kind is not None:
+        return entry.kind == kind
+    return entry.username == username
 
 
 def _pick_account(
@@ -389,4 +413,10 @@ def use(
         raise _EXIT_FAILURE
     target = _pick_account(entries, selector)
     _set_active(cli_ctx, target)
-    print_success(f"Active account: {target.username} @ {target.base_url}")
+    print_success(f"Active account: {_account_display_label(target)}")
+
+
+def _account_display_label(account: AccountIdentifier) -> str:
+    if account.kind == "pdp":
+        return f"[pdp] @ {account.base_url}"
+    return f"{account.username} @ {account.base_url}"

--- a/src/nextlabs_sdk/_cli/_cache_key.py
+++ b/src/nextlabs_sdk/_cli/_cache_key.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import Protocol
 
 _TOKEN_PATH_SUFFIX = "/cas/oidc/accessToken"
+_KIND_CLOUDAZ = "cloudaz"
+_KIND_PDP = "pdp"
+_VALID_KINDS = (_KIND_CLOUDAZ, _KIND_PDP)
 
 
 class _AccountKeyFields(Protocol):
@@ -12,35 +15,61 @@ class _AccountKeyFields(Protocol):
     def username(self) -> str: ...
     @property
     def client_id(self) -> str: ...
+    @property
+    def kind(self) -> str: ...
 
 
 def cache_key_for(account: _AccountKeyFields) -> str:
     """Build the token-cache key for an account.
 
-    Single source of truth for the cache-key format. Accepts any object
-    exposing ``base_url``, ``username``, and ``client_id`` (e.g.
-    ``AccountIdentifier`` from ``_account_menu`` or ``ResolvedAccount``
-    from ``_account_resolver``) so callers don't have to convert between
-    structurally-equivalent dataclasses.
+    Single source of truth for the 4-segment cache-key format
+    ``<url>|<username>|<client_id>|<kind>``. The URL segment includes
+    the CloudAz OIDC path suffix for ``kind="cloudaz"`` entries and is
+    the raw base URL for ``kind="pdp"`` entries. Accepts any object
+    exposing ``base_url``, ``username``, ``client_id``, and ``kind``.
     """
-    return (
-        f"{account.base_url}{_TOKEN_PATH_SUFFIX}"
-        f"|{account.username}|{account.client_id}"
-    )
+    if account.kind == _KIND_PDP:
+        url_segment = account.base_url
+    else:
+        url_segment = f"{account.base_url}{_TOKEN_PATH_SUFFIX}"
+    return f"{url_segment}|{account.username}|{account.client_id}|{account.kind}"
 
 
-def parse_cache_key(key: str) -> tuple[str, str, str] | None:
-    """Parse a token-cache key into ``(base_url, username, client_id)``.
+def parse_cache_key(key: str) -> tuple[str, str, str, str] | None:
+    """Parse a token-cache key into ``(base_url, username, client_id, kind)``.
 
-    Returns ``None`` when the key does not match the expected format.
+    Accepts both the new 4-segment format and the legacy 3-segment
+    CloudAz format; legacy keys resolve to ``kind="cloudaz"`` so users
+    upgrading from pre-#58 caches do not lose their session. Returns
+    ``None`` when the key does not match either format.
     """
     parts = key.split("|")
-    if len(parts) != 3:
+    if len(parts) == 4:
+        return _parse_four_segment(parts)
+    if len(parts) == 3:
+        return _parse_legacy_three_segment(parts)
+    return None
+
+
+def _parse_four_segment(parts: list[str]) -> tuple[str, str, str, str] | None:
+    url_part, username, client_id, kind = parts
+    if kind not in _VALID_KINDS or not (url_part and client_id):
         return None
+    if kind == _KIND_PDP:
+        return url_part, username, client_id, kind
+    if not url_part.endswith(_TOKEN_PATH_SUFFIX) or not username:
+        return None
+    base_url = url_part[: -len(_TOKEN_PATH_SUFFIX)]
+    if not base_url:
+        return None
+    return base_url, username, client_id, kind
+
+
+def _parse_legacy_three_segment(parts: list[str]) -> tuple[str, str, str, str] | None:
     base_part, username, client_id = parts
     if not base_part.endswith(_TOKEN_PATH_SUFFIX):
         return None
     base_url = base_part[: -len(_TOKEN_PATH_SUFFIX)]
     if not (base_url and username and client_id):
         return None
-    return base_url, username, client_id
+    return base_url, username, client_id, _KIND_CLOUDAZ

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -32,6 +32,11 @@ _PASSWORD_REQUIRED = f"--password or NEXTLABS_PASSWORD is required (or {_LOGIN_H
 _PDP_URL_HELP = "PDP API host serving /dpc/authorization/*"
 _CLOUDAZ_ENDPOINT = "/cas/token on the CloudAz host"
 _PDP_ENDPOINT = "/dpc/oauth on the PDP host"
+_ACTIVE_IS_PDP = (
+    "Active account is a PDP account; CloudAz commands need a CloudAz account. "
+    "Run `nextlabs auth use <username>@<url>` to switch, or pass --base-url and "
+    "--username explicitly."
+)
 
 
 def _client_secret_required(flavor: PdpAuthSource) -> str:
@@ -143,6 +148,8 @@ def _build_static_token_client(ctx: CliContext) -> CloudAzClient:
 def _resolve_or_raise(ctx: CliContext) -> ResolvedAccount:
     account = resolve_account(ctx)
     if account is not None:
+        if account.kind != "cloudaz":
+            raise typer.BadParameter(_ACTIVE_IS_PDP)
         return account
     if not ctx.base_url:
         raise typer.BadParameter(_BASE_URL_REQUIRED)

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import time
+from dataclasses import dataclass
 
 import typer
 
@@ -175,12 +176,11 @@ def make_pdp_client(ctx: CliContext) -> PdpClient:
     account = resolve_account(ctx)
     client_id = account.client_id if account else ctx.client_id
 
-    flavor = _resolve_flavor(ctx)
+    overrides = _load_pdp_overrides(ctx, account)
+    flavor = _resolve_flavor(ctx, overrides)
     base_url = _resolve_cloudaz_base_url(ctx, account, flavor)
-    pdp_url = _resolve_pdp_url(ctx, flavor)
-
-    if not ctx.client_secret:
-        raise typer.BadParameter(_client_secret_required(flavor))
+    pdp_url = _resolve_pdp_url(ctx, flavor, overrides)
+    client_secret = _resolve_client_secret(ctx, flavor, overrides)
 
     auth_base_url = base_url if flavor is PdpAuthSource.CLOUDAZ else None
 
@@ -188,14 +188,53 @@ def make_pdp_client(ctx: CliContext) -> PdpClient:
         base_url=pdp_url,
         auth_base_url=auth_base_url,
         client_id=client_id,
-        client_secret=ctx.client_secret,
+        client_secret=client_secret,
         http_config=_http_config(ctx, account),
     )
 
 
-def _resolve_flavor(ctx: CliContext) -> PdpAuthSource:
+@dataclass(frozen=True)
+class _PdpOverrides:
+    """Cached PDP credentials pulled from active-account storage."""
+
+    client_secret: str | None = None
+    pdp_url: str | None = None
+    flavor: PdpAuthSource | None = None
+
+
+def _load_pdp_overrides(
+    ctx: CliContext,
+    account: ResolvedAccount | None,
+) -> _PdpOverrides:
+    if account is None or account.kind != "pdp":
+        return _PdpOverrides()
+    prefs = load_account_prefs(build_prefs_store(ctx), account)
+    entry = build_file_cache(ctx).load(cache_key_for(account))
+    flavor = _coerce_flavor(prefs.pdp_auth_source if prefs else None)
+    return _PdpOverrides(
+        client_secret=entry.client_secret if entry else None,
+        pdp_url=prefs.pdp_url if prefs else None,
+        flavor=flavor,
+    )
+
+
+def _coerce_flavor(raw: str | None) -> PdpAuthSource | None:
+    if raw is None:
+        return None
+    try:
+        return PdpAuthSource(raw)
+    except ValueError:
+        return None
+
+
+def _resolve_flavor(
+    ctx: CliContext,
+    overrides: _PdpOverrides,
+) -> PdpAuthSource:
     if ctx.pdp_auth is not None:
         return ctx.pdp_auth
+    if overrides.flavor is not None:
+        return overrides.flavor
     return PdpAuthSource.CLOUDAZ if ctx.base_url else PdpAuthSource.PDP
 
 
@@ -216,10 +255,28 @@ def _resolve_cloudaz_base_url(
     raise typer.BadParameter(_base_url_required_for_cloudaz_flavor())
 
 
-def _resolve_pdp_url(ctx: CliContext, flavor: PdpAuthSource) -> str:
+def _resolve_pdp_url(
+    ctx: CliContext,
+    flavor: PdpAuthSource,
+    overrides: _PdpOverrides,
+) -> str:
     if ctx.pdp_url:
         return ctx.pdp_url
+    if overrides.pdp_url:
+        return overrides.pdp_url
     prompted = _prompt_url_if_tty("PDP base URL")
     if prompted:
         return prompted
     raise typer.BadParameter(_pdp_url_required(flavor))
+
+
+def _resolve_client_secret(
+    ctx: CliContext,
+    flavor: PdpAuthSource,
+    overrides: _PdpOverrides,
+) -> str:
+    if ctx.client_secret:
+        return ctx.client_secret
+    if overrides.client_secret:
+        return overrides.client_secret
+    raise typer.BadParameter(_client_secret_required(flavor))

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -13,7 +13,7 @@ from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
     build_file_cache,
     build_prefs_store,
-    prefs_key_for,
+    load_account_prefs,
     resolve_account,
 )
 from nextlabs_sdk._cli._cache_key import cache_key_for
@@ -103,7 +103,7 @@ def _persisted_verify(
     prefs: AccountPreferencesStore,
     account: ResolvedAccount,
 ) -> bool | None:
-    entry = prefs.load(prefs_key_for(account))
+    entry = load_account_prefs(prefs, account)
     return None if entry is None else entry.verify_ssl
 
 

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -21,8 +21,13 @@ from nextlabs_sdk._cli._account_resolver import (
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._json_response import decode_json_object, require_int, require_str
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
-from nextlabs_sdk.exceptions import AuthenticationError
+from nextlabs_sdk.exceptions import (
+    AuthenticationError,
+    RequestTimeoutError,
+    TransportError,
+)
 
 _HTTP_OK = 200
 _KIND_PDP = "pdp"
@@ -135,17 +140,32 @@ def _mint_client_credentials_token(
     verify_ssl: bool,
     timeout: float,
 ) -> _TokenPayload:
-    response = httpx.post(
-        token_url,
-        data={
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-        },
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        timeout=timeout,
-        verify=verify_ssl,
-    )
+    try:
+        response = httpx.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=timeout,
+            verify=verify_ssl,
+        )
+    except (httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
+        detail = str(exc) or exc.__class__.__name__
+        raise RequestTimeoutError(
+            f"Request timed out: {detail}",
+            request_method="POST",
+            request_url=token_url,
+        ) from exc
+    except httpx.RequestError as exc:
+        detail = str(exc) or exc.__class__.__name__
+        raise TransportError(
+            f"Connection error: {detail}",
+            request_method="POST",
+            request_url=token_url,
+        ) from exc
     if response.status_code != _HTTP_OK:
         raise AuthenticationError(
             f"Token acquisition failed: HTTP {response.status_code}",
@@ -154,12 +174,32 @@ def _mint_client_credentials_token(
             request_method="POST",
             request_url=token_url,
         )
-    body = response.json()
+    body = decode_json_object(
+        response,
+        error_cls=AuthenticationError,
+        context=" in token response",
+    )
+    access_token = require_str(
+        body,
+        "access_token",
+        error_cls=AuthenticationError,
+        context=" in token response",
+    )
+    expires_in = require_int(
+        body,
+        "expires_in",
+        error_cls=AuthenticationError,
+        context=" in token response",
+    )
+    token_type_raw = body.get("token_type", "bearer")
+    token_type = token_type_raw if isinstance(token_type_raw, str) else "bearer"
+    scope_raw = body.get("scope")
+    scope = scope_raw if isinstance(scope_raw, str) else None
     return _TokenPayload(
-        access_token=body["access_token"],
-        expires_in=int(body["expires_in"]),
-        token_type=body.get("token_type", "bearer"),
-        scope=body.get("scope"),
+        access_token=access_token,
+        expires_in=expires_in,
+        token_type=token_type,
+        scope=scope,
     )
 
 

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -1,0 +1,215 @@
+"""PDP ``auth login`` flow: collect, mint, persist, activate."""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+
+import httpx
+import typer
+
+from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._cli._account_menu import AccountIdentifier, cache_key_for
+from nextlabs_sdk._cli._account_preferences import AccountPreferences
+from nextlabs_sdk._cli._account_resolver import (
+    build_active_store,
+    build_file_cache,
+    build_prefs_store,
+)
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._output import print_success
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
+from nextlabs_sdk.exceptions import AuthenticationError
+
+_HTTP_OK = 200
+_KIND_PDP = "pdp"
+_PDP_TOKEN_ENDPOINT = "/dpc/oauth"
+_CLOUDAZ_TOKEN_ENDPOINT = "/cas/token"
+
+
+def login_pdp(cli_ctx: CliContext) -> None:
+    """Register a PDP account via OAuth2 client-credentials."""
+    flavor = _resolve_flavor(cli_ctx)
+    pdp_url = _resolve_pdp_url(cli_ctx, flavor)
+    auth_base_url = _resolve_auth_base_url(cli_ctx, flavor)
+    client_secret = _resolve_client_secret(cli_ctx, flavor)
+
+    token_url = resolve_pdp_token_url(
+        base_url=pdp_url,
+        auth_base_url=auth_base_url,
+        token_url=None,
+    )
+    verify_ssl = True if cli_ctx.verify is None else cli_ctx.verify
+    payload = _mint_client_credentials_token(
+        token_url=token_url,
+        client_id=cli_ctx.client_id,
+        client_secret=client_secret,
+        verify_ssl=verify_ssl,
+        timeout=cli_ctx.timeout,
+    )
+
+    account = AccountIdentifier(
+        base_url=auth_base_url or pdp_url,
+        username="",
+        client_id=cli_ctx.client_id,
+        kind=_KIND_PDP,
+    )
+    _persist_login(
+        cli_ctx,
+        _PersistedLogin(
+            account=account,
+            payload=payload,
+            client_secret=client_secret,
+            pdp_url=pdp_url,
+            flavor=flavor,
+            verify_ssl=verify_ssl,
+        ),
+    )
+    print_success("PDP login successful; credentials cached")
+
+
+def _resolve_flavor(cli_ctx: CliContext) -> PdpAuthSource:
+    if cli_ctx.pdp_auth is not None:
+        return cli_ctx.pdp_auth
+    return PdpAuthSource.CLOUDAZ if cli_ctx.base_url else PdpAuthSource.PDP
+
+
+def _resolve_pdp_url(cli_ctx: CliContext, flavor: PdpAuthSource) -> str:
+    if cli_ctx.pdp_url:
+        return cli_ctx.pdp_url
+    if sys.stdin.isatty():
+        return typer.prompt("PDP base URL")
+    suffix = " for --pdp-auth=pdp" if flavor is PdpAuthSource.PDP else ""
+    raise typer.BadParameter(
+        f"--pdp-url or NEXTLABS_PDP_URL is required{suffix}",
+    )
+
+
+def _resolve_auth_base_url(
+    cli_ctx: CliContext,
+    flavor: PdpAuthSource,
+) -> str | None:
+    if flavor is not PdpAuthSource.CLOUDAZ:
+        return None
+    if cli_ctx.base_url:
+        return cli_ctx.base_url
+    if sys.stdin.isatty():
+        return typer.prompt("CloudAz base URL")
+    raise typer.BadParameter(
+        "--base-url or NEXTLABS_BASE_URL is required for --pdp-auth=cloudaz",
+    )
+
+
+def _resolve_client_secret(cli_ctx: CliContext, flavor: PdpAuthSource) -> str:
+    if cli_ctx.client_secret:
+        return cli_ctx.client_secret
+    if sys.stdin.isatty():
+        return typer.prompt("Client secret", hide_input=True)
+    endpoint = (
+        _CLOUDAZ_TOKEN_ENDPOINT
+        if flavor is PdpAuthSource.CLOUDAZ
+        else _PDP_TOKEN_ENDPOINT
+    )
+    raise typer.BadParameter(
+        "--client-secret or NEXTLABS_CLIENT_SECRET is required "
+        f"(used at {endpoint})",
+    )
+
+
+@dataclass(frozen=True)
+class _TokenPayload:
+    access_token: str
+    expires_in: int
+    token_type: str
+    scope: str | None
+
+
+def _mint_client_credentials_token(
+    *,
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    verify_ssl: bool,
+    timeout: float,
+) -> _TokenPayload:
+    response = httpx.post(
+        token_url,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=timeout,
+        verify=verify_ssl,
+    )
+    if response.status_code != _HTTP_OK:
+        raise AuthenticationError(
+            f"Token acquisition failed: HTTP {response.status_code}",
+            status_code=response.status_code,
+            response_body=response.text,
+            request_method="POST",
+            request_url=token_url,
+        )
+    body = response.json()
+    return _TokenPayload(
+        access_token=body["access_token"],
+        expires_in=int(body["expires_in"]),
+        token_type=body.get("token_type", "bearer"),
+        scope=body.get("scope"),
+    )
+
+
+@dataclass(frozen=True)
+class _PersistedLogin:
+    account: AccountIdentifier
+    payload: _TokenPayload
+    client_secret: str
+    pdp_url: str
+    flavor: PdpAuthSource
+    verify_ssl: bool
+
+
+def _persist_login(cli_ctx: CliContext, record: _PersistedLogin) -> None:
+    cache = build_file_cache(cli_ctx)
+    prefs = build_prefs_store(cli_ctx)
+    active = build_active_store(cli_ctx)
+    account = record.account
+    payload = record.payload
+
+    cache.save(
+        cache_key_for(account),
+        CachedToken(
+            access_token=payload.access_token,
+            refresh_token=None,
+            expires_at=time.time() + payload.expires_in,
+            token_type=payload.token_type,
+            scope=payload.scope,
+            id_token=None,
+            refresh_expires_at=None,
+            client_secret=record.client_secret,
+        ),
+    )
+    prefs.save(
+        _prefs_key(account),
+        AccountPreferences(
+            verify_ssl=record.verify_ssl,
+            pdp_url=record.pdp_url,
+            pdp_auth_source=record.flavor.value,
+        ),
+    )
+    active.save(
+        ActiveAccount(
+            base_url=account.base_url,
+            username=account.username,
+            client_id=account.client_id,
+            kind=account.kind,
+        ),
+    )
+
+
+def _prefs_key(account: AccountIdentifier) -> str:
+    return f"{account.base_url}|{account.username}|{account.client_id}|{account.kind}"

--- a/tests/architecture/test_issue_58_invariants.py
+++ b/tests/architecture/test_issue_58_invariants.py
@@ -1,0 +1,149 @@
+"""Architectural invariants for issue #58 (PDP `auth login --type pdp`).
+
+These guardrails pin the contracts the feature relies on so future
+refactors do not silently regress the cache-key format, the persisted
+token schema, or the ``ActiveAccount`` migration behavior.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+from nextlabs_sdk._cli._account_menu import AccountIdentifier, cache_key_for
+from nextlabs_sdk._cli._cache_key import parse_cache_key
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "nextlabs_sdk"
+_CACHED_TOKEN_FILE = _SRC_ROOT / "_auth" / "_token_cache" / "_cached_token.py"
+
+
+def test_cache_key_is_four_segments_for_cloudaz() -> None:
+    account = AccountIdentifier(
+        base_url="https://cloudaz.example",
+        username="alice",
+        client_id="ControlCenterOIDCClient",
+        kind="cloudaz",
+    )
+
+    key = cache_key_for(account)
+
+    assert key.count("|") == 3
+
+
+def test_cache_key_is_four_segments_for_pdp() -> None:
+    account = AccountIdentifier(
+        base_url="https://pdp.example",
+        username="",
+        client_id="pdp-client",
+        kind="pdp",
+    )
+
+    key = cache_key_for(account)
+
+    assert key.count("|") == 3
+
+
+def test_cached_token_has_client_secret_field_and_schema_v3() -> None:
+    tree = ast.parse(_CACHED_TOKEN_FILE.read_text(encoding="utf-8"))
+
+    class_node = _find_class(tree, "CachedToken")
+    field_names = _dataclass_field_names(class_node)
+    assert "client_secret" in field_names
+
+    schema_value = _find_module_constant(tree, "_SCHEMA_VERSION")
+    assert schema_value == 3
+
+
+def test_legacy_three_segment_cache_key_parses_as_cloudaz() -> None:
+    parsed = parse_cache_key("https://x/cas/oidc/accessToken|u|c")
+
+    assert parsed is not None
+    assert parsed[-1] == "cloudaz"
+
+
+def test_active_account_tolerates_missing_kind() -> None:
+    account = ActiveAccount.from_dict(
+        {
+            "base_url": "https://cloudaz.example",
+            "username": "alice",
+            "client_id": "ControlCenterOIDCClient",
+        },
+    )
+
+    assert account.kind == "cloudaz"
+
+
+def test_no_type_ignore_or_noqa_in_edited_sources() -> None:
+    forbidden = ("# type: ignore", "# noqa")
+    edited_files = (
+        _SRC_ROOT / "_auth" / "_active_account" / "_active_account.py",
+        _SRC_ROOT / "_auth" / "_token_cache" / "_cached_token.py",
+        _SRC_ROOT / "_cli" / "_account_menu.py",
+        _SRC_ROOT / "_cli" / "_account_preferences.py",
+        _SRC_ROOT / "_cli" / "_account_resolver.py",
+        _SRC_ROOT / "_cli" / "_account_status_label.py",
+        _SRC_ROOT / "_cli" / "_auth_cmd.py",
+        _SRC_ROOT / "_cli" / "_cache_key.py",
+        _SRC_ROOT / "_cli" / "_client_factory.py",
+        _SRC_ROOT / "_cli" / "_pdp_login.py",
+    )
+
+    offenders: list[str] = []
+    for path in edited_files:
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in forbidden):
+            offenders.append(str(path.relative_to(_SRC_ROOT)))
+
+    assert not offenders, f"Forbidden suppressions found in: {offenders}"
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found")
+
+
+def _dataclass_field_names(node: ast.ClassDef) -> set[str]:
+    names: set[str] = set()
+    for stmt in node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            names.add(stmt.target.id)
+    return names
+
+
+def _find_module_constant(tree: ast.Module, name: str) -> object:
+    for stmt in tree.body:
+        literal = _constant_value(stmt, name)
+        if literal is not _NOT_FOUND:
+            return literal
+    raise AssertionError(f"module constant {name} not found")
+
+
+_NOT_FOUND = object()
+
+
+def _constant_value(stmt: ast.stmt, name: str) -> object:
+    if isinstance(stmt, ast.Assign):
+        return _assign_value(stmt, name)
+    if isinstance(stmt, ast.AnnAssign):
+        return _ann_assign_value(stmt, name)
+    return _NOT_FOUND
+
+
+def _assign_value(stmt: ast.Assign, name: str) -> object:
+    for target in stmt.targets:
+        if isinstance(target, ast.Name) and target.id == name:
+            return ast.literal_eval(stmt.value)
+    return _NOT_FOUND
+
+
+def _ann_assign_value(stmt: ast.AnnAssign, name: str) -> object:
+    if (
+        isinstance(stmt.target, ast.Name)
+        and stmt.target.id == name
+        and stmt.value is not None
+    ):
+        return ast.literal_eval(stmt.value)
+    return _NOT_FOUND

--- a/tests/test_account_preferences.py
+++ b/tests/test_account_preferences.py
@@ -43,3 +43,34 @@ def test_from_dict_rejects_non_bool_verify_ssl(value: object):
         AccountPreferences.from_dict(
             {"schema_version": 1, "verify_ssl": value},
         )
+
+
+def test_roundtrip_with_pdp_fields():
+    prefs = AccountPreferences(
+        verify_ssl=True,
+        pdp_url="https://pdp.example.com",
+        pdp_auth_source="pdp",
+    )
+    assert AccountPreferences.from_dict(prefs.to_dict()) == prefs
+
+
+def test_from_dict_tolerates_missing_pdp_fields():
+    restored = AccountPreferences.from_dict(
+        {"schema_version": 1, "verify_ssl": True},
+    )
+    assert restored.pdp_url is None
+    assert restored.pdp_auth_source is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        pytest.param("pdp_url", id="pdp_url"),
+        pytest.param("pdp_auth_source", id="pdp_auth_source"),
+    ],
+)
+def test_from_dict_rejects_non_string_pdp_field(field: str):
+    with pytest.raises(TypeError, match=field):
+        AccountPreferences.from_dict(
+            {"schema_version": 1, "verify_ssl": True, field: 42},
+        )

--- a/tests/test_active_account_store.py
+++ b/tests/test_active_account_store.py
@@ -97,6 +97,40 @@ def test_save_is_atomic_no_stale_tmp_files(tmp_path: Path) -> None:
     assert leftovers == []
 
 
+def test_kind_defaults_to_cloudaz_on_legacy_payload(tmp_path: Path) -> None:
+    legacy: dict[str, object] = {
+        "base_url": "https://x",
+        "username": "u",
+        "client_id": "c",
+    }
+    loaded = ActiveAccount.from_dict(legacy)
+    assert loaded.kind == "cloudaz"
+
+
+def test_kind_roundtrip_pdp(tmp_path: Path) -> None:
+    store = ActiveAccountStore(path=tmp_path / "active.json")
+    acct = ActiveAccount(
+        base_url="https://pdp.example",
+        username="",
+        client_id="c",
+        kind="pdp",
+    )
+    store.save(acct)
+    assert store.load() == acct
+
+
+def test_from_dict_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="kind"):
+        ActiveAccount.from_dict(
+            {
+                "base_url": "https://x",
+                "username": "u",
+                "client_id": "c",
+                "kind": "mystery",
+            },
+        )
+
+
 @pytest.mark.parametrize(
     "set_env,unset_env,expected_suffix",
     [

--- a/tests/test_cached_token.py
+++ b/tests/test_cached_token.py
@@ -9,7 +9,7 @@ from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 
 def _base_dict() -> dict[str, Any]:
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "access_token": "id",
         "expires_at": 1_700_000_000.0,
         "token_type": "bearer",
@@ -36,6 +36,7 @@ def _make_token(**overrides: Any) -> CachedToken:
             {"refresh_expires_at": 1_700_003_600.0}, id="with-refresh-expires"
         ),
         pytest.param({"id_token": "id-jwt"}, id="with-id-token"),
+        pytest.param({"client_secret": "shh"}, id="with-client-secret"),
     ],
 )
 def test_roundtrip_to_dict_and_back(overrides):
@@ -56,6 +57,7 @@ def test_from_dict_tolerates_missing_optional_fields():
     assert restored.scope is None
     assert restored.refresh_expires_at is None
     assert restored.id_token is None
+    assert restored.client_secret is None
 
 
 def test_to_dict_includes_id_token():
@@ -71,6 +73,7 @@ def test_to_dict_includes_id_token():
     [
         pytest.param({}, id="missing"),
         pytest.param({"schema_version": 1}, id="older"),
+        pytest.param({"schema_version": 2}, id="v2"),
     ],
 )
 def test_from_dict_rejects_invalid_schema_version(schema_version_patch):

--- a/tests/test_cli_account_resolver.py
+++ b/tests/test_cli_account_resolver.py
@@ -135,3 +135,99 @@ def test_cache_dir_from_ctx_is_honoured(tmp_path: Path) -> None:
 def test_build_file_cache_respects_cache_dir(tmp_path: Path) -> None:
     cache = build_file_cache(_ctx(cache_dir=str(tmp_path)))
     assert cache.path == tmp_path / "tokens.json"
+
+
+def test_resolved_account_carries_kind_from_active_pointer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    build_active_store(_ctx()).save(
+        ActiveAccount(
+            base_url="https://pdp.example",
+            username="",
+            client_id="c",
+            kind="pdp",
+        ),
+    )
+
+    resolved = resolve_account(_ctx())
+
+    assert resolved is not None
+    assert resolved.kind == "pdp"
+    assert resolved.username == ""
+
+
+def test_explicit_flags_default_to_cloudaz_kind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    resolved = resolve_account(
+        _ctx(base_url="https://x", username="u"),
+    )
+    assert resolved is not None
+    assert resolved.kind == "cloudaz"
+
+
+def test_prefs_key_for_includes_kind() -> None:
+    from nextlabs_sdk._cli._account_resolver import ResolvedAccount, prefs_key_for
+
+    account = ResolvedAccount(
+        base_url="https://x",
+        username="u",
+        client_id="c",
+        kind="pdp",
+    )
+    assert prefs_key_for(account) == "https://x|u|c|pdp"
+
+
+def test_load_account_prefs_reads_legacy_three_segment_cloudaz_entry(
+    tmp_path: Path,
+) -> None:
+    from nextlabs_sdk._cli._account_preferences import AccountPreferences
+    from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+    from nextlabs_sdk._cli._account_resolver import (
+        ResolvedAccount,
+        load_account_prefs,
+    )
+
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    store.save("https://x|u|c", AccountPreferences(verify_ssl=False))
+    account = ResolvedAccount(
+        base_url="https://x",
+        username="u",
+        client_id="c",
+        kind="cloudaz",
+    )
+
+    loaded = load_account_prefs(store, account)
+
+    assert loaded is not None
+    assert loaded.verify_ssl is False
+
+
+def test_load_account_prefs_prefers_new_four_segment_entry(
+    tmp_path: Path,
+) -> None:
+    from nextlabs_sdk._cli._account_preferences import AccountPreferences
+    from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+    from nextlabs_sdk._cli._account_resolver import (
+        ResolvedAccount,
+        load_account_prefs,
+    )
+
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    store.save("https://x|u|c", AccountPreferences(verify_ssl=False))
+    store.save("https://x|u|c|cloudaz", AccountPreferences(verify_ssl=True))
+    account = ResolvedAccount(
+        base_url="https://x",
+        username="u",
+        client_id="c",
+        kind="cloudaz",
+    )
+
+    loaded = load_account_prefs(store, account)
+
+    assert loaded is not None
+    assert loaded.verify_ssl is True

--- a/tests/test_cli_active_account.py
+++ b/tests/test_cli_active_account.py
@@ -51,7 +51,7 @@ def _capture_factory(monkeypatch: pytest.MonkeyPatch) -> list[CliContext]:
 
 
 def _key(base_url: str, username: str, client_id: str) -> str:
-    return f"{base_url}/cas/oidc/accessToken|{username}|{client_id}"
+    return f"{base_url}/cas/oidc/accessToken|{username}|{client_id}|cloudaz"
 
 
 def _seed_cache(
@@ -103,7 +103,12 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
             None,
             ALPHA,
             "alice",
-            {"base_url": ALPHA, "username": "alice", "client_id": CLIENT},
+            {
+                "base_url": ALPHA,
+                "username": "alice",
+                "client_id": CLIENT,
+                "kind": "cloudaz",
+            },
             id="promote-new",
         ),
         pytest.param(
@@ -114,6 +119,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
                 "base_url": "https://new.example.com",
                 "username": "newbie",
                 "client_id": CLIENT,
+                "kind": "cloudaz",
             },
             id="overwrite-existing",
         ),

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -495,6 +495,93 @@ def test_status_refreshable_is_no_when_refresh_known_expired(
     assert "expired" in result.output
 
 
+_PDP_HOST = "https://pdp.example"
+_PDP_KEY = f"{_PDP_HOST}||pdp-client|pdp"
+
+
+def _seed_pdp_cache(tmp_path: object) -> None:
+    from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+    from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+
+    cache = FileTokenCache(path=f"{tmp_path}/tokens.json")
+    cache.save(
+        _PDP_KEY,
+        CachedToken(
+            access_token="pdp-token",
+            refresh_token=None,
+            expires_at=9_999_999_999.0,
+            token_type="bearer",
+            scope=None,
+            client_secret="S",
+        ),
+    )
+
+
+def test_accounts_lists_pdp_row(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_pdp_cache(tmp_path)
+
+    result = runner.invoke(app, ["auth", "accounts"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    assert "Kind" in result.output
+    assert "pdp" in result.output.lower()
+    assert "pdp.example" in result.output
+
+
+def test_use_selector_accepts_pdp_host_syntax(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_pdp_cache(tmp_path)
+
+    result = runner.invoke(app, ["auth", "use", f"[pdp]@{_PDP_HOST}"])
+
+    assert result.exit_code == 0, result.output
+    from nextlabs_sdk._auth._active_account._active_account_store import (
+        ActiveAccountStore,
+    )
+
+    active = ActiveAccountStore(path=f"{tmp_path}/active_account.json").load()
+    assert active is not None
+    assert active.kind == "pdp"
+    assert active.base_url == _PDP_HOST
+
+
+def test_logout_pdp_clears_all(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_pdp_cache(tmp_path)
+
+    from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+    from nextlabs_sdk._auth._active_account._active_account_store import (
+        ActiveAccountStore,
+    )
+
+    ActiveAccountStore(path=f"{tmp_path}/active_account.json").save(
+        ActiveAccount(
+            base_url=_PDP_HOST,
+            username="",
+            client_id="pdp-client",
+            kind="pdp",
+        ),
+    )
+
+    result = runner.invoke(app, ["auth", "logout"])
+
+    assert result.exit_code == 0, result.output
+    from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+
+    assert FileTokenCache(path=f"{tmp_path}/tokens.json").load(_PDP_KEY) is None
+    assert ActiveAccountStore(path=f"{tmp_path}/active_account.json").load() is None
+
+
 def test_status_all_has_refreshable_column(
     tmp_path: object,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -102,10 +102,10 @@ def _seed_cache(tmp_path: object, *keys: str):
         cache.save(key, tok)
 
 
-_ALPHA_KEY = (
-    "https://alpha.example.com/cas/oidc/accessToken|alice|ControlCenterOIDCClient"
+_ALPHA_KEY = "https://alpha.example.com/cas/oidc/accessToken|alice|ControlCenterOIDCClient|cloudaz"
+_BETA_KEY = (
+    "https://beta.example.com/cas/oidc/accessToken|bob|ControlCenterOIDCClient|cloudaz"
 )
-_BETA_KEY = "https://beta.example.com/cas/oidc/accessToken|bob|ControlCenterOIDCClient"
 
 
 def test_login_prompts_for_password_when_missing(login_ctx):
@@ -250,7 +250,7 @@ def test_login_persists_verify_preference_default_true(login_ctx):
     from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 
     store = AccountPreferencesStore(path=f"{cache_dir}/account_prefs.json")
-    entry = store.load("https://example.com|admin|ControlCenterOIDCClient")
+    entry = store.load("https://example.com|admin|ControlCenterOIDCClient|cloudaz")
     assert entry is not None
     assert entry.verify_ssl is True
 
@@ -279,7 +279,7 @@ def test_login_persists_verify_false_when_no_verify_passed(login_ctx):
     from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 
     store = AccountPreferencesStore(path=f"{cache_dir}/account_prefs.json")
-    entry = store.load("https://example.com|admin|ControlCenterOIDCClient")
+    entry = store.load("https://example.com|admin|ControlCenterOIDCClient|cloudaz")
     assert entry is not None
     assert entry.verify_ssl is False
 
@@ -306,7 +306,7 @@ def test_logout_deletes_persisted_preference(
     )
     prefs_path = f"{tmp_path}/account_prefs.json"
     prefs_store = AccountPreferencesStore(path=prefs_path)
-    prefs_key = "https://alpha.example.com|alice|ControlCenterOIDCClient"
+    prefs_key = "https://alpha.example.com|alice|ControlCenterOIDCClient|cloudaz"
     prefs_store.save(prefs_key, AccountPreferences(verify_ssl=False))
 
     result = runner.invoke(app, ["auth", "logout"])
@@ -325,7 +325,7 @@ def _seed_status_cache(tmp_path: object, *, refresh_expires_at: float | None):
 
     cache = FileTokenCache(path=f"{tmp_path}/tokens.json")
     cache.save(
-        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient",
+        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient|cloudaz",
         CachedToken(
             access_token="t",
             refresh_token="rt",
@@ -404,7 +404,7 @@ def test_status_expired_exits_with_details(
 
     _isolate_cache(tmp_path, monkeypatch)
     FileTokenCache(path=f"{tmp_path}/tokens.json").save(
-        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient",
+        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient|cloudaz",
         CachedToken(
             access_token="t",
             refresh_token="rt",
@@ -470,7 +470,7 @@ def test_status_refreshable_is_no_when_refresh_known_expired(
 
     _isolate_cache(tmp_path, monkeypatch)
     FileTokenCache(path=f"{tmp_path}/tokens.json").save(
-        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient",
+        "https://example.com/cas/oidc/accessToken|admin|ControlCenterOIDCClient|cloudaz",
         CachedToken(
             access_token="t",
             refresh_token="rt",

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -283,3 +283,152 @@ def test_login_pdp_token_error_surfaces(
         "authentication failed" in result.output.lower()
         or "token acquisition" in result.output.lower()
     )
+
+
+# ─────────────────────── Recommended regression tests ──────────────────────
+
+
+from click.testing import Result as _CliResult
+
+
+def _invoke_pdp_login(secret: str) -> _CliResult:
+    return runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            secret,
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+
+def test_pdp_relogin_overwrites_client_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    when(httpx).post(
+        "https://pdp.example/dpc/oauth",
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(
+        _TokenResp({"access_token": "AT", "expires_in": 3600}),
+    )
+
+    first = _invoke_pdp_login("OLD")
+    assert first.exit_code == 0, first.output
+    second = _invoke_pdp_login("NEW")
+    assert second.exit_code == 0, second.output
+
+    entry = FileTokenCache(path=tmp_path / "tokens.json").load(
+        "https://pdp.example||ccid|pdp",
+    )
+    assert entry is not None
+    assert entry.client_secret == "NEW"
+
+
+def test_cloudaz_login_still_uses_four_segment_cache_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _capture_factory(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://cloudaz.example",
+            "--username",
+            "alice",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    active = ActiveAccountStore(path=tmp_path / "active_account.json").load()
+    assert active is not None
+    assert active.kind == "cloudaz"
+
+    from nextlabs_sdk._cli._account_menu import (
+        AccountIdentifier,
+        cache_key_for,
+    )
+
+    key = cache_key_for(
+        AccountIdentifier(
+            base_url=active.base_url,
+            username=active.username,
+            client_id=active.client_id,
+            kind=active.kind,
+        ),
+    )
+    assert key.count("|") == 3
+    assert key.endswith("|cloudaz")
+
+
+def test_switching_active_account_between_kinds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    when(httpx).post(
+        "https://pdp.example/dpc/oauth",
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(_TokenResp({"access_token": "AT", "expires_in": 3600}))
+
+    from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+
+    cache = FileTokenCache(path=tmp_path / "tokens.json")
+    cache.save(
+        "https://cloudaz.example/cas/oidc/accessToken|alice|cc|cloudaz",
+        CachedToken(
+            access_token="id",
+            refresh_token="rt",
+            expires_at=9_999_999_999.0,
+            token_type="bearer",
+            scope=None,
+        ),
+    )
+
+    pdp = _invoke_pdp_login("S")
+    assert pdp.exit_code == 0, pdp.output
+
+    active_store = ActiveAccountStore(path=tmp_path / "active_account.json")
+    active_after_pdp = active_store.load()
+    assert active_after_pdp is not None and active_after_pdp.kind == "pdp"
+
+    back = runner.invoke(
+        app,
+        ["auth", "use", "alice@https://cloudaz.example"],
+    )
+    assert back.exit_code == 0, back.output
+    active_after_back = active_store.load()
+    assert active_after_back is not None
+    assert active_after_back.kind == "cloudaz"
+
+    forward = runner.invoke(
+        app,
+        ["auth", "use", "[pdp]@https://pdp.example"],
+    )
+    assert forward.exit_code == 0, forward.output
+    active_after_forward = active_store.load()
+    assert active_after_forward is not None
+    assert active_after_forward.kind == "pdp"

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
+import httpx
 import pytest
-from mockito import mock, when
+from mockito import ANY, mock, when
 from typer.testing import CliRunner
 
+from nextlabs_sdk._auth._active_account._active_account_store import (
+    ActiveAccountStore,
+)
+from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _auth_cmd, _client_factory
+from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cloudaz._client import CloudAzClient
@@ -135,3 +141,145 @@ def test_login_type_invalid_raises_bad_parameter(
 
     assert result.exit_code != 0
     assert "type" in result.output.lower()
+
+
+# ─────────────────────────── Task 5: PDP login ───────────────────────────
+
+
+class _TokenResp:
+    status_code = 200
+    text = ""
+
+    def __init__(self, body: dict[str, object]) -> None:
+        self._body = body
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+
+class _ErrResp:
+    def __init__(self, status_code: int, text: str) -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+def test_login_pdp_pdp_flavor_persists_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+    when(httpx).post(
+        "https://pdp.example/dpc/oauth",
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(resp)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    cache = FileTokenCache(path=tmp_path / "tokens.json")
+    entry = cache.load("https://pdp.example||ccid|pdp")
+    assert entry is not None
+    assert entry.access_token == "AT"
+    assert entry.client_secret == "S3cret"
+
+    prefs = AccountPreferencesStore(
+        path=tmp_path / "account_prefs.json",
+    ).load("https://pdp.example||ccid|pdp")
+    assert prefs is not None
+    assert prefs.pdp_url == "https://pdp.example"
+    assert prefs.pdp_auth_source == "pdp"
+
+    active = ActiveAccountStore(path=tmp_path / "active_account.json").load()
+    assert active is not None
+    assert active.kind == "pdp"
+    assert active.base_url == "https://pdp.example"
+    assert active.username == ""
+
+
+def test_login_pdp_cloudaz_flavor_requires_base_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "cc",
+            "--client-secret",
+            "S",
+            "--pdp-auth",
+            "cloudaz",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "base-url" in result.output.lower()
+
+
+def test_login_pdp_token_error_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    when(httpx).post(
+        ANY,
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(_ErrResp(status_code=401, text="bad creds"))
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "cc",
+            "--client-secret",
+            "bad",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "authentication failed" in result.output.lower()
+        or "token acquisition" in result.output.lower()
+    )

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+from mockito import mock, when
+from typer.testing import CliRunner
+
+from nextlabs_sdk._cli import _auth_cmd, _client_factory
+from nextlabs_sdk._cli._app import app
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cloudaz._client import CloudAzClient
+from nextlabs_sdk._cloudaz._operators import OperatorService
+
+runner = CliRunner()
+
+
+def _mock_cloudaz_client() -> CloudAzClient:
+    client = mock(CloudAzClient)
+    ops = mock(OperatorService)
+    client.operators = ops
+    when(ops).list_types().thenReturn([])
+    when(client).authenticate().thenReturn(None)
+    return cast(CloudAzClient, client)
+
+
+def _isolate_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXTLABS_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+
+def _capture_factory(monkeypatch: pytest.MonkeyPatch) -> list[CliContext]:
+    captured: list[CliContext] = []
+
+    def _fake(ctx: CliContext) -> CloudAzClient:
+        captured.append(ctx)
+        return _mock_cloudaz_client()
+
+    monkeypatch.setattr(_client_factory, "make_cloudaz_client", _fake)
+    return captured
+
+
+def test_login_type_cloudaz_keeps_existing_flow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    captured = _capture_factory(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+            "--type",
+            "cloudaz",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured and captured[0].base_url == "https://example.com"
+
+
+def test_login_without_type_in_non_tty_defaults_to_cloudaz(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _capture_factory(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_login_type_pdp_reaches_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    called: list[bool] = []
+
+    def _fake_pdp(cli_ctx: CliContext) -> None:
+        called.append(True)
+
+    monkeypatch.setattr(_auth_cmd, "_login_pdp", _fake_pdp)
+
+    result = runner.invoke(app, ["auth", "login", "--type", "pdp"])
+
+    assert called == [True]
+    assert result.exit_code == 0, result.output
+
+
+def test_login_type_invalid_raises_bad_parameter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _capture_factory(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+            "--type",
+            "bogus",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "type" in result.output.lower()

--- a/tests/test_cli_cache_key.py
+++ b/tests/test_cli_cache_key.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nextlabs_sdk._cli._cache_key import cache_key_for, parse_cache_key
+
+
+@dataclass(frozen=True)
+class _Account:
+    base_url: str
+    username: str
+    client_id: str
+    kind: str = "cloudaz"
+
+
+def test_cache_key_cloudaz_appends_kind_and_oidc_path():
+    key = cache_key_for(
+        _Account(base_url="https://x.example", username="alice", client_id="cc"),
+    )
+    assert key == "https://x.example/cas/oidc/accessToken|alice|cc|cloudaz"
+
+
+def test_cache_key_pdp_has_no_path_suffix_and_empty_username():
+    key = cache_key_for(
+        _Account(
+            base_url="https://pdp.example", username="", client_id="cc", kind="pdp"
+        ),
+    )
+    assert key == "https://pdp.example||cc|pdp"
+
+
+def test_parse_four_segment_cloudaz_key():
+    parsed = parse_cache_key(
+        "https://x.example/cas/oidc/accessToken|alice|cc|cloudaz",
+    )
+    assert parsed == ("https://x.example", "alice", "cc", "cloudaz")
+
+
+def test_parse_four_segment_pdp_key():
+    parsed = parse_cache_key("https://pdp.example||cc|pdp")
+    assert parsed == ("https://pdp.example", "", "cc", "pdp")
+
+
+def test_parse_legacy_three_segment_key_defaults_to_cloudaz():
+    parsed = parse_cache_key(
+        "https://x.example/cas/oidc/accessToken|alice|cc",
+    )
+    assert parsed == ("https://x.example", "alice", "cc", "cloudaz")
+
+
+def test_parse_returns_none_for_unknown_kind():
+    assert parse_cache_key("https://x||cc|mystery") is None
+
+
+def test_parse_returns_none_for_cloudaz_missing_path_suffix():
+    assert parse_cache_key("https://x|u|cc|cloudaz") is None
+
+
+def test_parse_returns_none_for_wrong_segment_count():
+    assert parse_cache_key("a|b") is None

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -583,3 +583,123 @@ def test_pdp_explicit_flavor_pdp_reaches_factory_via_cli(
     # With --pdp-auth pdp, base_url is ignored even when set.
     assert captured["auth_base_url"] is None
     assert captured["base_url"] == "https://pdp.example.com"
+
+
+# ─── Cached PDP credentials (#58 Task 6) ───────────────────────────────────
+
+
+def _seed_active_pdp(
+    tmp_path: Path,
+    *,
+    base_url: str = "https://pdp.example",
+    pdp_url: str = "https://pdp.example",
+    flavor: str = "pdp",
+    client_secret: str = "CachedSecret",
+) -> None:
+    from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+    from nextlabs_sdk._auth._active_account._active_account_store import (
+        ActiveAccountStore,
+    )
+
+    ActiveAccountStore(path=tmp_path / "active_account.json").save(
+        ActiveAccount(
+            base_url=base_url,
+            username="",
+            client_id="c",
+            kind="pdp",
+        ),
+    )
+    kind_key_base = base_url
+    if flavor == "cloudaz":
+        kind_key_base = base_url  # keep raw for 4-seg format
+    key = f"{kind_key_base}||c|pdp"
+    FileTokenCache(path=tmp_path / "tokens.json").save(
+        key,
+        CachedToken(
+            access_token="AT",
+            refresh_token=None,
+            expires_at=9_999_999_999.0,
+            token_type="bearer",
+            scope=None,
+            client_secret=client_secret,
+        ),
+    )
+    AccountPreferencesStore(path=tmp_path / "account_prefs.json").save(
+        key,
+        AccountPreferences(
+            verify_ssl=True,
+            pdp_url=pdp_url,
+            pdp_auth_source=flavor,
+        ),
+    )
+
+
+def test_make_pdp_client_uses_cached_credentials_when_active_is_pdp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_active_pdp(tmp_path)
+    captured = _capture_pdp_kwargs(monkeypatch)
+    ctx = _make_ctx(
+        base_url=None,
+        username=None,
+        password=None,
+        client_id="c",
+        client_secret=None,
+        pdp_url=None,
+        cache_dir=str(tmp_path),
+    )
+
+    _client_factory.make_pdp_client(ctx)
+
+    assert captured["client_secret"] == "CachedSecret"
+    assert captured["base_url"] == "https://pdp.example"
+    assert captured["auth_base_url"] is None
+
+
+def test_make_pdp_client_cli_flag_overrides_cached_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_active_pdp(tmp_path)
+    captured = _capture_pdp_kwargs(monkeypatch)
+    ctx = _make_ctx(
+        base_url=None,
+        username=None,
+        password=None,
+        client_id="c",
+        client_secret="Override",
+        pdp_url=None,
+        cache_dir=str(tmp_path),
+    )
+
+    _client_factory.make_pdp_client(ctx)
+
+    assert captured["client_secret"] == "Override"
+
+
+def test_make_pdp_client_cloudaz_flavor_from_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_active_pdp(
+        tmp_path,
+        base_url="https://cloudaz.example",
+        pdp_url="https://pdp.example",
+        flavor="cloudaz",
+    )
+    captured = _capture_pdp_kwargs(monkeypatch)
+    ctx = _make_ctx(
+        base_url=None,
+        username=None,
+        password=None,
+        client_id="c",
+        client_secret=None,
+        pdp_url=None,
+        cache_dir=str(tmp_path),
+    )
+
+    _client_factory.make_pdp_client(ctx)
+
+    assert captured["base_url"] == "https://pdp.example"
+    assert captured["auth_base_url"] == "https://cloudaz.example"

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -703,3 +703,24 @@ def test_make_pdp_client_cloudaz_flavor_from_cache(
 
     assert captured["base_url"] == "https://pdp.example"
     assert captured["auth_base_url"] == "https://cloudaz.example"
+
+
+def test_make_cloudaz_client_rejects_active_pdp_account(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Active PDP account must not bleed into CloudAz clients (#59 review)."""
+    _seed_active_pdp(tmp_path)
+    ctx = _make_ctx(
+        base_url=None,
+        username=None,
+        password=None,
+        client_id="c",
+        client_secret=None,
+        pdp_url=None,
+        cache_dir=str(tmp_path),
+    )
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    with pytest.raises(typer.BadParameter, match="PDP account"):
+        _client_factory.make_cloudaz_client(ctx)

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -18,7 +18,7 @@ from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 
 TOKEN_URL = "https://cloudaz.example.com/cas/oidc/accessToken"
 API_URL = "https://cloudaz.example.com/api"
-_DERIVED_KEY = f"{TOKEN_URL}|admin|ControlCenterOIDCClient"
+_DERIVED_KEY = f"{TOKEN_URL}|admin|ControlCenterOIDCClient|cloudaz"
 
 
 def _make_auth(


### PR DESCRIPTION
Adds `nextlabs auth login --type {cloudaz,pdp}` so PDP client-credentials (client_id, client_secret, pdp_url, and auth flavor) can be registered once and reused by every subsequent `nextlabs pdp …` invocation.

Closes #58

## What changes

- **Login flow** — `auth login --type pdp` mints a token via the selected OAuth endpoint (`/cas/token` or `/dpc/oauth`), persists the token plus `client_secret` in the local cache, stores `pdp_url` and `pdp_auth_source` as `AccountPreferences`, and marks the account active. On a TTY without `--type`, the CLI prompts; in non-interactive contexts it defaults to `cloudaz` (back-compat).
- **Cache key format** — now four segments: `<url>|<username>|<client_id>|<kind>`. PDP entries use the raw base URL (no `/cas/oidc/accessToken` suffix) and an empty username. Legacy three-segment keys still parse as `cloudaz`. `CachedToken` schema bumped to v3 (client_secret field); v2 entries are invalidated once (users re-login).
- **Client factory** — `make_pdp_client` reads the cached `client_secret`, `pdp_url`, and `pdp_auth_source` when the active account is PDP. Explicit CLI/env values still win.
- **Auth subcommands** — `accounts` / `status --all` gain a "Kind" column; `use` accepts `[pdp]@<url>` and `[cloudaz]@<url>` selectors in addition to `username@url`; the `use` success line renders `[pdp] @ <url>` for PDP entries. `logout` clears token, preferences, and active pointer for PDP accounts.
- **Docs** — new README subsection "Register a PDP account once with `auth login --type pdp`" and a troubleshooting entry pointing users at the flow.

## Review step

- **Architectural invariants** — `tests/architecture/test_issue_58_invariants.py` guards the cache-key shape (4 segments for both kinds), the `CachedToken.client_secret` field + `_SCHEMA_VERSION == 3`, legacy 3-seg parse → `cloudaz`, `ActiveAccount.from_dict` tolerating a missing `kind`, and the absence of `# type: ignore` / `# noqa` in the files touched by this issue. All pass.
- **Recommended regression tests** — present in `tests/test_cli_auth_pdp_login.py`: re-login overwrites the cached secret, a CloudAz login still uses the 4-seg `|cloudaz` key, and `auth use` toggles active between a `cloudaz` and a `pdp` account.
- **Self-report checklist** — `python ./tools/checks.py` green (Black + Flake8 + MyPy + Pyright); `python ./tools/tests.py --short` green (1819 passed, coverage 95.99%); `git grep "cas/oidc/accessToken|.*|.*$" src/` returns no dangling 3-seg references; `git grep "_SCHEMA_VERSION.*2" src/nextlabs_sdk/_auth/_token_cache/` is empty.

## lint-escape actions

None in this branch. All static-analysis findings resolved with clean code (helper extraction, module-level constants, shared status-label module).

## Assumption to verify against a real PDP

The PDP client-credentials response is assumed to match CloudAz's shape — `access_token`, `expires_in`, optional `token_type` / `scope`. If a production PDP returns a different key name or wraps the body, `_mint_client_credentials_token` in `src/nextlabs_sdk/_cli/_pdp_login.py` is the single place to adapt.
