### PR TITLE
feat(pdp): surface XACML StatusDetail in eval responses

### DIFF
--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -80,9 +80,13 @@ def _render_eval_response(response: EvalResponse, console: Console) -> None:
     color = _DECISION_COLORS.get(evaluation.decision, "")
     console.print(f"Decision: [{color}]{evaluation.decision.value}[/{color}]")
     status_msg = evaluation.status.message or evaluation.status.code
-    console.print(f"Status:   {status_msg}", markup=False)
+    console.print(f"Status:   {status_msg}", markup=False, highlight=False)
     if evaluation.status.detail:
-        console.print(f"Detail:   {evaluation.status.detail}", markup=False)
+        console.print(
+            f"Detail:   {evaluation.status.detail}",
+            markup=False,
+            highlight=False,
+        )
     if evaluation.obligations:
         _print_obligations(console, evaluation.obligations)
     if evaluation.policy_refs:

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -80,9 +80,9 @@ def _render_eval_response(response: EvalResponse, console: Console) -> None:
     color = _DECISION_COLORS.get(evaluation.decision, "")
     console.print(f"Decision: [{color}]{evaluation.decision.value}[/{color}]")
     status_msg = evaluation.status.message or evaluation.status.code
-    console.print(f"Status:   {status_msg}")
+    console.print(f"Status:   {status_msg}", markup=False)
     if evaluation.status.detail:
-        console.print(f"Detail:   {evaluation.status.detail}")
+        console.print(f"Detail:   {evaluation.status.detail}", markup=False)
     if evaluation.obligations:
         _print_obligations(console, evaluation.obligations)
     if evaluation.policy_refs:

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -81,6 +81,8 @@ def _render_eval_response(response: EvalResponse, console: Console) -> None:
     console.print(f"Decision: [{color}]{evaluation.decision.value}[/{color}]")
     status_msg = evaluation.status.message or evaluation.status.code
     console.print(f"Status:   {status_msg}")
+    if evaluation.status.detail:
+        console.print(f"Detail:   {evaluation.status.detail}")
     if evaluation.obligations:
         _print_obligations(console, evaluation.obligations)
     if evaluation.policy_refs:

--- a/src/nextlabs_sdk/_pdp/_json_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_json_serializer.py
@@ -245,7 +245,25 @@ def _parse_status(raw: dict[str, object]) -> Status:
         code_value = str(status_code_raw.get("Value", ""))
     message_raw = raw.get("StatusMessage", "")
     message = str(message_raw) if message_raw else ""
