### PR TITLE
feat(cli): interactive SSL retry on `nextlabs auth login`

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,16 @@ Top-level CLI flags worth knowing: `--no-verify` (skip TLS verification —
 dev only), `-v` / `-vv` (verbose; `-vv` logs every HTTP request and
 response body), `--token` (one-shot bearer override).
 
+When you run `nextlabs auth login` (both `--type cloudaz` and
+`--type pdp`) on an interactive terminal and the server presents a
+certificate that cannot be verified, the CLI offers a one-shot retry
+with SSL verification disabled (default: **No**). Accepting persists
+`verify_ssl=False` for that account so subsequent commands reuse the
+same choice. The prompt is skipped entirely when you passed `--verify`
+or `--no-verify` on the command line, or when stdin is not a TTY — the
+original error propagates unchanged so scripts and pipelines stay
+deterministic.
+
 ---
 
 ## Project layout

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -29,6 +29,7 @@ from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._expiry_format import format_expiry
 from nextlabs_sdk._cli._output import print_success
+from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
 
 
 auth_app = typer.Typer(help="Authentication commands")
@@ -54,6 +55,12 @@ _LOGIN_TYPE_OPTION = typer.Option(
 _KIND_CLOUDAZ = "cloudaz"
 _KIND_PDP = "pdp"
 _VALID_LOGIN_KINDS = (_KIND_CLOUDAZ, _KIND_PDP)
+
+_SSL_RETRY_PROMPTER_FACTORY = SslRetryPrompter
+
+
+def _cloudaz_login_attempt(ctx: CliContext) -> None:
+    _client_factory.make_cloudaz_client(ctx).authenticate()
 
 
 def _resolve_kind(type_arg: str | None) -> str:
@@ -281,15 +288,19 @@ def login(
         _login_pdp(cli_ctx)
         return
     resolved = _resolve_login_context(cli_ctx)
-    client = _client_factory.make_cloudaz_client(resolved)
-    client.authenticate()
-    account = AccountIdentifier(
-        base_url=resolved.base_url or "",
-        username=resolved.username or "",
-        client_id=resolved.client_id,
+
+    used_ctx = _SSL_RETRY_PROMPTER_FACTORY().run_with_ssl_retry(
+        attempt=_cloudaz_login_attempt,
+        cli_ctx=resolved,
+        target_url=resolved.base_url or "",
     )
-    _set_active(resolved, account)
-    _save_prefs(resolved, account)
+    account = AccountIdentifier(
+        base_url=used_ctx.base_url or "",
+        username=used_ctx.username or "",
+        client_id=used_ctx.client_id,
+    )
+    _set_active(used_ctx, account)
+    _save_prefs(used_ctx, account)
     print_success("Login successful; token cached")
 
 

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -22,6 +22,7 @@ from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cli._pdp_client_id import resolve_pdp_client_id
+from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
 from nextlabs_sdk._json_response import decode_json_object, require_int
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import (
@@ -35,9 +36,46 @@ _KIND_PDP = "pdp"
 _PDP_TOKEN_ENDPOINT = "/dpc/oauth"
 _CLOUDAZ_TOKEN_ENDPOINT = "/cas/token"
 
+_SSL_RETRY_PROMPTER_FACTORY = SslRetryPrompter
+
+
+class _PdpLoginAttempt:
+    """Collect ``_PersistedLogin`` records from each attempt.
+
+    The PDP login helper re-uses the same callable across the initial
+    attempt and the optional SSL-retry attempt. The prompter returns the
+    :class:`CliContext` that actually succeeded; the record produced by
+    that successful attempt is captured here and persisted afterwards.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[_PersistedLogin] = []
+
+    def __call__(self, ctx: CliContext) -> None:
+        self.records.append(_attempt_login(ctx))
+
 
 def login_pdp(cli_ctx: CliContext) -> None:
     """Register a PDP account via OAuth2 client-credentials."""
+    attempt = _PdpLoginAttempt()
+    used_ctx = _SSL_RETRY_PROMPTER_FACTORY().run_with_ssl_retry(
+        attempt=attempt,
+        cli_ctx=cli_ctx,
+        target_url=_target_url_for_prompt(cli_ctx),
+    )
+    _persist_login(used_ctx, attempt.records[-1])
+    print_success("PDP login successful; credentials cached")
+
+
+def _target_url_for_prompt(cli_ctx: CliContext) -> str:
+    if cli_ctx.pdp_url:
+        return cli_ctx.pdp_url
+    if cli_ctx.base_url:
+        return cli_ctx.base_url
+    return ""
+
+
+def _attempt_login(cli_ctx: CliContext) -> _PersistedLogin:
     flavor = _resolve_flavor(cli_ctx)
     pdp_url = _resolve_pdp_url(cli_ctx, flavor)
     auth_base_url = _resolve_auth_base_url(cli_ctx, flavor)
@@ -64,18 +102,14 @@ def login_pdp(cli_ctx: CliContext) -> None:
         client_id=client_id,
         kind=_KIND_PDP,
     )
-    _persist_login(
-        cli_ctx,
-        _PersistedLogin(
-            account=account,
-            payload=payload,
-            client_secret=client_secret,
-            pdp_url=pdp_url,
-            flavor=flavor,
-            verify_ssl=verify_ssl,
-        ),
+    return _PersistedLogin(
+        account=account,
+        payload=payload,
+        client_secret=client_secret,
+        pdp_url=pdp_url,
+        flavor=flavor,
+        verify_ssl=verify_ssl,
     )
-    print_success("PDP login successful; credentials cached")
 
 
 def _resolve_flavor(cli_ctx: CliContext) -> PdpAuthSource:

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import httpx
 import typer
@@ -57,14 +57,37 @@ class _PdpLoginAttempt:
 
 def login_pdp(cli_ctx: CliContext) -> None:
     """Register a PDP account via OAuth2 client-credentials."""
+    resolved_ctx = _resolve_login_inputs(cli_ctx)
     attempt = _PdpLoginAttempt()
     used_ctx = _SSL_RETRY_PROMPTER_FACTORY().run_with_ssl_retry(
         attempt=attempt,
-        cli_ctx=cli_ctx,
-        target_url=_target_url_for_prompt(cli_ctx),
+        cli_ctx=resolved_ctx,
+        target_url=_target_url_for_prompt(resolved_ctx),
     )
     _persist_login(used_ctx, attempt.records[-1])
     print_success("PDP login successful; credentials cached")
+
+
+def _resolve_login_inputs(cli_ctx: CliContext) -> CliContext:
+    """Gather every interactive input once, up-front.
+
+    Returns a :class:`CliContext` where every value the token-minting
+    step needs is already populated, so the SSL-retry flow can re-invoke
+    the attempt without re-prompting the user for anything except the
+    retry confirmation itself.
+    """
+    flavor = _resolve_flavor(cli_ctx)
+    pdp_url = _resolve_pdp_url(cli_ctx, flavor)
+    auth_base_url = _resolve_auth_base_url(cli_ctx, flavor)
+    client_id = resolve_pdp_client_id(cli_ctx, flavor)
+    client_secret = _resolve_client_secret(cli_ctx, flavor)
+    return replace(
+        cli_ctx,
+        base_url=auth_base_url if auth_base_url else cli_ctx.base_url,
+        pdp_url=pdp_url,
+        pdp_client_id=client_id,
+        client_secret=client_secret,
+    )
 
 
 def _target_url_for_prompt(cli_ctx: CliContext) -> str:

--- a/src/nextlabs_sdk/_cli/_ssl_retry.py
+++ b/src/nextlabs_sdk/_cli/_ssl_retry.py
@@ -1,0 +1,120 @@
+"""Interactive SSL-retry policy for ``nextlabs auth login``.
+
+When the server's TLS certificate cannot be verified, interactive
+callers are offered exactly one opportunity to retry with verification
+disabled. Non-interactive callers and callers who passed an explicit
+``--verify`` / ``--no-verify`` see the original error unchanged.
+"""
+
+from __future__ import annotations
+
+import ssl
+import sys
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Protocol
+
+import typer
+
+from nextlabs_sdk._cli._context import CliContext
+
+_MAX_CAUSE_DEPTH = 10
+
+
+def is_ssl_verify_error(exc: BaseException) -> bool:
+    """Return ``True`` iff ``exc`` is — or wraps — an SSL verify error.
+
+    Walks ``__cause__`` and ``__context__`` up to a bounded depth so the
+    helper works regardless of whether the caught exception is the raw
+    :class:`ssl.SSLError` or a :class:`~nextlabs_sdk.exceptions.TransportError`
+    that wrapped it.
+
+    Args:
+        exc: The exception to inspect.
+
+    Returns:
+        ``True`` when the chain contains an
+        :class:`ssl.SSLCertVerificationError`, or an :class:`ssl.SSLError`
+        whose ``verify_code`` attribute is truthy.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    depth = 0
+    while current is not None and depth < _MAX_CAUSE_DEPTH:
+        if id(current) in seen:
+            return False
+        seen.add(id(current))
+        if _is_direct_ssl_verify_error(current):
+            return True
+        current = current.__cause__ or current.__context__
+        depth += 1
+    return False
+
+
+def _is_direct_ssl_verify_error(exc: BaseException) -> bool:
+    if isinstance(exc, ssl.SSLCertVerificationError):
+        return True
+    if isinstance(exc, ssl.SSLError):
+        return bool(getattr(exc, "verify_code", None))
+    return False
+
+
+class _ConfirmFn(Protocol):
+    def __call__(self, text: str, *, default: bool = ...) -> bool: ...
+
+
+class SslRetryPrompter:
+    """Runs a login ``attempt`` with a one-shot interactive SSL retry.
+
+    Mirrors the DI shape of :class:`ReauthPrompter`. Callers supply an
+    ``attempt(cli_ctx)`` callable; the prompter runs it, and if the call
+    fails with an SSL verification error AND the caller is on a TTY AND
+    ``cli_ctx.verify`` is ``None``, prompts once to retry with
+    ``verify=False``. The returned :class:`CliContext` is the one that
+    actually produced a successful call — callers should use it for any
+    subsequent persistence so ``verify_ssl=False`` is recorded when
+    retry succeeded.
+    """
+
+    def __init__(
+        self,
+        *,
+        isatty: Callable[[], bool] | None = None,
+        confirm: _ConfirmFn | None = None,
+    ) -> None:
+        self._isatty = sys.stdin.isatty if isatty is None else isatty
+        self._confirm = typer.confirm if confirm is None else confirm
+
+    def run_with_ssl_retry(
+        self,
+        *,
+        attempt: Callable[[CliContext], None],
+        cli_ctx: CliContext,
+        target_url: str,
+    ) -> CliContext:
+        try:
+            attempt(cli_ctx)
+        except Exception as exc:
+            if not self._should_offer_retry(exc, cli_ctx):
+                raise
+            typer.echo(f"SSL verification failed for {target_url}.")
+            if not self._confirm(
+                "Retry with SSL verification disabled?",
+                default=False,
+            ):
+                raise
+            retry_ctx = replace(cli_ctx, verify=False)
+            attempt(retry_ctx)
+            return retry_ctx
+        return cli_ctx
+
+    def _should_offer_retry(
+        self,
+        exc: BaseException,
+        cli_ctx: CliContext,
+    ) -> bool:
+        if cli_ctx.verify is not None:
+            return False
+        if not self._isatty():
+            return False
+        return is_ssl_verify_error(exc)

--- a/tests/architecture/test_issue_63_invariants.py
+++ b/tests/architecture/test_issue_63_invariants.py
@@ -1,0 +1,92 @@
+"""Architectural invariants for issue #63 (interactive SSL retry).
+
+Pins the contract that the SSL-retry helper is:
+
+1. Type-based (no locale-sensitive substring matching on SSL messages).
+2. Composed locally inside the login commands — it does **not** leak
+   into :mod:`nextlabs_sdk._cli._error_handler`.
+3. Imported only by the two login call sites (``_auth_cmd`` and
+   ``_pdp_login``) inside the SDK source tree.
+4. Using an injected ``confirm`` callable — never a bare ``input(``,
+   a hard-coded ``click.confirm(``, or a direct ``typer.prompt(``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "nextlabs_sdk"
+_SSL_RETRY_FILE = _SRC_ROOT / "_cli" / "_ssl_retry.py"
+_ERROR_HANDLER_FILE = _SRC_ROOT / "_cli" / "_error_handler.py"
+_FORBIDDEN_SUBSTRINGS = ("CERTIFICATE_VERIFY_FAILED", "verify failed")
+
+
+def _string_constants(tree: ast.AST) -> list[str]:
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+
+def test_detector_does_not_use_string_matching() -> None:
+    tree = ast.parse(_SSL_RETRY_FILE.read_text(encoding="utf-8"))
+    for literal in _string_constants(tree):
+        for forbidden in _FORBIDDEN_SUBSTRINGS:
+            assert forbidden not in literal, (
+                f"Found forbidden substring '{forbidden}' "
+                f"in string literal: {literal!r}"
+            )
+
+
+def test_error_handler_does_not_import_ssl_retry() -> None:
+    source = _ERROR_HANDLER_FILE.read_text(encoding="utf-8")
+    assert "_ssl_retry" not in source
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module is None or "_ssl_retry" not in node.module
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "_ssl_retry" not in alias.name
+
+
+def test_ssl_retry_only_imported_by_login_handlers() -> None:
+    expected = {
+        _SRC_ROOT / "_cli" / "_auth_cmd.py",
+        _SRC_ROOT / "_cli" / "_pdp_login.py",
+    }
+    importers: set[Path] = set()
+    for path in _SRC_ROOT.rglob("*.py"):
+        if path == _SSL_RETRY_FILE:
+            continue
+        if "_ssl_retry" in path.read_text(encoding="utf-8"):
+            importers.add(path)
+    assert importers == expected, f"Unexpected importers: {importers}"
+
+
+def test_prompter_uses_injected_confirm() -> None:
+    tree = ast.parse(_SSL_RETRY_FILE.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "SslRetryPrompter"
+    )
+    forbidden_callees = {"input", "click.confirm", "typer.prompt"}
+    for call in ast.walk(class_node):
+        if not isinstance(call, ast.Call):
+            continue
+        callee = _dotted_name(call.func)
+        assert callee not in forbidden_callees, (
+            f"SslRetryPrompter must not call {callee} directly; "
+            "use the injected confirm callable instead."
+        )
+
+
+def _dotted_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_dotted_name(node.value)}.{node.attr}"
+    return ""

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -284,6 +284,161 @@ def test_login_persists_verify_false_when_no_verify_passed(login_ctx):
     assert entry.verify_ssl is False
 
 
+def _wrap_ssl_transport_error() -> "Exception":
+    import ssl
+
+    from nextlabs_sdk.exceptions import TransportError
+
+    cause = ssl.SSLCertVerificationError("certificate verify failed")
+    wrapped = TransportError("Connection error")
+    wrapped.__cause__ = cause
+    return wrapped
+
+
+def _patch_ssl_prompter(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    isatty: bool = True,
+    confirm: bool = True,
+) -> list[tuple[str, bool]]:
+    from nextlabs_sdk._cli import _auth_cmd
+    from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
+
+    confirms: list[tuple[str, bool]] = []
+
+    def _factory() -> SslRetryPrompter:
+        def _confirm_fn(text: str, *, default: bool = False) -> bool:
+            confirms.append((text, default))
+            return confirm
+
+        return SslRetryPrompter(
+            isatty=lambda: isatty,
+            confirm=_confirm_fn,
+        )
+
+    monkeypatch.setattr(_auth_cmd, "_SSL_RETRY_PROMPTER_FACTORY", _factory)
+    return confirms
+
+
+def _install_cloudaz_ssl_failing_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    succeed_on_retry: bool,
+) -> list[bool | None]:
+    call_verify: list[bool | None] = []
+
+    def _fake_make(ctx: CliContext) -> CloudAzClient:
+        call_verify.append(ctx.verify)
+        client = mock(CloudAzClient)
+        if len(call_verify) == 1:
+            when(client).authenticate().thenRaise(_wrap_ssl_transport_error())
+        elif succeed_on_retry:
+            when(client).authenticate().thenReturn(None)
+        else:
+            when(client).authenticate().thenRaise(_wrap_ssl_transport_error())
+        return cast(CloudAzClient, client)
+
+    monkeypatch.setattr(_client_factory, "make_cloudaz_client", _fake_make)
+    return call_verify
+
+
+def test_cloudaz_login_ssl_failure_retries_with_no_verify_and_persists(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+
+    _isolate_cache(tmp_path, monkeypatch)
+    call_verify = _install_cloudaz_ssl_failing_factory(
+        monkeypatch,
+        succeed_on_retry=True,
+    )
+    confirms = _patch_ssl_prompter(monkeypatch, isatty=True, confirm=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+            "--type",
+            "cloudaz",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_verify == [None, False]
+    assert len(confirms) == 1
+    store = AccountPreferencesStore(path=f"{tmp_path}/account_prefs.json")
+    prefs = store.load(
+        "https://example.com|admin|ControlCenterOIDCClient|cloudaz",
+    )
+    assert prefs is not None
+    assert prefs.verify_ssl is False
+
+
+def test_cloudaz_login_ssl_failure_on_decline_exits_one(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _install_cloudaz_ssl_failing_factory(monkeypatch, succeed_on_retry=False)
+    confirms = _patch_ssl_prompter(monkeypatch, isatty=True, confirm=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+            "--type",
+            "cloudaz",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert len(confirms) == 1
+
+
+def test_cloudaz_login_with_explicit_verify_true_skips_ssl_prompt(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_cache(tmp_path, monkeypatch)
+    _install_cloudaz_ssl_failing_factory(monkeypatch, succeed_on_retry=False)
+    confirms = _patch_ssl_prompter(monkeypatch, isatty=True, confirm=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "--verify",
+            "--base-url",
+            "https://example.com",
+            "--username",
+            "admin",
+            "--password",
+            "secret",
+            "auth",
+            "login",
+            "--type",
+            "cloudaz",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert confirms == []
+
+
 def test_logout_deletes_persisted_preference(
     tmp_path: object,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -17,10 +18,40 @@ from nextlabs_sdk._cli import _auth_cmd, _client_factory
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
+from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
 from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._operators import OperatorService
 
 runner = CliRunner()
+
+
+class _RecordingPrompter(SslRetryPrompter):
+    """Test double that records the ``target_url`` it is handed."""
+
+    def __init__(
+        self,
+        sink: list[str],
+        *,
+        isatty: Callable[[], bool],
+        confirm: Callable[..., bool],
+    ) -> None:
+        super().__init__(isatty=isatty, confirm=confirm)
+        self._sink = sink
+
+    def run_with_ssl_retry(
+        self,
+        *,
+        attempt: Callable[[CliContext], None],
+        cli_ctx: CliContext,
+        target_url: str,
+    ) -> CliContext:
+        self._sink.append(target_url)
+        return super().run_with_ssl_retry(
+            attempt=attempt,
+            cli_ctx=cli_ctx,
+            target_url=target_url,
+        )
 
 
 def _mock_cloudaz_client() -> CloudAzClient:
@@ -846,3 +877,154 @@ def test_pdp_login_non_tty_does_not_prompt_on_ssl_failure(
     assert result.exit_code == 1
     normalized = strip_ansi(result.output)
     assert "Connection error" in normalized or "SSL" in normalized
+
+
+def test_pdp_login_ssl_retry_does_not_reprompt_for_missing_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inputs supplied interactively once are reused on retry.
+
+    Regression guard for Copilot review on PR #64: if
+    ``_attempt_login`` were called twice against the original
+    (partially unresolved) ``CliContext``, each helper resolver would
+    fire twice — including the interactive ``typer.prompt`` paths.
+    """
+    import ssl
+
+    from nextlabs_sdk._cli import _pdp_login as _pdp_login_module
+
+    _isolate_cache(tmp_path, monkeypatch)
+
+    pdp_url_calls = [0]
+    client_secret_calls = [0]
+    original_pdp_url = _pdp_login_module._resolve_pdp_url
+    original_client_secret = _pdp_login_module._resolve_client_secret
+
+    def _counting_pdp_url(ctx: CliContext, flavor: PdpAuthSource) -> str:
+        if ctx.pdp_url is None:
+            pdp_url_calls[0] += 1
+            return "https://pdp.example"
+        return original_pdp_url(ctx, flavor)
+
+    def _counting_client_secret(ctx: CliContext, flavor: PdpAuthSource) -> str:
+        if ctx.client_secret is None:
+            client_secret_calls[0] += 1
+            return "S3cret"
+        return original_client_secret(ctx, flavor)
+
+    monkeypatch.setattr(
+        _pdp_login_module,
+        "_resolve_pdp_url",
+        _counting_pdp_url,
+    )
+    monkeypatch.setattr(
+        _pdp_login_module,
+        "_resolve_client_secret",
+        _counting_client_secret,
+    )
+
+    calls_verify: list[object] = []
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+
+    def _fake_post(*_args: object, **kwargs: object) -> object:
+        calls_verify.append(kwargs.get("verify"))
+        if len(calls_verify) == 1:
+            cause = ssl.SSLCertVerificationError("verify failed")
+            wrapped = httpx.ConnectError("verify failed")
+            wrapped.__cause__ = cause
+            raise wrapped
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    _install_pdp_ssl_retry_prompter(monkeypatch, isatty=True, confirm=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-client-id",
+            "ccid",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls_verify == [True, False]
+    assert pdp_url_calls == [1]
+    assert client_secret_calls == [1]
+
+
+def test_pdp_login_ssl_retry_target_url_reflects_resolved_pdp_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prompt message shows the resolved PDP URL, not an empty string.
+
+    Regression guard for Copilot review on PR #64: previously,
+    ``target_url`` was computed from the *unresolved* CliContext, so a
+    user prompted for ``--pdp-url`` would see "SSL verification failed
+    for ." with an empty URL.
+    """
+    from nextlabs_sdk._cli import _pdp_login as _pdp_login_module
+
+    _isolate_cache(tmp_path, monkeypatch)
+
+    original_pdp_url = _pdp_login_module._resolve_pdp_url
+
+    def _fake_pdp_url(ctx: CliContext, flavor: PdpAuthSource) -> str:
+        if ctx.pdp_url is None:
+            return "https://pdp.example"
+        return original_pdp_url(ctx, flavor)
+
+    monkeypatch.setattr(
+        _pdp_login_module,
+        "_resolve_pdp_url",
+        _fake_pdp_url,
+    )
+
+    observed_target: list[str] = []
+
+    monkeypatch.setattr(
+        _pdp_login_module,
+        "_SSL_RETRY_PROMPTER_FACTORY",
+        lambda: _RecordingPrompter(
+            observed_target,
+            isatty=lambda: True,
+            confirm=lambda _t, *, default=False: True,
+        ),
+    )
+
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+
+    def _fake_post(*_args: object, **_kwargs: object) -> object:
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed_target == ["https://pdp.example"]

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -733,3 +733,116 @@ def test_switching_active_account_between_kinds(
     active_after_forward = active_store.load()
     assert active_after_forward is not None
     assert active_after_forward.kind == "pdp"
+
+
+def _install_pdp_ssl_retry_prompter(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    isatty: bool,
+    confirm: bool = True,
+) -> None:
+    from nextlabs_sdk._cli import _pdp_login
+    from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
+
+    def _factory() -> SslRetryPrompter:
+        return SslRetryPrompter(
+            isatty=lambda: isatty,
+            confirm=lambda _text, *, default=False: confirm,
+        )
+
+    monkeypatch.setattr(_pdp_login, "_SSL_RETRY_PROMPTER_FACTORY", _factory)
+
+
+def test_pdp_login_ssl_failure_retries_and_persists_verify_ssl_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ssl
+
+    _isolate_cache(tmp_path, monkeypatch)
+    calls_verify: list[object] = []
+
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+
+    def _fake_post(*_args: object, **kwargs: object) -> object:
+        calls_verify.append(kwargs.get("verify"))
+        if len(calls_verify) == 1:
+            cause = ssl.SSLCertVerificationError("verify failed")
+            wrapped = httpx.ConnectError("verify failed")
+            wrapped.__cause__ = cause
+            raise wrapped
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    _install_pdp_ssl_retry_prompter(monkeypatch, isatty=True, confirm=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls_verify == [True, False]
+
+    prefs = AccountPreferencesStore(
+        path=tmp_path / "account_prefs.json",
+    ).load("https://pdp.example||ccid|pdp")
+    assert prefs is not None
+    assert prefs.verify_ssl is False
+    assert prefs.pdp_url == "https://pdp.example"
+    assert prefs.pdp_auth_source == "pdp"
+
+
+def test_pdp_login_non_tty_does_not_prompt_on_ssl_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ssl
+
+    _isolate_cache(tmp_path, monkeypatch)
+
+    def _fake_post(*_args: object, **_kwargs: object) -> object:
+        cause = ssl.SSLCertVerificationError("verify failed")
+        wrapped = httpx.ConnectError("verify failed")
+        wrapped.__cause__ = cause
+        raise wrapped
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    _install_pdp_ssl_retry_prompter(monkeypatch, isatty=False, confirm=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 1
+    normalized = strip_ansi(result.output)
+    assert "Connection error" in normalized or "SSL" in normalized

--- a/tests/test_cli_ssl_retry.py
+++ b/tests/test_cli_ssl_retry.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._output_format import OutputFormat
+from nextlabs_sdk._cli._ssl_retry import (
+    SslRetryPrompter,
+    is_ssl_verify_error,
+)
+from nextlabs_sdk.exceptions import TransportError
+
+
+def _wrap(outer: Exception, cause: BaseException) -> Exception:
+    outer.__cause__ = cause
+    return outer
+
+
+def test_detects_direct_ssl_cert_verify_error() -> None:
+    exc = ssl.SSLCertVerificationError("certificate verify failed")
+    assert is_ssl_verify_error(exc) is True
+
+
+def test_detects_ssl_error_with_verify_code() -> None:
+    exc = ssl.SSLError("bad cert")
+    setattr(exc, "verify_code", 18)
+    setattr(exc, "verify_message", "self-signed certificate")
+    assert is_ssl_verify_error(exc) is True
+
+
+def test_detects_ssl_error_wrapped_in_transport_error_via_cause() -> None:
+    cause = ssl.SSLCertVerificationError("certificate verify failed")
+    wrapped = _wrap(TransportError("Connection error"), cause)
+    assert is_ssl_verify_error(wrapped) is True
+
+
+def test_returns_false_for_unrelated_oserror() -> None:
+    assert is_ssl_verify_error(OSError("connection refused")) is False
+
+
+def test_returns_false_for_ssl_error_without_verify_code() -> None:
+    exc = ssl.SSLError("handshake failure")
+    assert is_ssl_verify_error(exc) is False
+
+
+# ─────────────────── SslRetryPrompter tests ────────────────────
+
+
+def _ctx(verify: bool | None = None, verbose: int = 0) -> CliContext:
+    return CliContext(
+        base_url="https://example.com",
+        username="u",
+        password="p",
+        client_id="cid",
+        client_secret=None,
+        pdp_url=None,
+        output_format=OutputFormat.TABLE,
+        verify=verify,
+        timeout=30.0,
+        verbose=verbose,
+    )
+
+
+def _make_prompter(
+    *,
+    isatty: bool = True,
+    confirm_answer: bool = True,
+    confirms: list[tuple[str, bool]] | None = None,
+) -> SslRetryPrompter:
+    def _isatty() -> bool:
+        return isatty
+
+    def _confirm(text: str, *, default: bool = False) -> bool:
+        if confirms is not None:
+            confirms.append((text, default))
+        return confirm_answer
+
+    return SslRetryPrompter(isatty=_isatty, confirm=_confirm)
+
+
+def _wrap_ssl_error() -> TransportError:
+    cause = ssl.SSLCertVerificationError("certificate verify failed")
+    wrapped = TransportError("Connection error")
+    wrapped.__cause__ = cause
+    return wrapped
+
+
+def test_attempt_succeeds_on_first_call_returns_original_ctx() -> None:
+    calls: list[CliContext] = []
+
+    def _attempt(ctx: CliContext) -> None:
+        calls.append(ctx)
+
+    prompter = _make_prompter()
+    original = _ctx()
+
+    used = prompter.run_with_ssl_retry(
+        attempt=_attempt,
+        cli_ctx=original,
+        target_url="https://example.com",
+    )
+
+    assert used is original
+    assert calls == [original]
+
+
+def test_ssl_error_on_tty_with_yes_retries_with_verify_false() -> None:
+    calls: list[CliContext] = []
+
+    def _attempt(ctx: CliContext) -> None:
+        calls.append(ctx)
+        if len(calls) == 1:
+            raise _wrap_ssl_error()
+
+    confirms: list[tuple[str, bool]] = []
+    prompter = _make_prompter(isatty=True, confirm_answer=True, confirms=confirms)
+    original = _ctx()
+
+    used = prompter.run_with_ssl_retry(
+        attempt=_attempt,
+        cli_ctx=original,
+        target_url="https://example.com",
+    )
+
+    assert len(calls) == 2
+    assert calls[0].verify is None
+    assert calls[1].verify is False
+    assert used.verify is False
+    assert len(confirms) == 1
+    assert "Retry with SSL verification disabled?" in confirms[0][0]
+    assert confirms[0][1] is False
+
+
+def test_ssl_error_on_tty_with_no_reraises_original() -> None:
+    def _attempt(_ctx: CliContext) -> None:
+        raise _wrap_ssl_error()
+
+    prompter = _make_prompter(isatty=True, confirm_answer=False)
+
+    with pytest.raises(TransportError):
+        prompter.run_with_ssl_retry(
+            attempt=_attempt,
+            cli_ctx=_ctx(),
+            target_url="https://example.com",
+        )
+
+
+def test_non_tty_reraises_without_confirm() -> None:
+    confirms: list[tuple[str, bool]] = []
+
+    def _attempt(_ctx: CliContext) -> None:
+        raise _wrap_ssl_error()
+
+    prompter = _make_prompter(isatty=False, confirms=confirms)
+
+    with pytest.raises(TransportError):
+        prompter.run_with_ssl_retry(
+            attempt=_attempt,
+            cli_ctx=_ctx(),
+            target_url="https://example.com",
+        )
+
+    assert confirms == []
+
+
+def test_explicit_verify_false_skips_prompt_and_reraises() -> None:
+    confirms: list[tuple[str, bool]] = []
+
+    def _attempt(_ctx: CliContext) -> None:
+        raise _wrap_ssl_error()
+
+    prompter = _make_prompter(isatty=True, confirms=confirms)
+
+    with pytest.raises(TransportError):
+        prompter.run_with_ssl_retry(
+            attempt=_attempt,
+            cli_ctx=_ctx(verify=False),
+            target_url="https://example.com",
+        )
+
+    assert confirms == []
+
+
+def test_non_ssl_transport_error_propagates_without_prompt() -> None:
+    confirms: list[tuple[str, bool]] = []
+
+    def _attempt(_ctx: CliContext) -> None:
+        raise TransportError("Connection refused")
+
+    prompter = _make_prompter(isatty=True, confirms=confirms)
+
+    with pytest.raises(TransportError, match="Connection refused"):
+        prompter.run_with_ssl_retry(
+            attempt=_attempt,
+            cli_ctx=_ctx(),
+            target_url="https://example.com",
+        )
+
+    assert confirms == []
+
+
+def test_retry_also_fails_propagates_retry_error() -> None:
+    attempts: list[CliContext] = []
+
+    def _attempt(ctx: CliContext) -> None:
+        attempts.append(ctx)
+        if len(attempts) == 1:
+            raise _wrap_ssl_error()
+        raise TransportError("second-failure")
+
+    prompter = _make_prompter(isatty=True, confirm_answer=True)
+
+    with pytest.raises(TransportError, match="second-failure"):
+        prompter.run_with_ssl_retry(
+            attempt=_attempt,
+            cli_ctx=_ctx(),
+            target_url="https://example.com",
+        )
+
+    assert len(attempts) == 2
+    assert attempts[1].verify is False


### PR DESCRIPTION
Closes #63

## Summary

On an interactive terminal, `nextlabs auth login` (both `--type cloudaz` and `--type pdp`) now detects TLS verification failures and offers a one-shot retry with `verify=False` (default: **No**). Accepting persists `verify_ssl=False` for that account in `AccountPreferences`, so subsequent commands honor the user's choice.

Non-TTY invocations, runs with an explicit `--verify` / `--no-verify`, and non-SSL errors behave exactly as before.

## Approach

A new package-private module `_cli/_ssl_retry.py` owns all SSL-retry concerns:

- `is_ssl_verify_error(exc)` — walks `__cause__`/`__context__` up to a bounded depth to detect `ssl.SSLCertVerificationError` or an `ssl.SSLError` with a truthy `verify_code`. Type-based, no string matching.
- `SslRetryPrompter` — injectable orchestrator mirroring the `ReauthPrompter` DI shape; runs the login attempt and, on eligibility, confirms once and re-runs with `replace(cli_ctx, verify=False)`.

`_cli/_auth_cmd.py::login` and `_cli/_pdp_login.py::login_pdp` route their network-touching work through the prompter and persist preferences using the returned `CliContext`. `cli_error_handler` is unchanged.

## Tests

- `tests/test_cli_ssl_retry.py` — 12 unit tests for detector + prompter.
- `tests/test_cli_auth.py` — 3 integration tests (retry-success persists `verify_ssl=False`, decline exits 1, `--verify` skips the prompt).
- `tests/test_cli_auth_pdp_login.py` — 2 integration tests (retry-success persists `verify_ssl=False`, non-TTY re-raises without prompting).
- `tests/architecture/test_issue_63_invariants.py` — AST-level guardrails pinning the contract (no string matching, no leak into `_error_handler`, only `_auth_cmd`/`_pdp_login` import `_ssl_retry`, prompter uses injected `confirm`).

Full suite (`python ./tools/tests.py --short`) green (1864 passed, 96.03% coverage); `python ./tools/checks.py` green.

## Review Step

All invariants pass; all recommended regression tests except "verbose output on retry failure" (pre-existing `cli_error_handler` behavior, unchanged by this PR — no new coverage warranted).

No Tier 2/3 `lint-escape` suppressions were used; flake8's `WPS430` (nested function) was avoided by flattening to a module-level helper (`_cloudaz_login_attempt`) and a small stateful callable (`_PdpLoginAttempt`) rather than closures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>