### PR TITLE
feat(cli): pretty-print JSON and allow suppressing truncation in -vv trace

### DIFF
--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -135,7 +135,11 @@ def main(
         count=True,
         help=(
             "Increase verbosity. -v: show request context on errors; "
-            "-vv: trace every HTTP request/response."
+            "-vv: trace every HTTP request/response (JSON bodies are "
+            "pretty-printed, bodies capped at 2000 chars); -vvv: same "
+            "as -vv but log full bodies with no truncation. Set "
+            "NEXTLABS_LOG_BODY_LIMIT=<N> to override the cap (0 means "
+            "unlimited)."
         ),
     ),
 ) -> None:

--- a/src/nextlabs_sdk/_cli/_body_limit.py
+++ b/src/nextlabs_sdk/_cli/_body_limit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from nextlabs_sdk._logging import _DEFAULT_BODY_LIMIT
+
+
+def resolve_body_limit(verbose: int, env_value: str | None) -> int | None:
+    """Return the effective log body limit.
+
+    Precedence: ``NEXTLABS_LOG_BODY_LIMIT`` (when valid) beats the verbose
+    level. ``0`` means unlimited. Invalid or negative env values fall back
+    to the verbose-level default.
+    """
+    override_found, override = _parse_env_override(env_value)
+    if override_found:
+        return override
+    if verbose >= 3:
+        return None
+    return _DEFAULT_BODY_LIMIT
+
+
+def _parse_env_override(env_value: str | None) -> tuple[bool, int | None]:
+    if env_value is None or env_value == "":
+        return (False, None)
+    try:
+        parsed = int(env_value)
+    except ValueError:
+        return (False, None)
+    if parsed == 0:
+        return (True, None)
+    if parsed > 0:
+        return (True, parsed)
+    return (False, None)

--- a/src/nextlabs_sdk/_cli/_logging_setup.py
+++ b/src/nextlabs_sdk/_cli/_logging_setup.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
+
+from nextlabs_sdk._cli._body_limit import resolve_body_limit
+from nextlabs_sdk._logging import set_effective_body_limit
 
 _HANDLER_NAME = "nextlabs-cli-verbose"
 _LOGGER_NAME = "nextlabs_sdk"
+_BODY_LIMIT_ENV = "NEXTLABS_LOG_BODY_LIMIT"
 
 
 def configure_cli_logging(verbose: int) -> None:
     """Attach a stderr handler to the SDK logger when verbose >= 2.
+
+    Also resolves the effective body limit for the verbose HTTP trace
+    from the ``verbose`` level and the ``NEXTLABS_LOG_BODY_LIMIT``
+    environment variable, and publishes it to the SDK logging module.
 
     Idempotent: subsequent calls neither duplicate the handler nor
     lower the log level.
     """
     if verbose < 2:
         return
+    set_effective_body_limit(
+        resolve_body_limit(verbose, os.environ.get(_BODY_LIMIT_ENV))
+    )
     sdk_logger = logging.getLogger(_LOGGER_NAME)
     for existing in sdk_logger.handlers:
         if getattr(existing, "name", None) == _HANDLER_NAME:

