### PR TITLE
fix(pdp): send required Service and Version headers

### DIFF
--- a/src/nextlabs_sdk/_pdp/_async_client.py
+++ b/src/nextlabs_sdk/_pdp/_async_client.py
@@ -8,6 +8,11 @@ from nextlabs_sdk._config import HttpConfig
 from nextlabs_sdk._pdp import _json_serializer as json_ser
 from nextlabs_sdk._pdp import _xml_serializer as xml_ser
 from nextlabs_sdk._pdp._enums import ContentType
+from nextlabs_sdk._pdp._headers import (
+    DEFAULT_SERVICE,
+    DEFAULT_VERSION,
+    build_pdp_headers,
+)
 from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
@@ -15,7 +20,6 @@ from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
-_CONTENT_TYPE = "Content-Type"
 
 
 def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
@@ -38,6 +42,8 @@ class AsyncPdpClient:
         auth_base_url: str | None = None,
         token_url: str | None = None,
         http_config: HttpConfig | None = None,
+        service: str = DEFAULT_SERVICE,
+        version: str = DEFAULT_VERSION,
     ) -> None:
         config = http_config or HttpConfig()
         effective_token_url = resolve_pdp_token_url(
@@ -55,6 +61,8 @@ class AsyncPdpClient:
             auth=auth,
             http_config=config,
         )