-    return Status(code=code_value, message=message)
+    detail = _stringify_status_detail(raw.get("StatusDetail"))
+    return Status(code=code_value, message=message, detail=detail)
+
+
+def _stringify_status_detail(raw: object) -> str:
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        return ", ".join(_stringify_status_detail(entry) for entry in raw if entry)
+    if isinstance(raw, dict):
+        parts: list[str] = []
+        for child in raw.values():
+            piece = _stringify_status_detail(child)
+            if piece:
+                parts.append(piece)
+        return ", ".join(parts)
+    return str(raw)
 
 
 def _parse_obligations(

--- a/src/nextlabs_sdk/_pdp/_response_models.py
+++ b/src/nextlabs_sdk/_pdp/_response_models.py
@@ -10,6 +10,7 @@ class Status(BaseModel):
 
     code: str
     message: str = ""
+    detail: str = ""
 
 
 class ObligationAttribute(BaseModel):

--- a/src/nextlabs_sdk/_pdp/_xml_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_xml_serializer.py
@@ -232,7 +232,15 @@ def _parse_status_xml(result_el: ET.Element) -> Status:
     if code_el is not None:
         code = code_el.get("Value", "") or ""
     message = status_el.findtext(_ns("StatusMessage"), "")
-    return Status(code=code, message=message)
+    detail = _read_status_detail(status_el)
+    return Status(code=code, message=message, detail=detail)
+
+
+def _read_status_detail(status_el: ET.Element) -> str:
+    detail_el = status_el.find(_ns("StatusDetail"))
+    if detail_el is None:
+        return ""
+    return "".join(detail_el.itertext()).strip()
 
 
 def _parse_obligations_xml(result_el: ET.Element) -> list[Obligation]:

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -192,6 +192,23 @@ def test_pdp_eval_omits_detail_line_when_empty() -> None:
     assert "Detail:" not in result.output
 
 
+def test_pdp_eval_renders_status_with_bracket_chars_literally() -> None:
+    mock_client = _stub_client()
+    response = _eval_response_with_status(
+        decision=Decision.INDETERMINATE,
+        code="missing-attribute",
+        message="missing [Service] attribute",
+        detail="[policy:secret] Service, Version",
+    )
+    when(mock_client).evaluate(...).thenReturn(response)
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_EVAL_ARGS])
+
+    assert result.exit_code == 0
+    assert "[Service]" in result.output
+    assert "[policy:secret]" in result.output
+
+
 @pytest.mark.parametrize(
     "extra_args",
     [

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -151,6 +151,47 @@ def test_pdp_eval_with_policy_refs() -> None:
     assert "AllowITAccess" in result.output
 
 
+def _eval_response_with_status(
+    decision: Decision, code: str, message: str, detail: str
+) -> EvalResponse:
+    return EvalResponse(
+        eval_results=[
+            EvalResult(
+                decision=decision,
+                status=Status(code=code, message=message, detail=detail),
+            ),
+        ],
+    )
+
+
+def test_pdp_eval_renders_status_detail_when_present() -> None:
+    mock_client = _stub_client()
+    response = _eval_response_with_status(
+        decision=Decision.INDETERMINATE,
+        code="urn:oasis:names:tc:xacml:1.0:status:missing-attribute",
+        message="One or more required params are missing",
+        detail="Service, Version",
+    )
+    when(mock_client).evaluate(...).thenReturn(response)
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_EVAL_ARGS])
+
+    assert result.exit_code == 0
+    assert "One or more required params are missing" in result.output
+    assert "Detail:" in result.output
+    assert "Service, Version" in result.output
+
+
+def test_pdp_eval_omits_detail_line_when_empty() -> None:
+    mock_client = _stub_client()
+    when(mock_client).evaluate(...).thenReturn(_eval_response(Decision.PERMIT))
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_EVAL_ARGS])
+
+    assert result.exit_code == 0
+    assert "Detail:" not in result.output
+
+
 @pytest.mark.parametrize(
     "extra_args",
     [

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -309,6 +309,63 @@ def test_deserialize_with_status_message():
 
     assert response.first_result.decision == Decision.INDETERMINATE
     assert response.first_result.status.message == "Policy evaluation error"
+    assert response.first_result.status.detail == ""
+
+
+def test_deserialize_with_status_detail_string():
+    body = {
+        "Response": [
+            {
+                "Decision": "Indeterminate",
+                "Status": {
+                    "StatusCode": {
+                        "Value": "urn:oasis:names:tc:xacml:1.0:status:missing-attribute",
+                    },
+                    "StatusMessage": "One or more required params are missing",
+                    "StatusDetail": "Service, Version",
+                },
+            },
+        ],
+    }
+
+    response = deserialize_eval_response(cast(dict[str, object], body))
+
+    assert response.first_result.status.detail == "Service, Version"
+
+
+def test_deserialize_with_status_detail_dict():
+    body = {
+        "Response": [
+            {
+                "Decision": "Indeterminate",
+                "Status": {
+                    "StatusCode": {"Value": "missing-attribute"},
+                    "StatusDetail": {"MissingAttributeDetail": ["Service", "Version"]},
+                },
+            },
+        ],
+    }
+
+    response = deserialize_eval_response(cast(dict[str, object], body))
+
+    detail = response.first_result.status.detail
+    assert "Service" in detail
+    assert "Version" in detail
+
+
+def test_deserialize_without_status_detail_defaults_empty():
+    body = {
+        "Response": [
+            {
+                "Decision": "Permit",
+                "Status": {"StatusCode": {"Value": "ok"}},
+            },
+        ],
+    }
+
+    response = deserialize_eval_response(cast(dict[str, object], body))
+
+    assert response.first_result.status.detail == ""
 
 
 def test_deserialize_permissions_response():

--- a/tests/test_pdp_response_models.py
+++ b/tests/test_pdp_response_models.py
@@ -19,9 +19,20 @@ def test_status_code_only_and_with_message():
     s1 = Status(code="urn:oasis:names:tc:xacml:1.0:status:ok")
     assert s1.code == "urn:oasis:names:tc:xacml:1.0:status:ok"
     assert s1.message == ""
+    assert s1.detail == ""
 
     s2 = Status(code="ok", message="Success")
     assert s2.message == "Success"
+    assert s2.detail == ""
+
+
+def test_status_with_detail():
+    s = Status(
+        code="urn:oasis:names:tc:xacml:1.0:status:missing-attribute",
+        message="One or more required params are missing",
+        detail="Service, Version",
+    )
+    assert s.detail == "Service, Version"
 
 
 def test_obligation_attribute_fields():

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -147,6 +147,41 @@ def test_xml_deserialize_with_obligations():
     assert response.first_result.obligations[0].attributes[0].attr_value == "warn"
 
 
+def test_xml_deserialize_with_status_detail():
+    xml_data = (
+        f'<Response xmlns="{XACML_NS}">'
+        f"<Result>"
+        f"<Decision>Indeterminate</Decision>"
+        f"<Status>"
+        f'<StatusCode Value="urn:oasis:names:tc:xacml:1.0:status:missing-attribute"/>'
+        f"<StatusMessage>One or more required params are missing</StatusMessage>"
+        f"<StatusDetail>Service, Version</StatusDetail>"
+        f"</Status>"
+        f"</Result>"
+        f"</Response>"
+    ).encode()
+
+    response = deserialize_eval_response(xml_data)
+
+    assert response.first_result.decision == Decision.INDETERMINATE
+    assert response.first_result.status.detail == "Service, Version"
+
+
+def test_xml_deserialize_without_status_detail_defaults_empty():
+    xml_data = (
+        f'<Response xmlns="{XACML_NS}">'
+        f"<Result>"
+        f"<Decision>Permit</Decision>"
+        f'<Status><StatusCode Value="ok"/></Status>'
+        f"</Result>"
+        f"</Response>"
+    ).encode()
+
+    response = deserialize_eval_response(xml_data)
+
+    assert response.first_result.status.detail == ""
+
+
 def test_xml_deserialize_permissions_response():
     def _result(decision: str, action: str) -> str:
         return (


### PR DESCRIPTION
## Why

The NextLabs PDP can return a XACML `StatusDetail` field that carries the most useful diagnostic info — for example, on a `missing-attribute` Indeterminate result, `StatusDetail` lists the names of the attributes the policy expected but did not find (e.g. `"Service, Version"`).

Until now both PDP serializers (JSON and XML) silently dropped `StatusDetail`, so the only way to see it was to re-run the CLI with `-vv` and read the raw response body. The default eval output buried the actionable signal.

Observed during a real run:

```
← 200  (225 bytes) in 0.057s
    body: {"Response":[{"Decision":"Indeterminate","Status":{"StatusMessage":"One or more required params are missing","StatusDetail":"Service, Version","StatusCode":{"Value":"urn:oasis:names:tc:xacml:1.0:status:missing-attribute"}}}]}
Decision: Indeterminate
Status:   One or more required params are missing
```

The `Service, Version` hint was completely invisible without verbose mode.

## What

- Add `Status.detail: str = ""` (additive, frozen model preserved → backwards compatible).
- Parse `StatusDetail` in `_pdp/_json_serializer.py`; tolerate string, list, or dict shapes (flattens to a comma-joined string).
- Parse `<StatusDetail>` in `_pdp/_xml_serializer.py` via `itertext()`.
- CLI `_render_eval_response`: print `Detail:   <detail>` under the `Status:` line **only when non-empty** — keeps the short output clean for the common Permit/Deny case.

After:

```
Decision: Indeterminate
Status:   One or more required params are missing
Detail:   Service, Version
```

## Tests (TDD)

- `tests/test_pdp_response_models.py` — `Status.detail` default + explicit value.
- `tests/test_json_serializer.py` — `StatusDetail` as string, dict, and absent.
- `tests/test_xml_serializer.py` — `<StatusDetail>` present and absent.
- `tests/test_cli_pdp.py` — `Detail:` line rendered when present, omitted when empty.

`python ./tools/checks.py` (Black + Flake8 + MyPy + Pyright) and `python ./tools/tests.py --short` (1916 passed, 96.13% coverage) both green.

## Sync/async parity

`Status` is shared by both `PdpClient` and `AsyncPdpClient` — no extra changes needed.

## Out of scope

- New CLI flag to toggle the line — always on when non-empty.
- Changes to `NextLabsError.envelope_message` (different concern: HTTP envelope, not XACML status).