### PR TITLE
feat(pdp): support file-based request payloads (JSON/YAML/XACML) — implements #65 tracer bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,37 @@ empty username; target them explicitly with
 `nextlabs auth logout` clears the cached token, preferences, and active
 pointer for the selected account.
 
+### PDP request payload files
+
+Both `nextlabs pdp eval` and `nextlabs pdp permissions` accept a
+`--payload PATH` option that loads the request body from a JSON, YAML,
+or raw XACML JSON file instead of assembling it from individual flags.
+`--payload` is mutually exclusive with any request-shaping flag
+(`--subject`, `--resource`, `--action`, `--subject-attr`, …).
+
+Structured JSON (validated against `EvalRequest` / `PermissionsRequest`):
+
+```bash
+nextlabs pdp eval --payload ./request.json
+```
+
+Structured YAML (requires the optional extra — `pip install 'nextlabs-sdk[yaml]'`):
+
+```bash
+nextlabs pdp eval --payload ./request.yaml
+```
+
+Raw XACML JSON (top-level `{"Request": {"Category": [...]}}`) is
+auto-detected by shape and forwarded verbatim to the PDP:
+
+```bash
+nextlabs pdp eval --payload ./xacml.json
+```
+
+Format auto-detection can be overridden with `--payload-format` (one of
+`auto`, `json`, `yaml`, `xacml`). `--payload-format xacml` forces the
+raw-XACML passthrough and rejects files whose shape does not match.
+
 **Environment variables**
 
 | Variable                   | Purpose                                                       |

--- a/README.md
+++ b/README.md
@@ -449,12 +449,14 @@ Structured JSON (validated against `EvalRequest` / `PermissionsRequest`):
 
 ```bash
 nextlabs pdp eval --payload ./request.json
+nextlabs pdp permissions --payload ./permissions-request.json
 ```
 
 Structured YAML (requires the optional extra — `pip install 'nextlabs-sdk[yaml]'`):
 
 ```bash
 nextlabs pdp eval --payload ./request.yaml
+nextlabs pdp permissions --payload ./permissions-request.yaml
 ```
 
 Raw XACML JSON (top-level `{"Request": {"Category": [...]}}`) is