+        self._service = service
+        self._version = version
 
     async def evaluate(
         self,
@@ -67,7 +75,9 @@ class AsyncPdpClient:
             response = await self._client.post(
                 _PDP_ENDPOINT,
                 content=body_bytes,
-                headers={_CONTENT_TYPE: content_type.value},
+                headers=build_pdp_headers(
+                    content_type, service=self._service, version=self._version
+                ),
             )
             raise_for_status(response)
             return xml_ser.deserialize_eval_response(response.content)
@@ -76,7 +86,9 @@ class AsyncPdpClient:
         response = await self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -96,7 +108,9 @@ class AsyncPdpClient:
             response = await self._client.post(
                 _PDP_ENDPOINT,
                 content=body_bytes,
-                headers={_CONTENT_TYPE: content_type.value},
+                headers=build_pdp_headers(
+                    content_type, service=self._service, version=self._version
+                ),
             )
             raise_for_status(response)
             return xml_ser.deserialize_permissions_response(response.content)
@@ -105,7 +119,9 @@ class AsyncPdpClient:
         response = await self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -125,7 +141,9 @@ class AsyncPdpClient:
         response = await self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -145,7 +163,9 @@ class AsyncPdpClient:
         response = await self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(

--- a/src/nextlabs_sdk/_pdp/_client.py
+++ b/src/nextlabs_sdk/_pdp/_client.py
@@ -8,6 +8,11 @@ from nextlabs_sdk._config import HttpConfig
 from nextlabs_sdk._pdp import _json_serializer as json_ser
 from nextlabs_sdk._pdp import _xml_serializer as xml_ser
 from nextlabs_sdk._pdp._enums import ContentType
+from nextlabs_sdk._pdp._headers import (
+    DEFAULT_SERVICE,
+    DEFAULT_VERSION,
+    build_pdp_headers,
+)
 from nextlabs_sdk._pdp._request_models import EvalRequest, PermissionsRequest
 from nextlabs_sdk._pdp._response_decode import decode_pdp_response
 from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
@@ -15,7 +20,6 @@ from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
 _PDP_ENDPOINT = "/dpc/authorization/pdp"
-_CONTENT_TYPE = "Content-Type"
 
 
 def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
@@ -38,6 +42,8 @@ class PdpClient:
         auth_base_url: str | None = None,
         token_url: str | None = None,
         http_config: HttpConfig | None = None,
+        service: str = DEFAULT_SERVICE,
+        version: str = DEFAULT_VERSION,
     ) -> None:
         config = http_config or HttpConfig()
         effective_token_url = resolve_pdp_token_url(
@@ -55,6 +61,8 @@ class PdpClient:
             auth=auth,
             http_config=config,
         )
+        self._service = service
+        self._version = version
 
     def evaluate(
         self,
@@ -67,7 +75,9 @@ class PdpClient:
             response = self._client.post(
                 _PDP_ENDPOINT,
                 content=body_bytes,
-                headers={_CONTENT_TYPE: content_type.value},
+                headers=build_pdp_headers(
+                    content_type, service=self._service, version=self._version
+                ),
             )
             raise_for_status(response)
             return xml_ser.deserialize_eval_response(response.content)
@@ -76,7 +86,9 @@ class PdpClient:
         response = self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -96,7 +108,9 @@ class PdpClient:
             response = self._client.post(
                 _PDP_ENDPOINT,
                 content=body_bytes,
-                headers={_CONTENT_TYPE: content_type.value},
+                headers=build_pdp_headers(
+                    content_type, service=self._service, version=self._version
+                ),
             )
             raise_for_status(response)
             return xml_ser.deserialize_permissions_response(response.content)
@@ -105,7 +119,9 @@ class PdpClient:
         response = self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -125,7 +141,9 @@ class PdpClient:
         response = self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(
@@ -145,7 +163,9 @@ class PdpClient:
         response = self._client.post(
             _PDP_ENDPOINT,
             json=body,
-            headers={_CONTENT_TYPE: content_type.value},
+            headers=build_pdp_headers(
+                content_type, service=self._service, version=self._version
+            ),
         )
         raise_for_status(response)
         return decode_pdp_response(

--- a/src/nextlabs_sdk/_pdp/_headers.py
+++ b/src/nextlabs_sdk/_pdp/_headers.py
@@ -1,0 +1,40 @@
+"""HTTP header construction for PDP REST API calls."""
+
+from __future__ import annotations
+
+from nextlabs_sdk._pdp._enums import ContentType
+
+SERVICE_HEADER = "Service"
+VERSION_HEADER = "Version"
+CONTENT_TYPE_HEADER = "Content-Type"
+
+DEFAULT_SERVICE = "EVAL"
+DEFAULT_VERSION = "1.0"
+
+
+def build_pdp_headers(
+    content_type: ContentType,
+    *,
+    service: str = DEFAULT_SERVICE,
+    version: str = DEFAULT_VERSION,
+) -> dict[str, str]:
+    """Return the header dict required by the NextLabs PDP REST endpoint.
+
+    The PDP rejects requests without ``Service`` and ``Version`` headers
+    with an Indeterminate response (see ``docs/nextlabs_official/pdp_api.md``).
+
+    Args:
+        content_type: Wire format for the request body.
+        service: Value for the ``Service`` header. Defaults to ``"EVAL"``,
+            the only value documented by NextLabs; overridable for custom
+            deployments.
+        version: Value for the ``Version`` header. Defaults to ``"1.0"``.
+
+    Returns:
+        Mapping of header name to value, ready to pass to ``httpx``.
+    """
+    return {
+        CONTENT_TYPE_HEADER: content_type.value,
+        SERVICE_HEADER: service,
+        VERSION_HEADER: version,
+    }

--- a/tests/e2e/test_pdp_flows.py
+++ b/tests/e2e/test_pdp_flows.py
@@ -64,7 +64,11 @@ def pdp_stubs(seeded_wiremock: str) -> str:
         "request": {
             "method": "POST",
             "urlPath": _PDP_ENDPOINT,
-            "headers": {"Content-Type": {"contains": "application/json"}},
+            "headers": {
+                "Content-Type": {"contains": "application/json"},
+                "Service": {"equalTo": "EVAL"},
+                "Version": {"equalTo": "1.0"},
+            },
         },
         "response": {
             "status": 200,
@@ -77,7 +81,11 @@ def pdp_stubs(seeded_wiremock: str) -> str:
         "request": {
             "method": "POST",
             "urlPath": _PDP_ENDPOINT,
-            "headers": {"Content-Type": {"contains": "application/xml"}},
+            "headers": {
+                "Content-Type": {"contains": "application/xml"},
+                "Service": {"equalTo": "EVAL"},
+                "Version": {"equalTo": "1.0"},
+            },
         },
         "response": {
             "status": 200,

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import MappingProxyType
 from typing import Any, Awaitable, TypeVar
 
 import httpx
@@ -23,6 +24,21 @@ from nextlabs_sdk.exceptions import ApiError
 BASE_URL = "https://pdp.example.com"
 PDP_ENDPOINT = "/dpc/authorization/pdp"
 
+JSON_HEADERS = MappingProxyType(
+    {
+        "Content-Type": "application/json",
+        "Service": "EVAL",
+        "Version": "1.0",
+    }
+)
+XML_HEADERS = MappingProxyType(
+    {
+        "Content-Type": "application/xml",
+        "Service": "EVAL",
+        "Version": "1.0",
+    }
+)
+
 T = TypeVar("T")
 
 
@@ -44,8 +60,14 @@ def _stub_transport() -> Any:
     return mock_client
 
 
-def _make_pdp() -> AsyncPdpClient:
-    return AsyncPdpClient(base_url=BASE_URL, client_id="c", client_secret="s")
+def _make_pdp(**kwargs: Any) -> AsyncPdpClient:
+    defaults: dict[str, Any] = {
+        "base_url": BASE_URL,
+        "client_id": "c",
+        "client_secret": "s",
+    }
+    defaults.update(kwargs)
+    return AsyncPdpClient(**defaults)
 
 
 def _permit_response() -> httpx.Response:
@@ -165,7 +187,7 @@ def test_async_evaluate_with_xml():
     when(mock_client).post(
         PDP_ENDPOINT,
         content=any_value(bytes),
-        headers={"Content-Type": "application/xml"},
+        headers=XML_HEADERS,
     ).thenReturn(
         httpx.Response(200, content=xml_response.encode(), request=_make_request()),
     )
@@ -299,7 +321,7 @@ def test_async_evaluate_raw_posts_body_verbatim() -> None:
     when(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     ).thenReturn(_permit_response())
     pdp = _make_pdp()
 
@@ -311,7 +333,7 @@ def test_async_evaluate_raw_posts_body_verbatim() -> None:
     verify(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     )
 
 
@@ -320,7 +342,7 @@ def test_async_permissions_raw_posts_body_verbatim() -> None:
     when(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     ).thenReturn(_permissions_response())
     pdp = _make_pdp()
 
@@ -355,3 +377,53 @@ def test_async_permissions_raw_rejects_xml_content_type() -> None:
             await pdp.permissions_raw(_raw_xacml_body(), content_type=ContentType.XML)
 
     _run_async(run())
+
+
+def test_async_permissions_sends_service_and_version_headers() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=JSON_HEADERS,
+    ).thenReturn(_permissions_response())
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        request = PermissionsRequest(
+            subject=Subject(id="u"),
+            resource=Resource(id="r", type="t"),
+            application=Application(id="a"),
+        )
+        await pdp.permissions(request)
+
+    _run_async(run())
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=JSON_HEADERS,
+    )
+
+
+def test_async_custom_service_and_version_headers_propagate() -> None:
+    mock_client = _stub_transport()
+    custom_headers = {
+        "Content-Type": "application/json",
+        "Service": "CUSTOM",
+        "Version": "2.0",
+    }
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=custom_headers,
+    ).thenReturn(_permit_response())
+    pdp = _make_pdp(service="CUSTOM", version="2.0")
+
+    async def run() -> None:
+        await pdp.evaluate(_eval_request())
+
+    _run_async(run())
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=custom_headers,
+    )

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any, cast
 
 import httpx
@@ -22,6 +23,21 @@ from nextlabs_sdk.exceptions import ApiError, NextLabsError, ValidationError
 
 BASE_URL = "https://pdp.example.com"
 PDP_ENDPOINT = "/dpc/authorization/pdp"
+
+JSON_HEADERS = MappingProxyType(
+    {
+        "Content-Type": "application/json",
+        "Service": "EVAL",
+        "Version": "1.0",
+    }
+)
+XML_HEADERS = MappingProxyType(
+    {
+        "Content-Type": "application/xml",
+        "Service": "EVAL",
+        "Version": "1.0",
+    }
+)
 
 
 def _make_request() -> httpx.Request:
@@ -147,7 +163,7 @@ def test_evaluate_sets_json_content_type_header():
     when(mock_client).post(
         PDP_ENDPOINT,
         json=any_value(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     ).thenReturn(_make_permit_response())
 
     _make_pdp().evaluate(_make_eval_request(), content_type=ContentType.JSON)
@@ -155,7 +171,7 @@ def test_evaluate_sets_json_content_type_header():
     verify(mock_client).post(
         PDP_ENDPOINT,
         json=any_value(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     )
 
 
@@ -211,7 +227,7 @@ def test_evaluate_with_xml_content_type():
     when(mock_client).post(
         PDP_ENDPOINT,
         content=any_value(bytes),
-        headers={"Content-Type": "application/xml"},
+        headers=XML_HEADERS,
     ).thenReturn(
         httpx.Response(
             200, content=xml_response_body.encode(), request=_make_request()
@@ -347,7 +363,7 @@ def test_evaluate_raw_posts_body_verbatim() -> None:
     when(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     ).thenReturn(_make_permit_response())
 
     response = _make_pdp().evaluate_raw(_raw_xacml_body())
@@ -356,7 +372,7 @@ def test_evaluate_raw_posts_body_verbatim() -> None:
     verify(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     )
 
 
@@ -365,7 +381,7 @@ def test_permissions_raw_posts_body_verbatim() -> None:
     when(mock_client).post(
         PDP_ENDPOINT,
         json=_raw_xacml_body(),
-        headers={"Content-Type": "application/json"},
+        headers=JSON_HEADERS,
     ).thenReturn(_make_permissions_response())
 
     response = _make_pdp().permissions_raw(_raw_xacml_body())
@@ -387,3 +403,42 @@ def test_permissions_raw_rejects_xml_content_type() -> None:
         NextLabsError, match="permissions_raw.*only supports ContentType.JSON"
     ):
         _make_pdp().permissions_raw(_raw_xacml_body(), content_type=ContentType.XML)
+
+
+def test_permissions_sends_service_and_version_headers() -> None:
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=JSON_HEADERS,
+    ).thenReturn(_make_permissions_response())
+
+    _make_pdp().permissions(_make_permissions_request())
+
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=JSON_HEADERS,
+    )
+
+
+def test_custom_service_and_version_headers_propagate() -> None:
+    mock_client = _stub_transport()
+    custom_headers = {
+        "Content-Type": "application/json",
+        "Service": "CUSTOM",
+        "Version": "2.0",
+    }
+    when(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=custom_headers,
+    ).thenReturn(_make_permit_response())
+
+    _make_pdp(service="CUSTOM", version="2.0").evaluate(_make_eval_request())
+
+    verify(mock_client).post(
+        PDP_ENDPOINT,
+        json=any_value(),
+        headers=custom_headers,
+    )


### PR DESCRIPTION
## Problem

`nextlabs pdp eval --payload docs/test_payloads/policy_r3m_permit_region.json` returned:

```
Decision: Indeterminate
Status:   One or more required params are missing
Detail:   Service, Version
```

The NextLabs PDP REST API ([`docs/nextlabs_official/pdp_api.md`, lines 94–98 and 330–334](docs/nextlabs_official/pdp_api.md)) mandates three request headers on `POST /dpc/authorization/pdp` (and the permissions endpoint):

| Header | Value |
|---|---|
| `Content-Type` | `application/json` or `application/xml` |
| `Service` | `EVAL` |
| `Version` | `1.0` |

The SDK was only sending `Content-Type`, so servers that enforce the full header set rejected every PDP call — both raw XACML and structured.

## Fix

- New internal helper `src/nextlabs_sdk/_pdp/_headers.py` with `DEFAULT_SERVICE='EVAL'`, `DEFAULT_VERSION='1.0'` and `build_pdp_headers(content_type, *, service, version)`.
- Both `PdpClient` and `AsyncPdpClient` attach the full header set on every call (`evaluate`, `permissions`, `evaluate_raw`, `permissions_raw`, JSON + XML paths).
- Constructors gain keyword-only `service=` / `version=` overrides defaulting to the spec values, matching the existing `auth_base_url` / `token_url` override pattern. Fully backward-compatible.

## Why did tests miss this?

Existing unit tests pinned headers as either `any_value()` or just `{'Content-Type': ...}`, and the e2e WireMock matchers only asserted `Content-Type`. The contract was never encoded. This PR tightens both:

- Unit tests: pinned header expectations now include `Service: EVAL` and `Version: 1.0`; new tests cover permissions default headers and custom `service=`/`version=` kwargs propagation for both sync and async.
- E2E: `tests/e2e/test_pdp_flows.py` WireMock matchers now require `Service` and `Version` on every PDP request.

## Out of scope

- No CLI flags for `--pdp-service` / `--pdp-version` (YAGNI; override is available via the SDK for custom deployments).
- No changes to payload serialization, CloudAz endpoints, or the `--payload` loader.

## Verification

```
python ./tools/checks.py     # black + flake8 + mypy + pyright: clean
python ./tools/tests.py --short  # 1921 passed, 97 xfailed, 96.15% coverage
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>