--- a/src/nextlabs_sdk/_http_transport_logging.py
+++ b/src/nextlabs_sdk/_http_transport_logging.py
@@ -8,6 +8,7 @@ import httpx
 from nextlabs_sdk._logging import (
     format_request_line,
     format_response_line,
+    get_effective_body_limit,
     logger,
     redact_body,
     redact_headers,
@@ -20,14 +21,14 @@ def _log_request_safely(request: httpx.Request) -> None:
         logger.debug(format_request_line(request))
         logger.debug("    headers: %s", redact_headers(request.headers))
         body = redact_body(request.headers.get("content-type"), request.content)
-        logger.debug("    body:    %s", truncate(body))
+        logger.debug("    body:    %s", truncate(body, get_effective_body_limit()))
 
 
 def _log_response_safely(response: httpx.Response, elapsed: float) -> None:
     with contextlib.suppress(Exception):
         logger.debug(format_response_line(response, elapsed))
         body = redact_body(response.headers.get("content-type"), response.content)
-        logger.debug("    body:    %s", truncate(body))
+        logger.debug("    body:    %s", truncate(body, get_effective_body_limit()))
 
 
 def _log_failure_safely(elapsed: float) -> None:

--- a/src/nextlabs_sdk/_logging.py
+++ b/src/nextlabs_sdk/_logging.py
@@ -83,17 +83,30 @@ def _dispatch_redaction(content_type: str | None, text: str) -> str:
         parsed = json.loads(text)
     except ValueError:
         return text
-    return json.dumps(_redact_json(parsed))
+    return json.dumps(_redact_json(parsed), indent=2)
 
 
 def redact_body(content_type: str | None, body: bytes) -> str:
     return _body_preview(content_type, body)
 
 
-def truncate(text: str, limit: int = _DEFAULT_BODY_LIMIT) -> str:
-    if len(text) <= limit:
+def truncate(text: str, limit: int | None = _DEFAULT_BODY_LIMIT) -> str:
+    if limit is None or len(text) <= limit:
         return text
     return f"{text[:limit]}… (truncated, {len(text)} bytes total)"
+
+
+_effective_body_limit_holder: dict[str, int | None] = {"limit": _DEFAULT_BODY_LIMIT}
+
+
+def set_effective_body_limit(limit: int | None) -> None:
+    """Override the body limit used by the verbose HTTP trace."""
+    _effective_body_limit_holder["limit"] = limit
+
+
+def get_effective_body_limit() -> int | None:
+    """Return the currently active body limit (``None`` means unlimited)."""
+    return _effective_body_limit_holder["limit"]
 
 
 def format_request_line(request: httpx.Request) -> str:

--- a/tests/test_body_limit_resolver.py
+++ b/tests/test_body_limit_resolver.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from nextlabs_sdk._cli._body_limit import resolve_body_limit
+
+
+@pytest.mark.parametrize(
+    "verbose,env_value,expected",
+    [
+        pytest.param(0, None, 2000, id="default-vv-level-2"),
+        pytest.param(2, None, 2000, id="vv-keeps-2000"),
+        pytest.param(3, None, None, id="vvv-unlimited"),
+        pytest.param(4, None, None, id="vvvv-also-unlimited"),
+        pytest.param(2, "0", None, id="env-zero-means-unlimited"),
+        pytest.param(0, "0", None, id="env-zero-wins-at-any-level"),
+        pytest.param(2, "500", 500, id="env-positive-overrides"),
+        pytest.param(3, "500", 500, id="env-wins-over-verbose"),
+        pytest.param(2, "abc", 2000, id="env-invalid-falls-back"),
+        pytest.param(2, "-1", 2000, id="env-negative-falls-back"),
+        pytest.param(2, "", 2000, id="env-empty-falls-back"),
+        pytest.param(3, "not-an-int", None, id="invalid-env-falls-back-to-verbose"),
+    ],
+)
+def test_resolve_body_limit(verbose, env_value, expected):
+    assert resolve_body_limit(verbose, env_value) == expected
+
+
+def test_logging_body_limit_holder_defaults_to_2000():
+    from nextlabs_sdk import _logging
+
+    _logging.set_effective_body_limit(2000)
+    assert _logging.get_effective_body_limit() == 2000
+
+
+def test_logging_body_limit_holder_can_be_unlimited():
+    from nextlabs_sdk import _logging
+
+    try:
+        _logging.set_effective_body_limit(None)
+        assert _logging.get_effective_body_limit() is None
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+
+def test_logging_body_limit_holder_accepts_custom_int():
+    from nextlabs_sdk import _logging
+
+    try:
+        _logging.set_effective_body_limit(500)
+        assert _logging.get_effective_body_limit() == 500
+    finally:
+        _logging.set_effective_body_limit(2000)

--- a/tests/test_cli_app_verbose.py
+++ b/tests/test_cli_app_verbose.py
@@ -15,3 +15,13 @@ def test_verbose_flag_appears_in_help():
     assert result.exit_code == 0
     assert "-v" in output
     assert "--verbose" in output
+
+
+def test_help_mentions_vvv_and_body_limit_env(monkeypatch):
+    monkeypatch.setenv("COLUMNS", "240")
+    result = runner.invoke(app, ["--help"], terminal_width=240)
+    output = strip_ansi(result.output)
+
+    assert result.exit_code == 0
+    assert "-vvv" in output
+    assert "NEXTLABS_LOG_BODY_LIMIT" in output

--- a/tests/test_cli_logging_setup.py
+++ b/tests/test_cli_logging_setup.py
@@ -50,3 +50,63 @@ def test_idempotent_second_call_does_not_duplicate_handler() -> None:
     configure_cli_logging(2)
 
     assert len(_our_handlers()) == 1
+
+
+def test_level_2_sets_default_body_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nextlabs_sdk import _logging
+
+    monkeypatch.delenv("NEXTLABS_LOG_BODY_LIMIT", raising=False)
+    _logging.set_effective_body_limit(999)
+    configure_cli_logging(2)
+
+    assert _logging.get_effective_body_limit() == 2000
+
+
+def test_level_3_sets_unlimited_body_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nextlabs_sdk import _logging
+
+    monkeypatch.delenv("NEXTLABS_LOG_BODY_LIMIT", raising=False)
+    _logging.set_effective_body_limit(2000)
+    try:
+        configure_cli_logging(3)
+        assert _logging.get_effective_body_limit() is None
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+
+def test_env_overrides_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nextlabs_sdk import _logging
+
+    monkeypatch.setenv("NEXTLABS_LOG_BODY_LIMIT", "123")
+    _logging.set_effective_body_limit(2000)
+    try:
+        configure_cli_logging(3)
+        assert _logging.get_effective_body_limit() == 123
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+
+def test_env_zero_means_unlimited_at_vv(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nextlabs_sdk import _logging
+
+    monkeypatch.setenv("NEXTLABS_LOG_BODY_LIMIT", "0")
+    _logging.set_effective_body_limit(2000)
+    try:
+        configure_cli_logging(2)
+        assert _logging.get_effective_body_limit() is None
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+
+def test_level_below_2_leaves_limit_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk import _logging
+
+    monkeypatch.setenv("NEXTLABS_LOG_BODY_LIMIT", "42")
+    _logging.set_effective_body_limit(2000)
+    try:
+        configure_cli_logging(1)
+        assert _logging.get_effective_body_limit() == 2000
+    finally:
+        _logging.set_effective_body_limit(2000)

--- a/tests/test_http_transport_logging.py
+++ b/tests/test_http_transport_logging.py
@@ -74,6 +74,64 @@ def test_sync_logging_transport_redacts_authorization_header(
     assert "Bearer ***" in joined
 
 
+def test_sync_logging_transport_truncates_by_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from nextlabs_sdk import _logging
+
+    big = ("x" * 5000).encode()
+    request = httpx.Request(
+        "POST",
+        "https://api.example.com/x",
+        headers={"content-type": "text/plain"},
+        content=big,
+    )
+    response = httpx.Response(200, request=request, content=b"ok")
+    wrapped = mock(httpx.BaseTransport)
+    when(wrapped).handle_request(request).thenReturn(response)
+
+    _logging.set_effective_body_limit(2000)
+    transport = LoggingTransport(wrapped=wrapped)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            transport.handle_request(request)
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+    joined = "\n".join(_capture_debug(caplog))
+    assert "truncated" in joined
+    assert "5000 bytes total" in joined
+
+
+def test_sync_logging_transport_honours_unlimited_holder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from nextlabs_sdk import _logging
+
+    big = ("x" * 5000).encode()
+    request = httpx.Request(
+        "POST",
+        "https://api.example.com/x",
+        headers={"content-type": "text/plain"},
+        content=big,
+    )
+    response = httpx.Response(200, request=request, content=b"ok")
+    wrapped = mock(httpx.BaseTransport)
+    when(wrapped).handle_request(request).thenReturn(response)
+
+    _logging.set_effective_body_limit(None)
+    transport = LoggingTransport(wrapped=wrapped)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            transport.handle_request(request)
+    finally:
+        _logging.set_effective_body_limit(2000)
+
+    joined = "\n".join(_capture_debug(caplog))
+    assert "truncated" not in joined
+    assert "x" * 5000 in joined
+
+
 class _FakeAsync(httpx.AsyncBaseTransport):
     async def handle_async_request(
         self,

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -126,6 +126,49 @@ def test_truncate_over_limit_annotated():
     assert "50 bytes total" in out
 
 
+def test_truncate_none_limit_returns_text_unchanged():
+    huge = "x" * 10_000
+
+    assert truncate(huge, limit=None) == huge
+
+
+def test_json_body_pretty_printed_with_indent():
+    body = json.dumps({"a": 1, "nested": {"b": 2}}).encode()
+
+    out = redact_body("application/json", body)
+
+    assert "\n" in out
+    assert '  "a": 1' in out
+    assert '    "b": 2' in out
+
+
+def test_json_body_pretty_printed_still_redacts():
+    body = json.dumps({"client_secret": "shh"}).encode()
+
+    out = redact_body("application/json", body)
+
+    assert "\n" in out
+    assert "shh" not in out
+    assert '"client_secret": "***"' in out
+
+
+def test_form_body_stays_single_line_after_pretty_change():
+    body = b"grant_type=password&username=u&password=secret"
+
+    out = redact_body("application/x-www-form-urlencoded", body)
+
+    assert "\n" not in out
+    assert "secret" not in out
+
+
+def test_plain_text_body_unchanged_by_pretty_change():
+    body = b"plain text"
+
+    out = redact_body("text/plain", body)
+
+    assert out == "plain text"
+
+
 def test_format_request_line():
     request = httpx.Request("POST", "https://example.com/x")
 


### PR DESCRIPTION
Closes #73.

## What changes

- JSON request/response bodies in the `-vv` HTTP trace are now
  pretty-printed (`json.dumps(indent=2)`) after redaction, so nested
  XACML payloads stay readable.
- New `-vvv` verbosity level disables body truncation entirely.
- New `NEXTLABS_LOG_BODY_LIMIT` env var overrides the cap at any
  verbosity (`0` = unlimited, positive int = explicit cap, invalid
  value falls back to the verbose-level default).
- `truncate()` now accepts `limit: int | None` (`None` = unlimited).
- Precedence (env > verbose level > default) is resolved in one place
  (`_cli/_body_limit.resolve_body_limit`) and published via a
  process-wide holder in `_logging` that both `LoggingTransport`
  (sync) and `AsyncLoggingTransport` (async) read at log time.
- `--help` for the root command documents `-vvv` and
  `NEXTLABS_LOG_BODY_LIMIT`.

## Scope

- No changes to the public SDK surface. All edits are in internal
  modules (`_logging`, `_http_transport_logging`, `_cli/_logging_setup`,
  `_cli/_body_limit`, `_cli/_app`).
- `-v` behavior (request context on errors only) is unchanged.
- Redaction rules unchanged; redaction still runs before
  indentation so `"client_secret": "***"` etc. appear in the
  pretty-printed output.
- Form-urlencoded and binary bodies are unchanged.

## Tests

- Extended `tests/test_logging_redaction.py` with cases for
  pretty-printed JSON, redaction inside pretty-printed JSON,
  `truncate(..., None)`, and form/text bodies staying single-line.
- New `tests/test_body_limit_resolver.py` covers every
  precedence/edge case of `resolve_body_limit` plus the
  `set_/get_effective_body_limit` holder.
- Extended `tests/test_cli_logging_setup.py` to cover env-var →
  holder wiring at `-vv` and `-vvv`, including invalid values.
- Extended `tests/test_http_transport_logging.py` to cover the
  transport honouring an unlimited holder.
- Extended `tests/test_cli_app_verbose.py` to assert the new
  `--help` content.

1949 unit tests pass; coverage at 96.19%. Black, Flake8, Mypy, and
Pyright all clean.