### PR TITLE
ci: use release-drafter v7 autolabeler sub-action for PR labels

### DIFF
--- a/.github/workflows/pr_labeling.yml
+++ b/.github/workflows/pr_labeling.yml
@@ -30,9 +30,8 @@ jobs:
     needs:
       - pr_title_check
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter/autolabeler@v7
         with:
-          disable-releaser: true
           config-name: pr_autolabeling_config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #57.

The root `release-drafter@v7` action silently ignores `disable-releaser: true` (upstream [release-drafter#1562](https://github.com/release-drafter/release-drafter/issues/1562)) and always attempts to create a draft release, which the `pr_auto_labeling` job cannot do because it is scoped to `pull-requests: write` only.

This PR switches the job to the dedicated `release-drafter/release-drafter/autolabeler@v7` sub-action — the documented v7 path for autolabel-only workflows — and drops the now-unsupported `disable-releaser` input. Permissions stay at `pull-requests: write`.

`release_drafting.yml` and `release_publishing.yml` are unchanged; they use the full action and already have `contents: write`.

### Acceptance criteria
- [x] `pr_auto_labeling` permissions remain `pull-requests: write`
- [x] `release_drafting.yml` / `release_publishing.yml` untouched
- [ ] `Automatically label the PR` passes on this PR (verified by CI run)
- [ ] `Check that the PR is labeled` downstream job runs

> Note: because `pr_labeling.yml` uses `pull_request_target`, the current (buggy) workflow from `main` runs against this PR. Only after merge will subsequent PRs exercise the fixed workflow.