### PR TITLE
fix(cli): collect PDP client-id and surface real OAuth errors (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,10 @@ The CLI exposes both via `--pdp-auth {cloudaz,pdp}` (env
 
 Explicit `--pdp-auth` always wins over the derivation. `--pdp-url` is
 required for every PDP command; `--base-url` is required only for the
-`cloudaz` flavor.
+`cloudaz` flavor. When `--pdp-auth=pdp`, the token POST needs a
+PDP-specific client ID — pass `--pdp-client-id` (or set
+`NEXTLABS_PDP_CLIENT_ID`); the CloudAz default `--client-id` is not
+reused.
 
 ```bash
 # CloudAz-hosted auth (default when --base-url is set)
@@ -398,14 +401,15 @@ nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
   pdp eval --subject alice --resource doc-42 --resource-type document \
            --action read
 
-# PDP-hosted auth
-nextlabs --pdp-url https://pdp.example --client-secret "$SECRET" \
+# PDP-hosted auth (requires an explicit PDP client ID)
+nextlabs --pdp-url https://pdp.example --pdp-client-id my-pdp-client \
+  --client-secret "$SECRET" \
   pdp eval --subject alice --resource doc-42 --resource-type document \
            --action read
 
 # Force PDP-hosted auth even when a CloudAz host is configured
 nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
-  --pdp-auth pdp --client-secret "$SECRET" \
+  --pdp-auth pdp --pdp-client-id my-pdp-client --client-secret "$SECRET" \
   pdp eval ...
 ```
 
@@ -413,13 +417,13 @@ nextlabs --base-url https://cloudaz.example --pdp-url https://pdp.example \
 
 You can also persist the PDP client credentials in the token cache so
 subsequent `nextlabs pdp …` calls do not need `--client-secret`,
-`--pdp-url`, or `--pdp-auth` on every invocation:
+`--pdp-url`, `--pdp-client-id`, or `--pdp-auth` on every invocation:
 
 ```bash
 # One-time login — mints a token, caches it alongside the client_secret,
 # and stores pdp_url / pdp_auth as preferences for this account.
 nextlabs auth login --type pdp \
-  --pdp-url https://pdp.example --client-id my-client \
+  --pdp-url https://pdp.example --pdp-client-id my-pdp-client \
   --client-secret "$SECRET" --pdp-auth pdp
 
 # Later commands reuse the cached credentials automatically.
@@ -440,10 +444,11 @@ pointer for the selected account.
 | `NEXTLABS_BASE_URL`        | CloudAz base URL                                              |
 | `NEXTLABS_USERNAME`        | CloudAz username                                              |
 | `NEXTLABS_PASSWORD`        | CloudAz password                                              |
-| `NEXTLABS_CLIENT_ID`       | OIDC client ID (default: `ControlCenterOIDCClient`)           |
+| `NEXTLABS_CLIENT_ID`       | CloudAz OIDC client ID (default: `ControlCenterOIDCClient`)   |
 | `NEXTLABS_CLIENT_SECRET`   | PDP client secret                                             |
 | `NEXTLABS_PDP_URL`         | PDP base URL (host serving `/dpc/authorization/*`)            |
 | `NEXTLABS_PDP_AUTH`        | PDP token endpoint flavor: `cloudaz` or `pdp` (see above)     |
+| `NEXTLABS_PDP_CLIENT_ID`   | PDP-specific client ID (required when `--pdp-auth=pdp`)       |
 | `NEXTLABS_TOKEN`           | Pre-issued bearer token; bypasses the login flow and cache    |
 | `NEXTLABS_CACHE_DIR`       | Directory holding `tokens.json` (overrides XDG default)       |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,12 +66,13 @@ the secret by re-running `auth login --type pdp` with the new value;
 clear the entry with `nextlabs auth logout` (after
 `nextlabs auth use "[pdp]@<pdp-url>"` if it is not already active).
 
-## `Authentication failed: missing 'access_token' in token response`
+## `Authentication failed: Token response missing 'access_token'`
 
 **Symptom:** `nextlabs auth login --type pdp` (or any PDP command using
 `--pdp-auth=pdp`) fails with
-`Authentication failed: missing 'access_token' in token response` or the
-server's own `OAuth error: invalid_client` text.
+`Authentication failed: Token response missing 'access_token'; body: …`,
+`Authentication failed: OAuth error: invalid_client: …`, or
+`Authentication failed: Token acquisition failed: HTTP 401: …`.
 
 **Cause:** the PDP's `/dpc/oauth` endpoint was called with the CloudAz
 OIDC default `client_id` (`ControlCenterOIDCClient`) because no

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,7 +55,7 @@ local cache, the CLI has nowhere to recover them from.
 
 ```bash
 nextlabs auth login --type pdp \
-  --pdp-url https://pdp.example --client-id my-client \
+  --pdp-url https://pdp.example --pdp-client-id my-pdp-client \
   --client-secret "$SECRET" --pdp-auth pdp
 ```
 
@@ -65,6 +65,32 @@ persists `pdp_url` + `pdp_auth` as account preferences. Subsequent
 the secret by re-running `auth login --type pdp` with the new value;
 clear the entry with `nextlabs auth logout` (after
 `nextlabs auth use "[pdp]@<pdp-url>"` if it is not already active).
+
+## `Authentication failed: missing 'access_token' in token response`
+
+**Symptom:** `nextlabs auth login --type pdp` (or any PDP command using
+`--pdp-auth=pdp`) fails with
+`Authentication failed: missing 'access_token' in token response` or the
+server's own `OAuth error: invalid_client` text.
+
+**Cause:** the PDP's `/dpc/oauth` endpoint was called with the CloudAz
+OIDC default `client_id` (`ControlCenterOIDCClient`) because no
+PDP-specific client ID was configured. The PDP rejects the request and
+returns either an OAuth error body or a non-standard 200 response that
+lacks `access_token`.
+
+**Fix:** pass `--pdp-client-id` (or export `NEXTLABS_PDP_CLIENT_ID`)
+with the PDP client ID your deployment expects, e.g.
+
+```bash
+nextlabs --pdp-url https://pdp.example --pdp-client-id my-pdp-client \
+  --client-secret "$SECRET" --pdp-auth pdp \
+  auth login --type pdp
+```
+
+The resulting error message now embeds the real server `error` /
+`error_description` (or a truncated response body) so the root cause is
+visible.
 
 ## SSL verification failures against an internal CloudAz instance
 

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -9,6 +9,7 @@ from nextlabs_sdk._cli._component_types_cmd import component_types_app
 from nextlabs_sdk._cli._components_cmd import components_app
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._dashboard_cmd import dashboard_app
+from nextlabs_sdk._cli._defaults import CLOUDAZ_DEFAULT_CLIENT_ID
 from nextlabs_sdk._cli._logging_setup import configure_cli_logging
 from nextlabs_sdk._cli._operators_cmd import operators_app
 from nextlabs_sdk._cli._output_format import OutputFormat
@@ -62,7 +63,7 @@ def main(
         help="CloudAz password",
     ),
     client_id: str = typer.Option(
-        "ControlCenterOIDCClient",
+        CLOUDAZ_DEFAULT_CLIENT_ID,
         envvar="NEXTLABS_CLIENT_ID",
         help="CloudAz OIDC client ID",
     ),

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -64,7 +64,13 @@ def main(
     client_id: str = typer.Option(
         "ControlCenterOIDCClient",
         envvar="NEXTLABS_CLIENT_ID",
-        help="OIDC client ID",
+        help="CloudAz OIDC client ID",
+    ),
+    pdp_client_id: str | None = typer.Option(
+        None,
+        "--pdp-client-id",
+        envvar="NEXTLABS_PDP_CLIENT_ID",
+        help="PDP-specific client ID (used when --pdp-auth=pdp).",
     ),
     client_secret: str | None = typer.Option(
         None,
@@ -148,6 +154,7 @@ def main(
         cache_dir=cache_dir,
         verbose=verbose,
         pdp_auth=pdp_auth,
+        pdp_client_id=pdp_client_id,
     )
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -20,6 +20,7 @@ from nextlabs_sdk._cli._account_resolver import (
 from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._cli._pdp_client_id import resolve_pdp_client_id
 from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._config import HttpConfig
 from nextlabs_sdk._pdp._client import PdpClient
@@ -181,13 +182,12 @@ def make_cloudaz_client(ctx: CliContext) -> CloudAzClient:
 
 def make_pdp_client(ctx: CliContext) -> PdpClient:
     account = resolve_account(ctx)
-    client_id = account.client_id if account else ctx.client_id
-
     overrides = _load_pdp_overrides(ctx, account)
     flavor = _resolve_flavor(ctx, overrides)
     base_url = _resolve_cloudaz_base_url(ctx, account, flavor)
     pdp_url = _resolve_pdp_url(ctx, flavor, overrides)
     client_secret = _resolve_client_secret(ctx, flavor, overrides)
+    client_id = _resolve_pdp_client_id(ctx, account, flavor)
 
     auth_base_url = base_url if flavor is PdpAuthSource.CLOUDAZ else None
 
@@ -198,6 +198,18 @@ def make_pdp_client(ctx: CliContext) -> PdpClient:
         client_secret=client_secret,
         http_config=_http_config(ctx, account),
     )
+
+
+def _resolve_pdp_client_id(
+    ctx: CliContext,
+    account: ResolvedAccount | None,
+    flavor: PdpAuthSource,
+) -> str:
+    if ctx.pdp_client_id:
+        return ctx.pdp_client_id
+    if account is not None:
+        return account.client_id
+    return resolve_pdp_client_id(ctx, flavor)
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_cli/_context.py
+++ b/src/nextlabs_sdk/_cli/_context.py
@@ -23,3 +23,4 @@ class CliContext:
     cache_dir: str | None = None
     verbose: int = 0
     pdp_auth: PdpAuthSource | None = None
+    pdp_client_id: str | None = None

--- a/src/nextlabs_sdk/_cli/_defaults.py
+++ b/src/nextlabs_sdk/_cli/_defaults.py
@@ -1,0 +1,5 @@
+"""Shared CLI default constants."""
+
+from __future__ import annotations
+
+CLOUDAZ_DEFAULT_CLIENT_ID = "ControlCenterOIDCClient"

--- a/src/nextlabs_sdk/_cli/_pdp_client_id.py
+++ b/src/nextlabs_sdk/_cli/_pdp_client_id.py
@@ -7,9 +7,8 @@ import sys
 import typer
 
 from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._defaults import CLOUDAZ_DEFAULT_CLIENT_ID
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
-
-_CLOUDAZ_DEFAULT_CLIENT_ID = "ControlCenterOIDCClient"
 
 
 def resolve_pdp_client_id(ctx: CliContext, flavor: PdpAuthSource) -> str:
@@ -27,7 +26,7 @@ def resolve_pdp_client_id(ctx: CliContext, flavor: PdpAuthSource) -> str:
         return ctx.pdp_client_id
     if flavor is PdpAuthSource.CLOUDAZ:
         return ctx.client_id
-    if ctx.client_id and ctx.client_id != _CLOUDAZ_DEFAULT_CLIENT_ID:
+    if ctx.client_id and ctx.client_id != CLOUDAZ_DEFAULT_CLIENT_ID:
         return ctx.client_id
     if sys.stdin.isatty():
         return typer.prompt("PDP client ID")

--- a/src/nextlabs_sdk/_cli/_pdp_client_id.py
+++ b/src/nextlabs_sdk/_cli/_pdp_client_id.py
@@ -1,0 +1,36 @@
+"""Resolver for the PDP-specific OAuth client ID used by the CLI."""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+
+_CLOUDAZ_DEFAULT_CLIENT_ID = "ControlCenterOIDCClient"
+
+
+def resolve_pdp_client_id(ctx: CliContext, flavor: PdpAuthSource) -> str:
+    """Return the client ID to use for PDP token minting.
+
+    Precedence:
+      1. ``ctx.pdp_client_id`` (``--pdp-client-id`` / env var) always wins.
+      2. For ``CLOUDAZ`` flavor, fall back to ``ctx.client_id`` unconditionally
+         (never prompt — preserves current ``--pdp-auth=cloudaz`` UX).
+      3. For ``PDP`` flavor, fall back to ``ctx.client_id`` only when it
+         differs from the CloudAz default sentinel; otherwise prompt on TTY
+         or raise ``typer.BadParameter``.
+    """
+    if ctx.pdp_client_id:
+        return ctx.pdp_client_id
+    if flavor is PdpAuthSource.CLOUDAZ:
+        return ctx.client_id
+    if ctx.client_id and ctx.client_id != _CLOUDAZ_DEFAULT_CLIENT_ID:
+        return ctx.client_id
+    if sys.stdin.isatty():
+        return typer.prompt("PDP client ID")
+    raise typer.BadParameter(
+        "--pdp-client-id or NEXTLABS_PDP_CLIENT_ID is required for --pdp-auth=pdp",
+    )

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -21,6 +21,7 @@ from nextlabs_sdk._cli._account_resolver import (
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._cli._pdp_client_id import resolve_pdp_client_id
 from nextlabs_sdk._json_response import decode_json_object, require_int, require_str
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import (
@@ -40,6 +41,7 @@ def login_pdp(cli_ctx: CliContext) -> None:
     flavor = _resolve_flavor(cli_ctx)
     pdp_url = _resolve_pdp_url(cli_ctx, flavor)
     auth_base_url = _resolve_auth_base_url(cli_ctx, flavor)
+    client_id = resolve_pdp_client_id(cli_ctx, flavor)
     client_secret = _resolve_client_secret(cli_ctx, flavor)
 
     token_url = resolve_pdp_token_url(
@@ -50,7 +52,7 @@ def login_pdp(cli_ctx: CliContext) -> None:
     verify_ssl = True if cli_ctx.verify is None else cli_ctx.verify
     payload = _mint_client_credentials_token(
         token_url=token_url,
-        client_id=cli_ctx.client_id,
+        client_id=client_id,
         client_secret=client_secret,
         verify_ssl=verify_ssl,
         timeout=cli_ctx.timeout,
@@ -59,7 +61,7 @@ def login_pdp(cli_ctx: CliContext) -> None:
     account = AccountIdentifier(
         base_url=auth_base_url or pdp_url,
         username="",
-        client_id=cli_ctx.client_id,
+        client_id=client_id,
         kind=_KIND_PDP,
     )
     _persist_login(

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -22,7 +22,7 @@ from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cli._pdp_client_id import resolve_pdp_client_id
-from nextlabs_sdk._json_response import decode_json_object, require_int, require_str
+from nextlabs_sdk._json_response import decode_json_object, require_int
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import (
     AuthenticationError,
@@ -134,6 +134,30 @@ class _TokenPayload:
     scope: str | None
 
 
+_MAX_BODY_SNIPPET = 500
+_METHOD_POST = "POST"
+
+
+def _truncate(text: str, limit: int = _MAX_BODY_SNIPPET) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}…"
+
+
+def _auth_error(
+    message: str,
+    response: httpx.Response,
+    token_url: str,
+) -> AuthenticationError:
+    return AuthenticationError(
+        message,
+        status_code=response.status_code,
+        response_body=response.text,
+        request_method=_METHOD_POST,
+        request_url=token_url,
+    )
+
+
 def _mint_client_credentials_token(
     *,
     token_url: str,
@@ -142,51 +166,26 @@ def _mint_client_credentials_token(
     verify_ssl: bool,
     timeout: float,
 ) -> _TokenPayload:
-    try:
-        response = httpx.post(
-            token_url,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": client_id,
-                "client_secret": client_secret,
-            },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=timeout,
-            verify=verify_ssl,
-        )
-    except (httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
-        detail = str(exc) or exc.__class__.__name__
-        raise RequestTimeoutError(
-            f"Request timed out: {detail}",
-            request_method="POST",
-            request_url=token_url,
-        ) from exc
-    except httpx.RequestError as exc:
-        detail = str(exc) or exc.__class__.__name__
-        raise TransportError(
-            f"Connection error: {detail}",
-            request_method="POST",
-            request_url=token_url,
-        ) from exc
+    response = _post_token(
+        token_url=token_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        verify_ssl=verify_ssl,
+        timeout=timeout,
+    )
     if response.status_code != _HTTP_OK:
-        raise AuthenticationError(
-            f"Token acquisition failed: HTTP {response.status_code}",
-            status_code=response.status_code,
-            response_body=response.text,
-            request_method="POST",
-            request_url=token_url,
+        raise _auth_error(
+            f"Token acquisition failed: HTTP {response.status_code}: "
+            f"{_truncate(response.text)}",
+            response,
+            token_url,
         )
     body = decode_json_object(
         response,
         error_cls=AuthenticationError,
         context=" in token response",
     )
-    access_token = require_str(
-        body,
-        "access_token",
-        error_cls=AuthenticationError,
-        context=" in token response",
-    )
+    access_token = _extract_access_token(body, response, token_url)
     expires_in = require_int(
         body,
         "expires_in",
@@ -203,6 +202,73 @@ def _mint_client_credentials_token(
         token_type=token_type,
         scope=scope,
     )
+
+
+def _post_token(
+    *,
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    verify_ssl: bool,
+    timeout: float,
+) -> httpx.Response:
+    try:
+        return httpx.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=timeout,
+            verify=verify_ssl,
+        )
+    except (httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
+        detail = str(exc) or exc.__class__.__name__
+        raise RequestTimeoutError(
+            f"Request timed out: {detail}",
+            request_method=_METHOD_POST,
+            request_url=token_url,
+        ) from exc
+    except httpx.RequestError as exc:
+        detail = str(exc) or exc.__class__.__name__
+        raise TransportError(
+            f"Connection error: {detail}",
+            request_method=_METHOD_POST,
+            request_url=token_url,
+        ) from exc
+
+
+def _extract_access_token(
+    body: dict[str, object],
+    response: httpx.Response,
+    token_url: str,
+) -> str:
+    if "error" in body:
+        raise _auth_error(
+            _format_oauth_error(body),
+            response,
+            token_url,
+        )
+    access_token_raw = body.get("access_token")
+    if not isinstance(access_token_raw, str):
+        raise _auth_error(
+            f"Token response missing 'access_token'; body: "
+            f"{_truncate(response.text)}",
+            response,
+            token_url,
+        )
+    return access_token_raw
+
+
+def _format_oauth_error(body: dict[str, object]) -> str:
+    error_code = body.get("error")
+    error_desc = body.get("error_description")
+    message = f"OAuth error: {error_code}"
+    if isinstance(error_desc, str) and error_desc:
+        return f"{message}: {error_desc}"
+    return message
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -245,9 +245,10 @@ def _extract_access_token(
     response: httpx.Response,
     token_url: str,
 ) -> str:
-    if "error" in body:
+    error_raw = body.get("error")
+    if isinstance(error_raw, str) and error_raw:
         raise _auth_error(
-            _format_oauth_error(body),
+            _format_oauth_error(body, error_raw),
             response,
             token_url,
         )
@@ -262,8 +263,7 @@ def _extract_access_token(
     return access_token_raw
 
 
-def _format_oauth_error(body: dict[str, object]) -> str:
-    error_code = body.get("error")
+def _format_oauth_error(body: dict[str, object], error_code: str) -> str:
     error_desc = body.get("error_description")
     message = f"OAuth error: {error_code}"
     if isinstance(error_desc, str) and error_desc:

--- a/tests/architecture/test_issue_61_invariants.py
+++ b/tests/architecture/test_issue_61_invariants.py
@@ -1,0 +1,63 @@
+"""Architectural invariants for issue #61 (PDP `--pdp-client-id`).
+
+These guardrails pin the contracts the feature relies on so future
+refactors do not silently regress the new CLI option, the resolver
+module shape, or the suppression-free policy.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from nextlabs_sdk._cli import _pdp_client_id as _resolver_module
+from nextlabs_sdk._cli._context import CliContext
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "nextlabs_sdk"
+_APP_FILE = _SRC_ROOT / "_cli" / "_app.py"
+_RESOLVER_FILE = _SRC_ROOT / "_cli" / "_pdp_client_id.py"
+
+
+def test_resolver_module_imports_cleanly() -> None:
+    assert _resolver_module.resolve_pdp_client_id is not None
+
+
+def test_cli_context_has_pdp_client_id_field() -> None:
+    assert "pdp_client_id" in {
+        field.name for field in CliContext.__dataclass_fields__.values()
+    }
+
+
+def test_app_declares_pdp_client_id_option() -> None:
+    source = _APP_FILE.read_text(encoding="utf-8")
+    assert "--pdp-client-id" in source
+    assert "NEXTLABS_PDP_CLIENT_ID" in source
+
+
+def test_resolver_module_is_single_public_function() -> None:
+    tree = ast.parse(_RESOLVER_FILE.read_text(encoding="utf-8"))
+    public_funcs = [
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_")
+    ]
+    assert public_funcs == ["resolve_pdp_client_id"]
+
+
+def test_no_type_ignore_or_noqa_in_edited_sources() -> None:
+    forbidden = ("# type: ignore", "# noqa")
+    edited_files = (
+        _SRC_ROOT / "_cli" / "_app.py",
+        _SRC_ROOT / "_cli" / "_context.py",
+        _SRC_ROOT / "_cli" / "_pdp_client_id.py",
+        _SRC_ROOT / "_cli" / "_pdp_login.py",
+        _SRC_ROOT / "_cli" / "_client_factory.py",
+    )
+
+    offenders: list[str] = []
+    for path in edited_files:
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in forbidden):
+            offenders.append(str(path.relative_to(_SRC_ROOT)))
+
+    assert not offenders, f"Forbidden suppressions found in: {offenders}"

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -285,6 +285,139 @@ def test_login_pdp_token_error_surfaces(
     )
 
 
+def test_login_pdp_uses_pdp_client_id_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    resp = _TokenResp({"access_token": "AT", "expires_in": 3600})
+    captured_data: list[dict[str, str]] = []
+
+    def _fake_post(
+        url: str,
+        *,
+        data: dict[str, str],
+        **_kwargs: object,
+    ) -> _TokenResp:
+        captured_data.append(dict(data))
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "pdp-only-id",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_data == [
+        {
+            "grant_type": "client_credentials",
+            "client_id": "pdp-only-id",
+            "client_secret": "S3cret",
+        },
+    ]
+
+    entry = FileTokenCache(path=tmp_path / "tokens.json").load(
+        "https://pdp.example||pdp-only-id|pdp",
+    )
+    assert entry is not None
+    assert entry.access_token == "AT"
+
+
+def _isatty_false_for_pdp_login() -> bool:
+    return False
+
+
+def test_login_pdp_rejects_missing_client_id_non_tty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false_for_pdp_login)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "pdp-client-id" in result.output.lower()
+
+
+def test_login_pdp_cloudaz_flavor_uses_client_id_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    resp = _TokenResp({"access_token": "AT", "expires_in": 3600})
+    captured_data: list[dict[str, str]] = []
+
+    def _fake_post(
+        url: str,
+        *,
+        data: dict[str, str],
+        **_kwargs: object,
+    ) -> _TokenResp:
+        captured_data.append(dict(data))
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://cloudaz.example",
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "cloudaz-oidc-client",
+            "--client-secret",
+            "S",
+            "--pdp-auth",
+            "cloudaz",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_data == [
+        {
+            "grant_type": "client_credentials",
+            "client_id": "cloudaz-oidc-client",
+            "client_secret": "S",
+        },
+    ]
+
+
 # ─────────────────────── Recommended regression tests ──────────────────────
 
 

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -460,6 +460,45 @@ def test_login_pdp_surfaces_oauth_error_fields(
     assert "Client authentication failed" in normalized
 
 
+def test_login_pdp_null_error_falls_back_to_body_snippet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    body: dict[str, object] = {"error": None, "detail": "weird-sentinel"}
+    when(httpx).post(
+        ANY,
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(_BodyResp(body, '{"error": null, "detail": "weird-sentinel"}'))
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "c",
+            "--client-secret",
+            "s",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    normalized = " ".join(strip_ansi(result.output).split())
+    assert "OAuth error: None" not in normalized
+    assert "missing 'access_token'" in normalized
+    assert "weird-sentinel" in normalized
+
+
 class _BodyResp:
     status_code = 200
 

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -418,6 +418,133 @@ def test_login_pdp_cloudaz_flavor_uses_client_id_fallback(
     ]
 
 
+def test_login_pdp_surfaces_oauth_error_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    body: dict[str, object] = {
+        "error": "invalid_client",
+        "error_description": "Client authentication failed",
+    }
+    when(httpx).post(
+        ANY,
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(_TokenResp(body))
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "c",
+            "--client-secret",
+            "bad",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    normalized = " ".join(result.output.split())
+    assert "invalid_client" in normalized
+    assert "Client authentication failed" in normalized
+
+
+class _BodyResp:
+    status_code = 200
+
+    def __init__(self, body: dict[str, object], text: str) -> None:
+        self._body = body
+        self.text = text
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+
+def test_login_pdp_200_missing_access_token_includes_body_snippet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    when(httpx).post(
+        ANY,
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(
+        _BodyResp({"foo": "bar"}, '{"foo": "bar"}'),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "c",
+            "--client-secret",
+            "s",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "foo" in result.output
+    assert "bar" in result.output
+
+
+def test_login_pdp_non_200_includes_body_snippet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    when(httpx).post(
+        ANY,
+        data=ANY,
+        headers=ANY,
+        timeout=ANY,
+        verify=ANY,
+    ).thenReturn(_ErrResp(status_code=401, text="invalid client credentials"))
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "c",
+            "--client-secret",
+            "bad",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    normalized = " ".join(result.output.split())
+    assert "401" in normalized
+    assert "invalid client credentials" in normalized
+
+
 # ─────────────────────── Recommended regression tests ──────────────────────
 
 

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -6,6 +6,7 @@ from typing import cast
 import httpx
 import pytest
 from mockito import ANY, mock, when
+from strip_ansi import strip_ansi
 from typer.testing import CliRunner
 
 from nextlabs_sdk._auth._active_account._active_account_store import (
@@ -454,7 +455,7 @@ def test_login_pdp_surfaces_oauth_error_fields(
     )
 
     assert result.exit_code == 1
-    normalized = " ".join(result.output.split())
+    normalized = " ".join(strip_ansi(result.output).split())
     assert "invalid_client" in normalized
     assert "Client authentication failed" in normalized
 
@@ -504,8 +505,9 @@ def test_login_pdp_200_missing_access_token_includes_body_snippet(
     )
 
     assert result.exit_code == 1
-    assert "foo" in result.output
-    assert "bar" in result.output
+    normalized = " ".join(strip_ansi(result.output).split())
+    assert "foo" in normalized
+    assert "bar" in normalized
 
 
 def test_login_pdp_non_200_includes_body_snippet(
@@ -540,7 +542,7 @@ def test_login_pdp_non_200_includes_body_snippet(
     )
 
     assert result.exit_code == 1
-    normalized = " ".join(result.output.split())
+    normalized = " ".join(strip_ansi(result.output).split())
     assert "401" in normalized
     assert "invalid client credentials" in normalized
 

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -31,6 +31,7 @@ def _make_ctx(
     cache_dir: str | None = None,
     pdp_url: str | None = "https://pdp.example.com",
     pdp_auth: PdpAuthSource | None = None,
+    pdp_client_id: str | None = None,
 ) -> CliContext:
     return CliContext(
         base_url=base_url,
@@ -44,6 +45,7 @@ def _make_ctx(
         timeout=30.0,
         cache_dir=cache_dir,
         pdp_auth=pdp_auth,
+        pdp_client_id=pdp_client_id,
     )
 
 
@@ -724,3 +726,52 @@ def test_make_cloudaz_client_rejects_active_pdp_account(
 
     with pytest.raises(typer.BadParameter, match="PDP account"):
         _client_factory.make_cloudaz_client(ctx)
+
+
+# ─── PDP client-id resolver integration (#61) ─────────────────────────────
+
+
+def test_make_pdp_client_uses_pdp_client_id_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture_pdp_kwargs(monkeypatch)
+
+    _client_factory.make_pdp_client(
+        _make_ctx(pdp_client_id="pdp-only-id"),
+    )
+
+    assert captured["client_id"] == "pdp-only-id"
+
+
+def test_make_pdp_client_flag_overrides_active_account_pointer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_active_pdp(tmp_path)
+    captured = _capture_pdp_kwargs(monkeypatch)
+    ctx = _make_ctx(
+        base_url=None,
+        username=None,
+        client_secret=None,
+        cache_dir=str(tmp_path),
+        pdp_client_id="override-id",
+    )
+
+    _client_factory.make_pdp_client(ctx)
+
+    assert captured["client_id"] == "override-id"
+
+
+def test_make_pdp_client_pdp_flavor_missing_client_id_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    with pytest.raises(typer.BadParameter, match="pdp-client-id"):
+        _client_factory.make_pdp_client(
+            _make_ctx(
+                base_url=None,
+                pdp_auth=PdpAuthSource.PDP,
+                client_id="ControlCenterOIDCClient",
+            ),
+        )

--- a/tests/test_cli_pdp_client_id.py
+++ b/tests/test_cli_pdp_client_id.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+import typer
+
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._output_format import OutputFormat
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._cli._pdp_client_id import resolve_pdp_client_id
+
+
+def _ctx(
+    *,
+    client_id: str = "ControlCenterOIDCClient",
+    pdp_client_id: str | None = None,
+) -> CliContext:
+    return CliContext(
+        base_url=None,
+        username=None,
+        password=None,
+        client_id=client_id,
+        client_secret=None,
+        pdp_url=None,
+        output_format=OutputFormat.TABLE,
+        verify=None,
+        timeout=30.0,
+        pdp_client_id=pdp_client_id,
+    )
+
+
+def _isatty_false() -> bool:
+    return False
+
+
+def _isatty_true() -> bool:
+    return True
+
+
+def test_resolve_returns_pdp_client_id_when_set() -> None:
+    ctx = _ctx(pdp_client_id="my-pdp-client")
+
+    result = resolve_pdp_client_id(ctx, PdpAuthSource.PDP)
+
+    assert result == "my-pdp-client"
+
+
+def test_resolve_pdp_flavor_falls_back_to_explicit_client_id() -> None:
+    ctx = _ctx(client_id="foo")
+
+    result = resolve_pdp_client_id(ctx, PdpAuthSource.PDP)
+
+    assert result == "foo"
+
+
+def test_resolve_pdp_flavor_rejects_cloudaz_default_when_non_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx()
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_false)
+
+    with pytest.raises(typer.BadParameter, match="pdp-client-id"):
+        resolve_pdp_client_id(ctx, PdpAuthSource.PDP)
+
+
+def test_resolve_pdp_flavor_prompts_on_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx()
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+    prompts: list[str] = []
+
+    def _fake_prompt(text: str, **_: object) -> str:
+        prompts.append(text)
+        return "prompted-id"
+
+    monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+    result = resolve_pdp_client_id(ctx, PdpAuthSource.PDP)
+
+    assert result == "prompted-id"
+    assert prompts and "client" in prompts[0].lower()
+
+
+def test_resolve_cloudaz_flavor_falls_back_to_client_id_without_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx()
+    monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+
+    def _fail_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("CloudAz flavor must not prompt")
+
+    monkeypatch.setattr(typer, "prompt", _fail_prompt)
+
+    result = resolve_pdp_client_id(ctx, PdpAuthSource.CLOUDAZ)
+
+    assert result == "ControlCenterOIDCClient"
+
+
+def test_resolve_cloudaz_flavor_pdp_flag_overrides_client_id() -> None:
+    ctx = _ctx(client_id="foo", pdp_client_id="bar")
+
+    result = resolve_pdp_client_id(ctx, PdpAuthSource.CLOUDAZ)
+
+    assert result == "bar"

--- a/tests/test_cli_pdp_client_id_option.py
+++ b/tests/test_cli_pdp_client_id_option.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from nextlabs_sdk._cli import _auth_cmd
+from nextlabs_sdk._cli._app import app
+from nextlabs_sdk._cli._context import CliContext
+
+runner = CliRunner()
+
+
+def test_pdp_client_id_option_populates_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[CliContext] = []
+
+    def _fake_pdp(cli_ctx: CliContext) -> None:
+        seen.append(cli_ctx)
+
+    monkeypatch.setattr(_auth_cmd, "_login_pdp", _fake_pdp)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--pdp-client-id",
+            "my-pdp-client",
+            "--client-secret",
+            "s3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen and seen[0].pdp_client_id == "my-pdp-client"
+
+
+def test_pdp_client_id_env_var_populates_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[CliContext] = []
+    monkeypatch.setenv("NEXTLABS_PDP_CLIENT_ID", "env-pdp-client")
+
+    def _fake_pdp(cli_ctx: CliContext) -> None:
+        seen.append(cli_ctx)
+
+    monkeypatch.setattr(_auth_cmd, "_login_pdp", _fake_pdp)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-secret",
+            "s3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen and seen[0].pdp_client_id == "env-pdp-client"


### PR DESCRIPTION
Collect a PDP-specific client ID in the CLI and surface the real OAuth/server error when PDP token minting fails, instead of hiding both behind the misleading "missing 'access_token'" shape-check error.

Closes #61

## What changed

- New `--pdp-client-id` / `NEXTLABS_PDP_CLIENT_ID` option threaded through `CliContext`.
- New `nextlabs_sdk._cli._pdp_client_id.resolve_pdp_client_id(ctx, flavor)` helper with the precedence:
  - flag/env wins;
  - `cloudaz` flavor falls back to `--client-id` (no prompt);
  - `pdp` flavor falls back to `--client-id` only when it is non-default (`ControlCenterOIDCClient`), otherwise prompts on TTY or raises `typer.BadParameter`.
- `login_pdp` and `make_pdp_client` delegate to the resolver; the factory keeps giving the active-account pointer precedence over the resolver fallback.
- `_mint_client_credentials_token` now surfaces OAuth `error` / `error_description` fields when present, and embeds a truncated body snippet in the error message for 200-with-no-`access_token` and non-200 responses.
- README + `docs/troubleshooting.md` updated; `--client-id` help tweaked to `"CloudAz OIDC client ID"`.

## Review step

Architectural invariants in `tests/architecture/test_issue_61_invariants.py` (five checks: resolver imports, `CliContext` field, `--pdp-client-id` option + env var strings present in `_app.py`, resolver exposes exactly one public function, no `# type: ignore` / `# noqa` in the five edited CLI source files) pass.

Recommended regression tests: `test_login_pdp_pdp_flavor_persists_all`, `test_pdp_relogin_overwrites_client_secret`, `test_make_pdp_client_uses_cached_credentials_when_active_is_pdp` still pass unchanged.

## Verification

- `python ./tools/checks.py` — green.
- `python ./tools/tests.py --short` — 1842 passed, coverage 95.99%.

No `lint-escape` tier-2/tier-3 actions were needed; all lint complaints were resolved with plain refactors (extract helpers, module constant `_METHOD_POST`, f-string for `…` suffix, top-level helper functions instead of lambdas in tests).