@@ -462,6 +464,7 @@ auto-detected by shape and forwarded verbatim to the PDP:
 
 ```bash
 nextlabs pdp eval --payload ./xacml.json
+nextlabs pdp permissions --payload ./xacml.json
 ```
 
 Format auto-detection can be overridden with `--payload-format` (one of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ cli = [
     "typer>=0.12,<1.0",
     "rich>=13.0,<14.0",
 ]
+yaml = [
+    "PyYAML>=6.0",
+]
 
 [project.scripts]
 nextlabs = "nextlabs_sdk._cli._entrypoint:main"

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 from types import MappingProxyType
 from typing import Annotated
 
@@ -15,19 +16,30 @@ from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import render_json
 from nextlabs_sdk._cli._output_format import OutputFormat
-from nextlabs_sdk._cli._parsing import parse_key_value_attrs
+from nextlabs_sdk._cli._pdp_payload_helpers import (
+    FlagInputs,
+    build_eval_request,
+    build_permissions_request,
+    reject_payload_conflicts,
+    require_flags,
+    run_payload_loader,
+)
 from nextlabs_sdk._pdp import (
-    Action,
-    Application,
     ContentType,
     Decision,
-    Environment,
     EvalRequest,
     EvalResponse,
-    Resource,
+    Obligation,
+    PermissionsRequest,
+    PermissionsResponse,
+    PolicyRef,
 )
-from nextlabs_sdk._pdp import Obligation, PolicyRef, ResourceDimension, Subject
-from nextlabs_sdk._pdp import PermissionsRequest, PermissionsResponse
+from nextlabs_sdk._pdp._client import PdpClient
+from nextlabs_sdk._pdp._payload._format import LoadedPayload, PayloadFormat
+from nextlabs_sdk._pdp._payload._loader import (
+    load_eval_payload,
+    load_permissions_payload,
+)
 
 pdp_app = typer.Typer(help="PDP evaluation commands")
 
@@ -109,16 +121,85 @@ def _render_permissions_detail(model: BaseModel, console: Console) -> None:
     _render_permissions_response(model, console)
 
 
+def _resolve_content_type(wire_format: str) -> ContentType:
+    return ContentType.XML if wire_format == "xml" else ContentType.JSON
+
+
+def _emit_eval(
+    response: EvalResponse,
+    output_format: OutputFormat,
+) -> None:
+    if output_format is OutputFormat.JSON:
+        render_json(response)
+    else:
+        _render_eval_response(response, Console())
+
+
+def _emit_permissions(
+    response: PermissionsResponse,
+    output_format: OutputFormat,
+) -> None:
+    if output_format is OutputFormat.JSON:
+        render_json(response)
+    else:
+        _render_permissions_response(response, Console())
+
+
+def _dispatch_eval_payload(
+    client: PdpClient,
+    loaded: LoadedPayload,
+    content_type: ContentType,
+) -> EvalResponse:
+    if loaded.kind == "raw_xacml":
+        assert loaded.body is not None
+        return client.evaluate_raw(loaded.body)
+    assert isinstance(loaded.request, EvalRequest)
+    return client.evaluate(loaded.request, content_type=content_type)
+
+
+def _dispatch_permissions_payload(
+    client: PdpClient,
+    loaded: LoadedPayload,
+    content_type: ContentType,
+) -> PermissionsResponse:
+    if loaded.kind == "raw_xacml":
+        assert loaded.body is not None
+        return client.permissions_raw(loaded.body)
+    assert isinstance(loaded.request, PermissionsRequest)
+    return client.permissions(loaded.request, content_type=content_type)
+
+
 @pdp_app.command(name="eval")
 @cli_error_handler
 def evaluate(
     ctx: typer.Context,
-    subject_id: Annotated[str, typer.Option("--subject", help="Subject ID")],
-    resource_id: Annotated[str, typer.Option("--resource", help="Resource ID")],
+    payload_path: Annotated[
+        Path | None,
+        typer.Option(
+            "--payload",
+            help="Path to a YAML / JSON / raw XACML JSON request file.",
+        ),
+    ] = None,
+    payload_format: Annotated[
+        PayloadFormat,
+        typer.Option(
+            "--payload-format",
+            help="Force payload format (auto, yaml, json, xacml).",
+            case_sensitive=False,
+        ),
+    ] = PayloadFormat.AUTO,
+    subject_id: Annotated[
+        str | None, typer.Option("--subject", help="Subject ID")
+    ] = None,
+    resource_id: Annotated[
+        str | None, typer.Option("--resource", help="Resource ID")
+    ] = None,
     resource_type: Annotated[
-        str, typer.Option("--resource-type", help="Resource type")
-    ],
-    action_id: Annotated[str, typer.Option("--action", help="Action name")],
+        str | None, typer.Option("--resource-type", help="Resource type")
+    ] = None,
+    action_id: Annotated[
+        str | None, typer.Option("--action", help="Action name")
+    ] = None,
     application_id: Annotated[
         str, typer.Option("--application", help="Application ID")
     ] = "",
@@ -154,59 +235,64 @@ def evaluate(
 ) -> None:
     """Evaluate a PDP policy decision."""
     cli_ctx: CliContext = ctx.obj
-    subject = Subject(
-        id=subject_id,
-        attributes=parse_key_value_attrs(subject_attrs or []),
-    )
-    dimension = None
-    if resource_dimension:
-        try:
-            dimension = ResourceDimension(resource_dimension)
-        except ValueError:
-            raise typer.BadParameter(
-                f"Invalid resource dimension: {resource_dimension}. "
-                f"Must be 'from' or 'to'",
-            )
-    resource = Resource(
-        id=resource_id,
-        type=resource_type,
-        dimension=dimension,
-        nocache=resource_nocache,
-        attributes=parse_key_value_attrs(resource_attrs or []),
-    )
-    application = Application(
-        id=application_id,
-        attributes=parse_key_value_attrs(app_attrs or []),
-    )
-    environment = (
-        Environment(attributes=parse_key_value_attrs(env_attrs)) if env_attrs else None
-    )
-    ct_enum = ContentType.XML if wire_format == "xml" else ContentType.JSON
-    request = EvalRequest(
-        subject=subject,
-        resource=resource,
-        action=Action(id=action_id),
-        application=application,
-        environment=environment,
+    flags = FlagInputs(
+        subject_id=subject_id,
+        resource_id=resource_id,
+        resource_type=resource_type,
+        action_id=action_id,
+        application_id=application_id,
+        subject_attrs=subject_attrs,
+        resource_attrs=resource_attrs,
+        app_attrs=app_attrs,
+        env_attrs=env_attrs,
+        resource_dimension=resource_dimension,
+        resource_nocache=resource_nocache,
         return_policy_ids=return_policy_ids,
     )
+    content_type = _resolve_content_type(wire_format)
     client = _client_factory.make_pdp_client(cli_ctx)
-    response = client.evaluate(request, content_type=ct_enum)
-    if cli_ctx.output_format is OutputFormat.JSON:
-        render_json(response)
+
+    if payload_path is None:
+        require_flags(flags, need_action=True)
+        request = build_eval_request(flags)
+        response = client.evaluate(request, content_type=content_type)
     else:
-        _render_eval_response(response, Console())
+        reject_payload_conflicts(flags)
+        loaded = run_payload_loader(load_eval_payload, payload_path, payload_format)
+        assert isinstance(loaded, LoadedPayload)
+        response = _dispatch_eval_payload(client, loaded, content_type)
+
+    _emit_eval(response, cli_ctx.output_format)
 
 
 @pdp_app.command()
 @cli_error_handler
 def permissions(
     ctx: typer.Context,
-    subject_id: Annotated[str, typer.Option("--subject", help="Subject ID")],
-    resource_id: Annotated[str, typer.Option("--resource", help="Resource ID")],
+    payload_path: Annotated[
+        Path | None,
+        typer.Option(
+            "--payload",
+            help="Path to a YAML / JSON / raw XACML JSON request file.",
+        ),
+    ] = None,
+    payload_format: Annotated[
+        PayloadFormat,
+        typer.Option(
+            "--payload-format",
+            help="Force payload format (auto, yaml, json, xacml).",
+            case_sensitive=False,
+        ),
+    ] = PayloadFormat.AUTO,
+    subject_id: Annotated[
+        str | None, typer.Option("--subject", help="Subject ID")
+    ] = None,
+    resource_id: Annotated[
+        str | None, typer.Option("--resource", help="Resource ID")
+    ] = None,
     resource_type: Annotated[
-        str, typer.Option("--resource-type", help="Resource type")
-    ],
+        str | None, typer.Option("--resource-type", help="Resource type")
+    ] = None,
     application_id: Annotated[
         str, typer.Option("--application", help="Application ID")
     ] = "",
@@ -246,48 +332,38 @@ def permissions(
 ) -> None:
     """Get allowed and denied actions for a subject-resource pair."""
     cli_ctx: CliContext = ctx.obj
-    subject = Subject(
-        id=subject_id,
-        attributes=parse_key_value_attrs(subject_attrs or []),
-    )
-    dimension = None
-    if resource_dimension:
-        try:
-            dimension = ResourceDimension(resource_dimension)
-        except ValueError:
-            raise typer.BadParameter(
-                f"Invalid resource dimension: {resource_dimension}. "
-                f"Must be 'from' or 'to'",
-            )
-    resource = Resource(
-        id=resource_id,
-        type=resource_type,
-        dimension=dimension,
-        nocache=resource_nocache,
-        attributes=parse_key_value_attrs(resource_attrs or []),
-    )
-    application = Application(
-        id=application_id,
-        attributes=parse_key_value_attrs(app_attrs or []),
-    )
-    environment = (
-        Environment(attributes=parse_key_value_attrs(env_attrs)) if env_attrs else None
-    )
-    ct_enum = ContentType.XML if wire_format == "xml" else ContentType.JSON
-    request = PermissionsRequest(
-        subject=subject,
-        resource=resource,
-        application=application,
-        environment=environment,
+    flags = FlagInputs(
+        subject_id=subject_id,
+        resource_id=resource_id,
+        resource_type=resource_type,
+        application_id=application_id,
+        subject_attrs=subject_attrs,
+        resource_attrs=resource_attrs,
+        app_attrs=app_attrs,
+        env_attrs=env_attrs,
+        resource_dimension=resource_dimension,
+        resource_nocache=resource_nocache,
         return_policy_ids=return_policy_ids,
         record_matching_policies=record_matching_policies,
     )
+    content_type = _resolve_content_type(wire_format)
     client = _client_factory.make_pdp_client(cli_ctx)
-    response = client.permissions(request, content_type=ct_enum)
-    if cli_ctx.output_format is OutputFormat.JSON:
-        render_json(response)
+
+    if payload_path is None:
+        require_flags(flags, need_action=False)
+        request = build_permissions_request(flags)
+        response = client.permissions(request, content_type=content_type)
     else:
-        _render_permissions_response(response, Console())
+        reject_payload_conflicts(flags)
+        loaded = run_payload_loader(
+            load_permissions_payload,
+            payload_path,
+            payload_format,
+        )
+        assert isinstance(loaded, LoadedPayload)
+        response = _dispatch_permissions_payload(client, loaded, content_type)
+
+    _emit_permissions(response, cli_ctx.output_format)
 
 
 register_detail_renderer(EvalResponse, _render_eval_detail)

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -152,7 +152,7 @@ def _dispatch_eval_payload(
 ) -> EvalResponse:
     if loaded.kind == "raw_xacml":
         assert loaded.body is not None
-        return client.evaluate_raw(loaded.body)
+        return client.evaluate_raw(loaded.body, content_type=content_type)
     assert isinstance(loaded.request, EvalRequest)
     return client.evaluate(loaded.request, content_type=content_type)
 
@@ -164,7 +164,7 @@ def _dispatch_permissions_payload(
 ) -> PermissionsResponse:
     if loaded.kind == "raw_xacml":
         assert loaded.body is not None
-        return client.permissions_raw(loaded.body)
+        return client.permissions_raw(loaded.body, content_type=content_type)
     assert isinstance(loaded.request, PermissionsRequest)
     return client.permissions(loaded.request, content_type=content_type)
 

--- a/src/nextlabs_sdk/_cli/_pdp_payload_helpers.py
+++ b/src/nextlabs_sdk/_cli/_pdp_payload_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Protocol
 
 import typer
 
@@ -153,14 +153,23 @@ def _build_environment(flags: FlagInputs) -> Environment | None:
     return Environment(attributes=parse_key_value_attrs(flags.env_attrs))
 
 
+class _PayloadLoader(Protocol):
+    def __call__(
+        self,
+        source: Path,
+        *,
+        payload_format: PayloadFormat,
+    ) -> LoadedPayload: ...
+
+
 def run_payload_loader(
-    loader: Callable[[Path, PayloadFormat], LoadedPayload],
+    loader: _PayloadLoader,
     path: Path,
     payload_format: PayloadFormat,
 ) -> LoadedPayload:
     """Invoke ``loader`` translating :class:`PdpPayloadError` into CLI exit."""
     try:
-        return loader(path, payload_format)
+        return loader(path, payload_format=payload_format)
     except PdpPayloadError as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from None

--- a/src/nextlabs_sdk/_cli/_pdp_payload_helpers.py
+++ b/src/nextlabs_sdk/_cli/_pdp_payload_helpers.py
@@ -1,0 +1,166 @@
+"""PDP CLI helpers: build requests, dispatch payloads, format selectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import typer
+
+from nextlabs_sdk._cli._output import print_error
+from nextlabs_sdk._cli._parsing import parse_key_value_attrs
+from nextlabs_sdk._pdp import ResourceDimension
+from nextlabs_sdk._pdp._payload._format import LoadedPayload, PayloadFormat
+from nextlabs_sdk._pdp._request_models import (
+    Action,
+    Application,
+    Environment,
+    EvalRequest,
+    PermissionsRequest,
+    Resource,
+    Subject,
+)
+from nextlabs_sdk.exceptions import PdpPayloadError
+
+
+@dataclass(frozen=True)
+class FlagInputs:
+    """Raw request-shaping CLI option values, before validation."""
+
+    subject_id: str | None = None
+    resource_id: str | None = None
+    resource_type: str | None = None
+    action_id: str | None = None
+    application_id: str = ""
+    subject_attrs: list[str] | None = None
+    resource_attrs: list[str] | None = None
+    app_attrs: list[str] | None = None
+    env_attrs: list[str] | None = None
+    resource_dimension: str | None = None
+    resource_nocache: bool = False
+    return_policy_ids: bool = False
+    record_matching_policies: bool = False
+
+
+def reject_payload_conflicts(flags: FlagInputs) -> None:
+    """Raise a Typer error naming any flag that conflicts with ``--payload``."""
+    conflicts = _collect_conflicts(flags)
+    if conflicts:
+        joined = ", ".join(conflicts)
+        print_error(
+            f"--payload cannot be combined with request-shaping flags; remove: {joined}",
+        )
+        raise typer.Exit(code=1)
+
+
+def _collect_conflicts(flags: FlagInputs) -> list[str]:
+    checks: list[tuple[str, object]] = [
+        ("--subject", flags.subject_id),
+        ("--resource", flags.resource_id),
+        ("--resource-type", flags.resource_type),
+        ("--action", flags.action_id),
+        ("--application", flags.application_id),
+        ("--subject-attr", flags.subject_attrs),
+        ("--resource-attr", flags.resource_attrs),
+        ("--app-attr", flags.app_attrs),
+        ("--env-attr", flags.env_attrs),
+        ("--resource-dimension", flags.resource_dimension),
+        ("--resource-nocache", flags.resource_nocache or None),
+        ("--return-policy-ids", flags.return_policy_ids or None),
+        ("--record-matching-policies", flags.record_matching_policies or None),
+    ]
+    return [name for name, given in checks if given]
+
+
+def require_flags(flags: FlagInputs, *, need_action: bool) -> None:
+    """Validate required request-shaping flags when ``--payload`` is absent."""
+    missing: list[str] = []
+    if not flags.subject_id:
+        missing.append("--subject")
+    if not flags.resource_id:
+        missing.append("--resource")
+    if not flags.resource_type:
+        missing.append("--resource-type")
+    if need_action and not flags.action_id:
+        missing.append("--action")
+    if missing:
+        joined = ", ".join(missing)
+        print_error(f"Missing required option(s): {joined}")
+        raise typer.Exit(code=1)
+
+
+def parse_dimension(raw: str | None) -> ResourceDimension | None:
+    if not raw:
+        return None
+    try:
+        return ResourceDimension(raw)
+    except ValueError:
+        raise typer.BadParameter(
+            f"Invalid resource dimension: {raw}. Must be 'from' or 'to'",
+        )
+
+
+def build_eval_request(flags: FlagInputs) -> EvalRequest:
+    return EvalRequest(
+        subject=_build_subject(flags),
+        resource=_build_resource(flags),
+        action=Action(id=flags.action_id or ""),
+        application=_build_application(flags),
+        environment=_build_environment(flags),
+        return_policy_ids=flags.return_policy_ids,
+    )
+
+
+def build_permissions_request(flags: FlagInputs) -> PermissionsRequest:
+    return PermissionsRequest(
+        subject=_build_subject(flags),
+        resource=_build_resource(flags),
+        application=_build_application(flags),
+        environment=_build_environment(flags),
+        return_policy_ids=flags.return_policy_ids,
+        record_matching_policies=flags.record_matching_policies,
+    )
+
+
+def _build_subject(flags: FlagInputs) -> Subject:
+    return Subject(
+        id=flags.subject_id or "",
+        attributes=parse_key_value_attrs(flags.subject_attrs or []),
+    )
+
+
+def _build_resource(flags: FlagInputs) -> Resource:
+    return Resource(
+        id=flags.resource_id or "",
+        type=flags.resource_type or "",
+        dimension=parse_dimension(flags.resource_dimension),
+        nocache=flags.resource_nocache,
+        attributes=parse_key_value_attrs(flags.resource_attrs or []),
+    )
+
+
+def _build_application(flags: FlagInputs) -> Application:
+    return Application(
+        id=flags.application_id,
+        attributes=parse_key_value_attrs(flags.app_attrs or []),
+    )
+
+
+def _build_environment(flags: FlagInputs) -> Environment | None:
+    if not flags.env_attrs:
+        return None
+    return Environment(attributes=parse_key_value_attrs(flags.env_attrs))
+
+
+def run_payload_loader(
+    loader: Callable[[Path, PayloadFormat], LoadedPayload],
+    path: Path,
+    payload_format: PayloadFormat,
+) -> LoadedPayload:
+    """Invoke ``loader`` translating :class:`PdpPayloadError` into CLI exit."""
+    try:
+        return loader(path, payload_format)
+    except PdpPayloadError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from None

--- a/src/nextlabs_sdk/_pdp/_async_client.py
+++ b/src/nextlabs_sdk/_pdp/_async_client.py
@@ -12,10 +12,18 @@ from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
-from nextlabs_sdk.exceptions import raise_for_status
+from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
 _CONTENT_TYPE = "Content-Type"
+
+
+def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
+    if content_type is not ContentType.JSON:
+        raise NextLabsError(
+            f"{method}() only supports ContentType.JSON; "
+            f"raw XML pass-through is not implemented",
+        )
 
 
 class AsyncPdpClient:
@@ -94,6 +102,46 @@ class AsyncPdpClient:
             return xml_ser.deserialize_permissions_response(response.content)
 
         body = json_ser.serialize_permissions_request(request)
+        response = await self._client.post(
+            _PDP_ENDPOINT,
+            json=body,
+            headers={_CONTENT_TYPE: content_type.value},
+        )
+        raise_for_status(response)
+        return decode_pdp_response(
+            response,
+            json_ser.deserialize_permissions_response,
+            what="permissions response",
+        )
+
+    async def evaluate_raw(
+        self,
+        body: dict[str, object],
+        *,
+        content_type: ContentType = ContentType.JSON,
+    ) -> EvalResponse:
+        """POST a pre-built raw XACML JSON body to the PDP eval endpoint."""
+        _require_json_content_type(content_type, method="evaluate_raw")
+        response = await self._client.post(
+            _PDP_ENDPOINT,
+            json=body,
+            headers={_CONTENT_TYPE: content_type.value},
+        )
+        raise_for_status(response)
+        return decode_pdp_response(
+            response,
+            json_ser.deserialize_eval_response,
+            what="eval response",
+        )
+
+    async def permissions_raw(
+        self,
+        body: dict[str, object],
+        *,
+        content_type: ContentType = ContentType.JSON,
+    ) -> PermissionsResponse:
+        """POST a pre-built raw XACML JSON body to the PDP permissions endpoint."""
+        _require_json_content_type(content_type, method="permissions_raw")
         response = await self._client.post(
             _PDP_ENDPOINT,
             json=body,

--- a/src/nextlabs_sdk/_pdp/_client.py
+++ b/src/nextlabs_sdk/_pdp/_client.py
@@ -12,10 +12,18 @@ from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
-from nextlabs_sdk.exceptions import raise_for_status
+from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
 _CONTENT_TYPE = "Content-Type"
+
+
+def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
+    if content_type is not ContentType.JSON:
+        raise NextLabsError(
+            f"{method}() only supports ContentType.JSON; "
+            f"raw XML pass-through is not implemented",
+        )
 
 
 class PdpClient:
@@ -94,6 +102,46 @@ class PdpClient:
             return xml_ser.deserialize_permissions_response(response.content)
 
         body = json_ser.serialize_permissions_request(request)
+        response = self._client.post(
+            _PDP_ENDPOINT,
+            json=body,
+            headers={_CONTENT_TYPE: content_type.value},
+        )
+        raise_for_status(response)
+        return decode_pdp_response(
+            response,
+            json_ser.deserialize_permissions_response,
+            what="permissions response",
+        )
+
+    def evaluate_raw(
+        self,
+        body: dict[str, object],
+        *,
+        content_type: ContentType = ContentType.JSON,
+    ) -> EvalResponse:
+        """POST a pre-built raw XACML JSON body to the PDP eval endpoint."""
+        _require_json_content_type(content_type, method="evaluate_raw")
+        response = self._client.post(
+            _PDP_ENDPOINT,
+            json=body,
+            headers={_CONTENT_TYPE: content_type.value},
+        )
+        raise_for_status(response)
+        return decode_pdp_response(
+            response,
+            json_ser.deserialize_eval_response,
+            what="eval response",
+        )
+
+    def permissions_raw(
+        self,
+        body: dict[str, object],
+        *,
+        content_type: ContentType = ContentType.JSON,
+    ) -> PermissionsResponse:
+        """POST a pre-built raw XACML JSON body to the PDP permissions endpoint."""
+        _require_json_content_type(content_type, method="permissions_raw")
         response = self._client.post(
             _PDP_ENDPOINT,
             json=body,

--- a/src/nextlabs_sdk/_pdp/_payload/__init__.py
+++ b/src/nextlabs_sdk/_pdp/_payload/__init__.py
@@ -1,0 +1,4 @@
+"""Internal PDP payload loader (YAML / JSON / raw XACML).
+
+See :mod:`nextlabs_sdk.pdp.payloads` for the public surface.
+"""

--- a/src/nextlabs_sdk/_pdp/_payload/_detect.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_detect.py
@@ -1,0 +1,22 @@
+"""Detect whether a payload text is JSON or YAML."""
+
+from __future__ import annotations
+
+import json
+
+from nextlabs_sdk._pdp._payload._format import PayloadFormat
+
+
+def detect_text_format(text: str) -> PayloadFormat:
+    """Return :data:`PayloadFormat.JSON` when ``text`` is valid JSON, else YAML.
+
+    Structured-vs-raw-XACML is decided later by shape, not by this helper.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return PayloadFormat.JSON
+    try:
+        json.loads(stripped)
+    except ValueError:
+        return PayloadFormat.YAML
+    return PayloadFormat.JSON

--- a/src/nextlabs_sdk/_pdp/_payload/_format.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_format.py
@@ -1,0 +1,41 @@
+"""Public value types for the PDP payload loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
+
+
+class PayloadFormat(str, Enum):
+    """Explicit payload-format override passed to the loader / CLI."""
+
+    AUTO = "auto"
+    YAML = "yaml"
+    JSON = "json"
+    XACML_JSON = "xacml"
+
+
+@dataclass(frozen=True)
+class LoadedPayload:
+    """Result of :func:`load_eval_payload` / :func:`load_permissions_payload`.
+
+    Exactly one of ``request`` / ``body`` is populated, matching ``kind``.
+    """
+
+    kind: Literal["structured", "raw_xacml"]
+    request: EvalRequest | PermissionsRequest | None = None
+    body: dict[str, object] | None = None
+
+    @classmethod
+    def structured(
+        cls,
+        request: EvalRequest | PermissionsRequest,
+    ) -> LoadedPayload:
+        return cls(kind="structured", request=request)
+
+    @classmethod
+    def raw_xacml(cls, body: dict[str, object]) -> LoadedPayload:
+        return cls(kind="raw_xacml", body=body)

--- a/src/nextlabs_sdk/_pdp/_payload/_loader.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_loader.py
@@ -1,0 +1,117 @@
+"""Orchestrator: read payload source, decode, classify, validate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from nextlabs_sdk._pdp._payload._detect import detect_text_format
+from nextlabs_sdk._pdp._payload._format import LoadedPayload, PayloadFormat
+from nextlabs_sdk._pdp._payload._parse import parse_text
+from nextlabs_sdk._pdp._payload._shape import is_raw_xacml, require_raw_xacml
+from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
+from nextlabs_sdk.exceptions import PdpPayloadError
+
+_Model = TypeVar("_Model", bound=BaseModel)
+
+PayloadSource = Path | str | bytes
+
+
+def load_eval_payload(
+    source: PayloadSource,
+    payload_format: PayloadFormat = PayloadFormat.AUTO,
+) -> LoadedPayload:
+    """Load a payload and validate structured entries against ``EvalRequest``."""
+    return _load(source, payload_format, EvalRequest)
+
+
+def load_permissions_payload(
+    source: PayloadSource,
+    payload_format: PayloadFormat = PayloadFormat.AUTO,
+) -> LoadedPayload:
+    """Load a payload and validate structured entries against ``PermissionsRequest``."""
+    return _load(source, payload_format, PermissionsRequest)
+
+
+def _load(
+    source: PayloadSource,
+    payload_format: PayloadFormat,
+    model_cls: Type[_Model],
+) -> LoadedPayload:
+    text = _read_source(source)
+    text_format, force_raw_xacml = _resolve_text_format(text, payload_format)
+    parsed = parse_text(text, text_format)
+    if force_raw_xacml:
+        return LoadedPayload.raw_xacml(require_raw_xacml(parsed))
+    if is_raw_xacml(parsed):
+        return LoadedPayload.raw_xacml(parsed)
+    validated = _validate_structured(parsed, model_cls)
+    assert isinstance(validated, (EvalRequest, PermissionsRequest))
+    return LoadedPayload.structured(validated)
+
+
+def _resolve_text_format(
+    text: str,
+    payload_format: PayloadFormat,
+) -> tuple[PayloadFormat, bool]:
+    if payload_format is PayloadFormat.JSON:
+        return PayloadFormat.JSON, False
+    if payload_format is PayloadFormat.YAML:
+        return PayloadFormat.YAML, False
+    if payload_format is PayloadFormat.XACML_JSON:
+        return PayloadFormat.JSON, True
+    return detect_text_format(text), False
+
+
+def _read_source(source: PayloadSource) -> str:
+    if isinstance(source, Path):
+        return _read_path(source)
+    if isinstance(source, bytes):
+        return _decode_bytes(source)
+    return source
+
+
+def _read_path(path: Path) -> str:
+    if not path.is_file():
+        raise PdpPayloadError(f"Payload file not found: {path}")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PdpPayloadError(f"Could not read payload file {path}: {exc}") from None
+
+
+def _decode_bytes(raw: bytes) -> str:
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PdpPayloadError(f"Payload bytes are not valid UTF-8: {exc}") from None
+
+
+def _validate_structured(
+    parsed: dict[str, object],
+    model_cls: Type[_Model],
+) -> _Model:
+    try:
+        return model_cls.model_validate(parsed)
+    except ValidationError as exc:
+        raise PdpPayloadError(_format_validation_error(exc)) from None
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    errors = exc.errors()
+    lines = [_format_one_error(err) for err in errors]
+    joined = "; ".join(lines) if lines else str(exc)
+    return f"Invalid structured payload: {joined}"
+
+
+def _format_one_error(err: object) -> str:
+    if not isinstance(err, dict):
+        return str(err)
+    loc_parts = err.get("loc", ())
+    if not isinstance(loc_parts, tuple):
+        loc_parts = ()
+    loc = ".".join(str(part) for part in loc_parts)
+    msg = err.get("msg", "invalid")
+    return f"{loc}: {msg}" if loc else str(msg)

--- a/src/nextlabs_sdk/_pdp/_payload/_loader.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_loader.py
@@ -21,6 +21,7 @@ PayloadSource = Path | str | bytes
 
 def load_eval_payload(
     source: PayloadSource,
+    *,
     payload_format: PayloadFormat = PayloadFormat.AUTO,
 ) -> LoadedPayload:
     """Load a payload and validate structured entries against ``EvalRequest``."""
@@ -29,6 +30,7 @@ def load_eval_payload(
 
 def load_permissions_payload(
     source: PayloadSource,
+    *,
     payload_format: PayloadFormat = PayloadFormat.AUTO,
 ) -> LoadedPayload:
     """Load a payload and validate structured entries against ``PermissionsRequest``."""
@@ -78,6 +80,10 @@ def _read_path(path: Path) -> str:
         raise PdpPayloadError(f"Payload file not found: {path}")
     try:
         return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise PdpPayloadError(
+            f"Payload file is not valid UTF-8: {path}: {exc}",
+        ) from None
     except OSError as exc:
         raise PdpPayloadError(f"Could not read payload file {path}: {exc}") from None
 

--- a/src/nextlabs_sdk/_pdp/_payload/_parse.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_parse.py
@@ -1,0 +1,57 @@
+"""Decode payload text to a dict using JSON or YAML."""
+
+from __future__ import annotations
+
+import json
+
+from nextlabs_sdk._pdp._payload._format import PayloadFormat
+from nextlabs_sdk.exceptions import PdpPayloadError
+
+_YAML_EXTRA_HINT = (
+    "YAML support requires PyYAML. Install it with: " "pip install 'nextlabs-sdk[yaml]'"
+)
+
+
+def parse_text(text: str, text_format: PayloadFormat) -> dict[str, object]:
+    """Parse ``text`` as JSON or YAML, returning a mapping.
+
+    Raises :class:`PdpPayloadError` on decode errors, non-object roots, or
+    when PyYAML is not installed while a YAML path is requested.
+    """
+    if text_format is PayloadFormat.JSON:
+        return _decode_json(text)
+    if text_format is PayloadFormat.YAML:
+        return _decode_yaml(text)
+    raise PdpPayloadError(
+        f"Unsupported text format for parsing: {text_format.value}",
+    )
+
+
+def _decode_json(text: str) -> dict[str, object]:
+    try:
+        decoded = json.loads(text) if text.strip() else None
+    except json.JSONDecodeError as exc:
+        raise PdpPayloadError(f"Invalid JSON: {exc.msg} at line {exc.lineno}") from None
+    return _require_mapping(decoded, source="JSON")
+
+
+def _decode_yaml(text: str) -> dict[str, object]:
+    try:
+        import yaml
+    except ImportError:
+        raise PdpPayloadError(_YAML_EXTRA_HINT) from None
+    try:
+        decoded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise PdpPayloadError(f"Invalid YAML: {exc}") from None
+    return _require_mapping(decoded, source="YAML")
+
+
+def _require_mapping(decoded: object, *, source: str) -> dict[str, object]:
+    if decoded is None:
+        raise PdpPayloadError(f"Empty {source} payload: expected an object")
+    if not isinstance(decoded, dict):
+        raise PdpPayloadError(
+            f"{source} payload root must be an object, got {type(decoded).__name__}",
+        )
+    return decoded

--- a/src/nextlabs_sdk/_pdp/_payload/_shape.py
+++ b/src/nextlabs_sdk/_pdp/_payload/_shape.py
@@ -1,0 +1,31 @@
+"""Raw-XACML shape detection for loaded payload dicts."""
+
+from __future__ import annotations
+
+from nextlabs_sdk.exceptions import PdpPayloadError
+
+
+def is_raw_xacml(payload: dict[str, object]) -> bool:
+    """Return ``True`` when ``payload`` has the raw XACML top-level shape.
+
+    Specifically, ``payload["Request"]`` must be an object and
+    ``payload["Request"]["Category"]`` must be a list.
+    """
+    request = payload.get("Request")
+    if not isinstance(request, dict):
+        return False
+    return isinstance(request.get("Category"), list)
+
+
+def require_raw_xacml(payload: dict[str, object]) -> dict[str, object]:
+    """Validate that ``payload`` is raw XACML-shaped; raise otherwise."""
+    request = payload.get("Request")
+    if not isinstance(request, dict):
+        raise PdpPayloadError(
+            "Raw XACML payload missing top-level 'Request' object",
+        )
+    if not isinstance(request.get("Category"), list):
+        raise PdpPayloadError(
+            "Raw XACML payload 'Request.Category' must be a list",
+        )
+    return payload

--- a/src/nextlabs_sdk/exceptions.py
+++ b/src/nextlabs_sdk/exceptions.py
@@ -81,6 +81,10 @@ class ApiError(NextLabsError):
     """Catch-all for unmapped HTTP errors."""
 
 
+class PdpPayloadError(NextLabsError):
+    """Raised for invalid or unreadable PDP request payload files."""
+
+
 class RateLimitError(ApiError):
     """HTTP 429 after retries exhausted."""
 

--- a/src/nextlabs_sdk/pdp/__init__.py
+++ b/src/nextlabs_sdk/pdp/__init__.py
@@ -5,6 +5,14 @@ Re-exports the curated PDP API from the internal ``_pdp`` package.
 
 from nextlabs_sdk._pdp._async_client import AsyncPdpClient as AsyncPdpClient
 from nextlabs_sdk._pdp._client import PdpClient as PdpClient
+from nextlabs_sdk._pdp._payload._format import LoadedPayload as LoadedPayload
+from nextlabs_sdk._pdp._payload._format import PayloadFormat as PayloadFormat
+from nextlabs_sdk._pdp._payload._loader import (
+    load_eval_payload as load_eval_payload,
+)
+from nextlabs_sdk._pdp._payload._loader import (
+    load_permissions_payload as load_permissions_payload,
+)
 from nextlabs_sdk._pdp._enums import ContentType as ContentType
 from nextlabs_sdk._pdp._enums import Decision as Decision
 from nextlabs_sdk._pdp._enums import ResourceDimension as ResourceDimension

--- a/src/nextlabs_sdk/pdp/payloads.py
+++ b/src/nextlabs_sdk/pdp/payloads.py
@@ -1,0 +1,27 @@
+"""Public API for loading PDP request payloads from YAML / JSON / raw XACML files.
+
+Example::
+
+    from pathlib import Path
+
+    from nextlabs_sdk.pdp.payloads import load_eval_payload
+
+    loaded = load_eval_payload(Path("request.json"))
+    if loaded.kind == "structured":
+        response = client.evaluate(loaded.request)
+    else:
+        response = client.evaluate_raw(loaded.body)
+"""
+
+from nextlabs_sdk._pdp._payload._format import (
+    LoadedPayload as LoadedPayload,
+)
+from nextlabs_sdk._pdp._payload._format import (
+    PayloadFormat as PayloadFormat,
+)
+from nextlabs_sdk._pdp._payload._loader import (
+    load_eval_payload as load_eval_payload,
+)
+from nextlabs_sdk._pdp._payload._loader import (
+    load_permissions_payload as load_permissions_payload,
+)

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -274,3 +274,84 @@ def test_async_pdp_client_explicit_token_url_overrides_auth_base_url(
     )
 
     assert captured["auth"]._token_url == "https://override.example.com/oauth"
+
+
+def _raw_xacml_body() -> dict[str, Any]:
+    return {
+        "Request": {
+            "Category": [
+                {
+                    "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+                    "Attribute": [
+                        {
+                            "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+                            "Value": "VIEW",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def test_async_evaluate_raw_posts_body_verbatim() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    ).thenReturn(_permit_response())
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        response = await pdp.evaluate_raw(_raw_xacml_body())
+        assert response.first_result.decision == Decision.PERMIT
+
+    _run_async(run())
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def test_async_permissions_raw_posts_body_verbatim() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    ).thenReturn(_permissions_response())
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        response = await pdp.permissions_raw(_raw_xacml_body())
+        assert len(response.allowed) == 1
+
+    _run_async(run())
+
+
+def test_async_evaluate_raw_rejects_xml_content_type() -> None:
+    from nextlabs_sdk.exceptions import NextLabsError
+
+    _stub_transport()
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        with pytest.raises(NextLabsError, match="evaluate_raw.*only supports"):
+            await pdp.evaluate_raw(_raw_xacml_body(), content_type=ContentType.XML)
+
+    _run_async(run())
+
+
+def test_async_permissions_raw_rejects_xml_content_type() -> None:
+    from nextlabs_sdk.exceptions import NextLabsError
+
+    _stub_transport()
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        with pytest.raises(NextLabsError, match="permissions_raw.*only supports"):
+            await pdp.permissions_raw(_raw_xacml_body(), content_type=ContentType.XML)
+
+    _run_async(run())

--- a/tests/test_cli_pdp_payload.py
+++ b/tests/test_cli_pdp_payload.py
@@ -1,0 +1,295 @@
+"""Integration tests for PDP CLI ``--payload`` / ``--payload-format`` options."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mockito import ANY, mock, verify, when
+from typer.testing import CliRunner
+
+from nextlabs_sdk._cli import _client_factory
+from nextlabs_sdk._cli._app import app
+from nextlabs_sdk._pdp import (
+    Decision,
+    EvalResponse,
+    EvalResult,
+    PdpClient,
+    PermissionsResponse,
+    Status,
+)
+
+runner = CliRunner()
+
+_GLOBAL_OPTS = (
+    "--base-url",
+    "https://example.com",
+    "--pdp-url",
+    "https://pdp.example.com",
+    "--client-secret",
+    "my-secret",
+)
+
+
+def _structured_eval() -> dict[str, Any]:
+    return {
+        "subject": {"id": "user@example.com"},
+        "action": {"id": "VIEW"},
+        "resource": {"id": "doc:1", "type": "documents"},
+        "application": {"id": "my-app"},
+    }
+
+
+def _structured_perm() -> dict[str, Any]:
+    return {
+        "subject": {"id": "user@example.com"},
+        "resource": {"id": "doc:1", "type": "documents"},
+        "application": {"id": "my-app"},
+    }
+
+
+def _raw_xacml() -> dict[str, Any]:
+    return {
+        "Request": {
+            "Category": [
+                {
+                    "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+                    "Attribute": [
+                        {
+                            "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+                            "Value": "VIEW",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def _stub_client() -> Any:
+    mock_client = mock(PdpClient)
+    when(_client_factory).make_pdp_client(...).thenReturn(mock_client)
+    return mock_client
+
+
+def _permit_eval() -> EvalResponse:
+    return EvalResponse(
+        eval_results=[
+            EvalResult(
+                decision=Decision.PERMIT,
+                status=Status(code="ok"),
+                obligations=[],
+                policy_refs=[],
+            ),
+        ],
+    )
+
+
+def _permit_perm() -> PermissionsResponse:
+    return PermissionsResponse(allowed=[], denied=[], dont_care=[])
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_eval_payload_structured_json(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate(...).thenReturn(_permit_eval())
+    path = _write(tmp_path, "p.json", json.dumps(_structured_eval()))
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "pdp", "eval", "--payload", str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Permit" in result.output
+    verify(mock_client).evaluate(ANY, content_type=ANY)
+
+
+def test_eval_payload_structured_yaml(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate(...).thenReturn(_permit_eval())
+    yaml_text = (
+        "subject:\n  id: user@example.com\n"
+        "action:\n  id: VIEW\n"
+        "resource:\n  id: doc:1\n  type: documents\n"
+        "application:\n  id: my-app\n"
+    )
+    path = _write(tmp_path, "p.yaml", yaml_text)
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "pdp", "eval", "--payload", str(path)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_eval_payload_raw_xacml_dispatches_evaluate_raw(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate_raw(...).thenReturn(_permit_eval())
+    path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "pdp", "eval", "--payload", str(path)])
+
+    assert result.exit_code == 0, result.output
+    verify(mock_client).evaluate_raw(_raw_xacml())
+
+
+def test_eval_payload_conflicts_with_flags(tmp_path: Path) -> None:
+    _stub_client()
+    path = _write(tmp_path, "p.json", json.dumps(_structured_eval()))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--payload",
+            str(path),
+            "--subject",
+            "u1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--payload cannot be combined" in result.output
+    assert "--subject" in result.output
+
+
+def test_eval_payload_missing_file(tmp_path: Path) -> None:
+    _stub_client()
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--payload",
+            str(tmp_path / "nope.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Payload file not found" in result.output
+
+
+def test_eval_payload_format_override_xacml(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate_raw(...).thenReturn(_permit_eval())
+    path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--payload",
+            str(path),
+            "--payload-format",
+            "xacml",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    verify(mock_client).evaluate_raw(_raw_xacml())
+
+
+def test_eval_payload_format_xacml_rejects_structured(tmp_path: Path) -> None:
+    _stub_client()
+    path = _write(tmp_path, "p.json", json.dumps(_structured_eval()))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--payload",
+            str(path),
+            "--payload-format",
+            "xacml",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Raw XACML" in result.output
+
+
+def test_eval_still_works_with_flags_and_no_payload() -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate(...).thenReturn(_permit_eval())
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--subject",
+            "u1",
+            "--resource",
+            "doc1",
+            "--resource-type",
+            "file",
+            "--action",
+            "VIEW",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_eval_missing_required_flag_without_payload() -> None:
+    _stub_client()
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "pdp", "eval", "--subject", "u1"])
+    assert result.exit_code != 0
+
+
+def test_permissions_payload_structured_json(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenReturn(_permit_perm())
+    path = _write(tmp_path, "p.json", json.dumps(_structured_perm()))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "pdp", "permissions", "--payload", str(path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    verify(mock_client).permissions(ANY, content_type=ANY)
+
+
+def test_permissions_payload_raw_xacml(tmp_path: Path) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions_raw(...).thenReturn(_permit_perm())
+    path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "pdp", "permissions", "--payload", str(path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    verify(mock_client).permissions_raw(_raw_xacml())
+
+
+def test_permissions_payload_conflicts_with_flags(tmp_path: Path) -> None:
+    _stub_client()
+    path = _write(tmp_path, "p.json", json.dumps(_structured_perm()))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "permissions",
+            "--payload",
+            str(path),
+            "--resource",
+            "r1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--payload cannot be combined" in result.output

--- a/tests/test_cli_pdp_payload.py
+++ b/tests/test_cli_pdp_payload.py
@@ -12,6 +12,7 @@ from typer.testing import CliRunner
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._pdp import (
+    ContentType,
     Decision,
     EvalResponse,
     EvalResult,
@@ -132,7 +133,7 @@ def test_eval_payload_raw_xacml_dispatches_evaluate_raw(tmp_path: Path) -> None:
     result = runner.invoke(app, [*_GLOBAL_OPTS, "pdp", "eval", "--payload", str(path)])
 
     assert result.exit_code == 0, result.output
-    verify(mock_client).evaluate_raw(_raw_xacml())
+    verify(mock_client).evaluate_raw(_raw_xacml(), content_type=ContentType.JSON)
 
 
 def test_eval_payload_conflicts_with_flags(tmp_path: Path) -> None:
@@ -192,7 +193,7 @@ def test_eval_payload_format_override_xacml(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    verify(mock_client).evaluate_raw(_raw_xacml())
+    verify(mock_client).evaluate_raw(_raw_xacml(), content_type=ContentType.JSON)
 
 
 def test_eval_payload_format_xacml_rejects_structured(tmp_path: Path) -> None:
@@ -271,7 +272,7 @@ def test_permissions_payload_raw_xacml(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    verify(mock_client).permissions_raw(_raw_xacml())
+    verify(mock_client).permissions_raw(_raw_xacml(), content_type=ContentType.JSON)
 
 
 def test_permissions_payload_conflicts_with_flags(tmp_path: Path) -> None:
@@ -293,3 +294,30 @@ def test_permissions_payload_conflicts_with_flags(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "--payload cannot be combined" in result.output
+
+
+def test_eval_raw_payload_forwards_xml_content_type(tmp_path: Path) -> None:
+    """When --content-type xml + raw payload, content_type must reach the client."""
+    from nextlabs_sdk.exceptions import NextLabsError
+
+    mock_client = _stub_client()
+    when(mock_client).evaluate_raw(...).thenRaise(
+        NextLabsError("evaluate_raw() only supports ContentType.JSON"),
+    )
+    path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "pdp",
+            "eval",
+            "--payload",
+            str(path),
+            "--content-type",
+            "xml",
+        ],
+    )
+
+    assert result.exit_code != 0
+    verify(mock_client).evaluate_raw(_raw_xacml(), content_type=ContentType.XML)

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -18,7 +18,7 @@ from nextlabs_sdk._pdp._request_models import (
     Resource,
     Subject,
 )
-from nextlabs_sdk.exceptions import ApiError, ValidationError
+from nextlabs_sdk.exceptions import ApiError, NextLabsError, ValidationError
 
 BASE_URL = "https://pdp.example.com"
 PDP_ENDPOINT = "/dpc/authorization/pdp"
@@ -322,3 +322,68 @@ def test_pdp_client_explicit_token_url_overrides_auth_base_url(
     )
 
     assert captured["auth"]._token_url == "https://override.example.com/oauth"
+
+
+def _raw_xacml_body() -> dict[str, Any]:
+    return {
+        "Request": {
+            "Category": [
+                {
+                    "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+                    "Attribute": [
+                        {
+                            "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+                            "Value": "VIEW",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def test_evaluate_raw_posts_body_verbatim() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    ).thenReturn(_make_permit_response())
+
+    response = _make_pdp().evaluate_raw(_raw_xacml_body())
+
+    assert response.first_result.decision == Decision.PERMIT
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def test_permissions_raw_posts_body_verbatim() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=_raw_xacml_body(),
+        headers={"Content-Type": "application/json"},
+    ).thenReturn(_make_permissions_response())
+
+    response = _make_pdp().permissions_raw(_raw_xacml_body())
+
+    assert len(response.allowed) == 1
+
+
+def test_evaluate_raw_rejects_xml_content_type() -> None:
+    _stub_transport()
+    with pytest.raises(
+        NextLabsError, match="evaluate_raw.*only supports ContentType.JSON"
+    ):
+        _make_pdp().evaluate_raw(_raw_xacml_body(), content_type=ContentType.XML)
+
+
+def test_permissions_raw_rejects_xml_content_type() -> None:
+    _stub_transport()
+    with pytest.raises(
+        NextLabsError, match="permissions_raw.*only supports ContentType.JSON"
+    ):
+        _make_pdp().permissions_raw(_raw_xacml_body(), content_type=ContentType.XML)

--- a/tests/test_pdp_payload_loader.py
+++ b/tests/test_pdp_payload_loader.py
@@ -102,18 +102,18 @@ def test_load_raw_xacml_auto_detect(tmp_path: Path) -> None:
 def test_load_force_xacml_rejects_structured(tmp_path: Path) -> None:
     path = _write(tmp_path, "struct.json", json.dumps(_structured_eval()))
     with pytest.raises(PdpPayloadError, match="Raw XACML payload missing"):
-        load_eval_payload(path, PayloadFormat.XACML_JSON)
+        load_eval_payload(path, payload_format=PayloadFormat.XACML_JSON)
 
 
 def test_load_force_json_on_yaml_raises(tmp_path: Path) -> None:
     path = _write(tmp_path, "bad.yaml", "subject:\n  id: x\n")
     with pytest.raises(PdpPayloadError, match="Invalid JSON"):
-        load_eval_payload(path, PayloadFormat.JSON)
+        load_eval_payload(path, payload_format=PayloadFormat.JSON)
 
 
 def test_load_force_yaml_on_json_ok(tmp_path: Path) -> None:
     path = _write(tmp_path, "ambiguous", json.dumps(_structured_eval()))
-    loaded = load_eval_payload(path, PayloadFormat.YAML)
+    loaded = load_eval_payload(path, payload_format=PayloadFormat.YAML)
     assert loaded.kind == "structured"
 
 
@@ -157,7 +157,7 @@ def test_load_from_invalid_bytes_source() -> None:
 
 def test_load_raw_xacml_force_accepts_xacml(tmp_path: Path) -> None:
     path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
-    loaded = load_eval_payload(path, PayloadFormat.XACML_JSON)
+    loaded = load_eval_payload(path, payload_format=PayloadFormat.XACML_JSON)
     assert loaded.kind == "raw_xacml"
 
 
@@ -174,7 +174,7 @@ def test_load_yaml_missing_pyyaml(
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(PdpPayloadError, match="YAML support requires PyYAML"):
-        load_eval_payload(path, PayloadFormat.YAML)
+        load_eval_payload(path, payload_format=PayloadFormat.YAML)
 
 
 def test_loaded_payload_structured_factory() -> None:
@@ -195,13 +195,13 @@ def test_loaded_payload_raw_xacml_factory() -> None:
 def test_invalid_yaml_raises(tmp_path: Path) -> None:
     path = _write(tmp_path, "broken.yaml", "key: [unclosed\n")
     with pytest.raises(PdpPayloadError, match="Invalid YAML"):
-        load_eval_payload(path, PayloadFormat.YAML)
+        load_eval_payload(path, payload_format=PayloadFormat.YAML)
 
 
 def test_yaml_non_object_root(tmp_path: Path) -> None:
     path = _write(tmp_path, "list.yaml", "- 1\n- 2\n")
     with pytest.raises(PdpPayloadError, match="YAML payload root must be an object"):
-        load_eval_payload(path, PayloadFormat.YAML)
+        load_eval_payload(path, payload_format=PayloadFormat.YAML)
 
 
 def test_xacml_force_missing_category_list(tmp_path: Path) -> None:
@@ -211,4 +211,4 @@ def test_xacml_force_missing_category_list(tmp_path: Path) -> None:
         json.dumps({"Request": {"Category": "oops"}}),
     )
     with pytest.raises(PdpPayloadError, match="'Request.Category' must be a list"):
-        load_eval_payload(path, PayloadFormat.XACML_JSON)
+        load_eval_payload(path, payload_format=PayloadFormat.XACML_JSON)

--- a/tests/test_pdp_payload_loader.py
+++ b/tests/test_pdp_payload_loader.py
@@ -1,0 +1,214 @@
+"""Tests for the public PDP payload loader (structured JSON/YAML + raw XACML)."""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nextlabs_sdk.exceptions import PdpPayloadError
+from nextlabs_sdk.pdp import (
+    EvalRequest,
+    PermissionsRequest,
+)
+from nextlabs_sdk.pdp.payloads import (
+    LoadedPayload,
+    PayloadFormat,
+    load_eval_payload,
+    load_permissions_payload,
+)
+
+
+def _structured_eval() -> dict[str, Any]:
+    return {
+        "subject": {"id": "user@example.com"},
+        "action": {"id": "VIEW"},
+        "resource": {"id": "doc:1", "type": "documents"},
+        "application": {"id": "my-app"},
+    }
+
+
+def _structured_permissions() -> dict[str, Any]:
+    return {
+        "subject": {"id": "user@example.com"},
+        "resource": {"id": "doc:1", "type": "documents"},
+        "application": {"id": "my-app"},
+    }
+
+
+def _raw_xacml() -> dict[str, Any]:
+    return {
+        "Request": {
+            "Category": [
+                {
+                    "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:access-subject",
+                    "Attribute": [
+                        {
+                            "AttributeId": "urn:oasis:names:tc:xacml:1.0:subject:subject-id",
+                            "Value": "user@example.com",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_load_eval_structured_json_from_path(tmp_path: Path) -> None:
+    path = _write(tmp_path, "eval.json", json.dumps(_structured_eval()))
+    loaded = load_eval_payload(path)
+    assert loaded.kind == "structured"
+    assert isinstance(loaded.request, EvalRequest)
+    assert loaded.request.subject.id == "user@example.com"
+
+
+def test_load_permissions_structured_json_from_path(tmp_path: Path) -> None:
+    path = _write(tmp_path, "perm.json", json.dumps(_structured_permissions()))
+    loaded = load_permissions_payload(path)
+    assert loaded.kind == "structured"
+    assert isinstance(loaded.request, PermissionsRequest)
+
+
+def test_load_eval_structured_yaml_auto_detect(tmp_path: Path) -> None:
+    yaml_text = (
+        "subject:\n  id: user@example.com\n"
+        "action:\n  id: VIEW\n"
+        "resource:\n  id: doc:1\n  type: documents\n"
+        "application:\n  id: my-app\n"
+    )
+    path = _write(tmp_path, "eval.yaml", yaml_text)
+    loaded = load_eval_payload(path)
+    assert loaded.kind == "structured"
+    assert isinstance(loaded.request, EvalRequest)
+    assert loaded.request.action.id == "VIEW"
+
+
+def test_load_raw_xacml_auto_detect(tmp_path: Path) -> None:
+    path = _write(tmp_path, "xacml.json", json.dumps(_raw_xacml()))
+    loaded = load_eval_payload(path)
+    assert loaded.kind == "raw_xacml"
+    assert loaded.body == _raw_xacml()
+
+
+def test_load_force_xacml_rejects_structured(tmp_path: Path) -> None:
+    path = _write(tmp_path, "struct.json", json.dumps(_structured_eval()))
+    with pytest.raises(PdpPayloadError, match="Raw XACML payload missing"):
+        load_eval_payload(path, PayloadFormat.XACML_JSON)
+
+
+def test_load_force_json_on_yaml_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path, "bad.yaml", "subject:\n  id: x\n")
+    with pytest.raises(PdpPayloadError, match="Invalid JSON"):
+        load_eval_payload(path, PayloadFormat.JSON)
+
+
+def test_load_force_yaml_on_json_ok(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ambiguous", json.dumps(_structured_eval()))
+    loaded = load_eval_payload(path, PayloadFormat.YAML)
+    assert loaded.kind == "structured"
+
+
+def test_load_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(PdpPayloadError, match="Payload file not found"):
+        load_eval_payload(tmp_path / "nope.json")
+
+
+def test_load_empty_file(tmp_path: Path) -> None:
+    path = _write(tmp_path, "empty.json", "")
+    with pytest.raises(PdpPayloadError, match="Empty JSON payload"):
+        load_eval_payload(path)
+
+
+def test_load_non_object_root(tmp_path: Path) -> None:
+    path = _write(tmp_path, "list.json", "[1, 2, 3]")
+    with pytest.raises(PdpPayloadError, match="root must be an object"):
+        load_eval_payload(path)
+
+
+def test_load_invalid_structured_surfaces_field_path(tmp_path: Path) -> None:
+    path = _write(tmp_path, "broken.json", json.dumps({"subject": "not-an-object"}))
+    with pytest.raises(PdpPayloadError, match="Invalid structured payload.*subject"):
+        load_eval_payload(path)
+
+
+def test_load_from_string_source() -> None:
+    loaded = load_eval_payload(json.dumps(_structured_eval()))
+    assert loaded.kind == "structured"
+
+
+def test_load_from_bytes_source() -> None:
+    loaded = load_eval_payload(json.dumps(_structured_eval()).encode("utf-8"))
+    assert loaded.kind == "structured"
+
+
+def test_load_from_invalid_bytes_source() -> None:
+    with pytest.raises(PdpPayloadError, match="not valid UTF-8"):
+        load_eval_payload(b"\xff\xfe\x00")
+
+
+def test_load_raw_xacml_force_accepts_xacml(tmp_path: Path) -> None:
+    path = _write(tmp_path, "x.json", json.dumps(_raw_xacml()))
+    loaded = load_eval_payload(path, PayloadFormat.XACML_JSON)
+    assert loaded.kind == "raw_xacml"
+
+
+def test_load_yaml_missing_pyyaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = _write(tmp_path, "x.yaml", "a: 1\n")
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "yaml":
+            raise ImportError("No module named 'yaml'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(PdpPayloadError, match="YAML support requires PyYAML"):
+        load_eval_payload(path, PayloadFormat.YAML)
+
+
+def test_loaded_payload_structured_factory() -> None:
+    req = EvalRequest.model_validate(_structured_eval())
+    loaded = LoadedPayload.structured(req)
+    assert loaded.kind == "structured"
+    assert loaded.request is req
+    assert loaded.body is None
+
+
+def test_loaded_payload_raw_xacml_factory() -> None:
+    loaded = LoadedPayload.raw_xacml(_raw_xacml())
+    assert loaded.kind == "raw_xacml"
+    assert loaded.body == _raw_xacml()
+    assert loaded.request is None
+
+
+def test_invalid_yaml_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path, "broken.yaml", "key: [unclosed\n")
+    with pytest.raises(PdpPayloadError, match="Invalid YAML"):
+        load_eval_payload(path, PayloadFormat.YAML)
+
+
+def test_yaml_non_object_root(tmp_path: Path) -> None:
+    path = _write(tmp_path, "list.yaml", "- 1\n- 2\n")
+    with pytest.raises(PdpPayloadError, match="YAML payload root must be an object"):
+        load_eval_payload(path, PayloadFormat.YAML)
+
+
+def test_xacml_force_missing_category_list(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "bad.json",
+        json.dumps({"Request": {"Category": "oops"}}),
+    )
+    with pytest.raises(PdpPayloadError, match="'Request.Category' must be a list"):
+        load_eval_payload(path, PayloadFormat.XACML_JSON)


### PR DESCRIPTION
Implements all 4 tracer-bullet slices from PRD #65 on a single branch.

## What

Adds end-to-end support for loading PDP request bodies from files in structured JSON / YAML / raw XACML JSON, at both the SDK and CLI level, instead of assembling them from individual flags.

### SDK (public surface)

- `nextlabs_sdk.pdp.payloads`: `PayloadFormat`, `LoadedPayload`, `load_eval_payload`, `load_permissions_payload`
- `evaluate_raw` / `permissions_raw` on both `PdpClient` and `AsyncPdpClient` — forward a pre-built raw XACML JSON body verbatim (JSON only; XML is out of scope and rejected with `NextLabsError`)
- `PdpPayloadError` in the `NextLabsError` hierarchy

### CLI

- `pdp eval` and `pdp permissions` accept:
  - `--payload PATH` — file in JSON, YAML, or raw XACML JSON
  - `--payload-format {auto,yaml,json,xacml}` — override auto-detection
- `--payload` is mutually exclusive with any request-shaping flag (`--subject`, `--resource`, `--action`, `--subject-attr`, …)
- raw XACML shape is auto-detected (top-level `{"Request": {"Category": [...]}}`) and dispatched via `evaluate_raw` / `permissions_raw`
- structured payloads are validated against the Pydantic `EvalRequest` / `PermissionsRequest` models with field-path error surfacing

### Packaging

- Optional `yaml` extra: `pip install 'nextlabs-sdk[yaml]'` (pulls in `PyYAML>=6.0`). Attempting to load YAML without the extra raises `PdpPayloadError` with an install hint.

## Tests

- `tests/test_pdp_payload_loader.py` — 21 unit tests (structured/raw dispatch, forced formats, bytes/str/Path sources, PyYAML-missing path, Pydantic field surfacing, empty / non-object roots)
- `tests/test_pdp_client.py` / `tests/test_async_pdp_client.py` — `evaluate_raw` / `permissions_raw` body pass-through + XML rejection
- `tests/test_cli_pdp_payload.py` — 12 CLI integration tests (eval + permissions, all three formats, mutual exclusion, missing file, `--payload-format xacml`)

Full suite: **1907 passed, 96.14% coverage**. All pre-commit hooks (black, flake8 wemake, mypy, pyright) pass with no `noqa` / `type: ignore` / `setup.cfg` changes.

## Closes

- Closes #66 (structured JSON end-to-end)
- Closes #67 (YAML via optional `[yaml]` extra)
- Closes #68 (raw XACML JSON + `evaluate_raw` / `permissions_raw`)
- Closes #69 (`--payload-format` override)
- Refs #65