### PR TITLE
fix(pdp): correct permissions endpoint, serialization, and response parser; add 'pdp explain' CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,38 @@ Format auto-detection can be overridden with `--payload-format` (one of
 `auto`, `json`, `yaml`, `xacml`). `--payload-format xacml` forces the
 raw-XACML passthrough and rejects files whose shape does not match.
 
+### `pdp explain` — which policies produced this decision?
+
+`nextlabs pdp explain --payload PATH` answers *why* the PDP reached a
+given decision by listing the matching policies for each action.
+Under the hood it calls the NextLabs **permissions** endpoint
+(`/dpc/authorization/pdppermissions`) with
+`record_matching_policies=true`, so responses group actions into
+`Allowed` / `Denied` / `Don't Care` buckets along with their matching
+policies and obligations.
+
+```bash
+# Start from the same payload you used for `pdp eval`
+nextlabs pdp explain --payload ./request.json
+
+# Narrow output to a single action
+nextlabs pdp explain --payload ./request.json --action DELETE
+
+# Machine-readable form
+nextlabs --output json pdp explain --payload ./request.json
+```
+
+Notes:
+
+- `pdp explain` reuses the `pdp eval` payload loader. Any `action`
+  supplied in the payload is ignored — the permissions endpoint returns
+  results for every action the policies cover.
+- The XACML `ReturnPolicyIdList="true"` flag has **no effect** on the
+  eval endpoint (`/dpc/authorization/pdp`); NextLabs PDP does not
+  populate `PolicyIdentifierList` there. Policy-identifier
+  introspection is only available via the permissions endpoint that
+  `pdp explain` uses.
+
 **Environment variables**
 
 | Variable                   | Purpose                                                       |

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -25,18 +25,22 @@ from nextlabs_sdk._cli._pdp_payload_helpers import (
     run_payload_loader,
 )
 from nextlabs_sdk._pdp import (
+    ActionPermission,
     ContentType,
     Decision,
     EvalRequest,
     EvalResponse,
     Obligation,
     PermissionsRequest,
+)
+from nextlabs_sdk._pdp import (
     PermissionsResponse,
     PolicyRef,
 )
 from nextlabs_sdk._pdp._client import PdpClient
-from nextlabs_sdk._pdp._payload._format import LoadedPayload, PayloadFormat
-from nextlabs_sdk._pdp._payload._loader import (
+from nextlabs_sdk._pdp._payload import (
+    LoadedPayload,
+    PayloadFormat,
     load_eval_payload,
     load_permissions_payload,
 )
@@ -374,3 +378,170 @@ def permissions(
 
 register_detail_renderer(EvalResponse, _render_eval_detail)
 register_detail_renderer(PermissionsResponse, _render_permissions_detail)
+
+
+_EXPLAIN_EMPTY_HINT = (
+    "No matching policies returned. If you expected policy names, verify that "
+    "record_matching_policies support is enabled on your PDP deployment."
+)
+
+
+@pdp_app.command()
+@cli_error_handler
+def explain(
+    ctx: typer.Context,
+    payload_path: Annotated[
+        Path,
+        typer.Option(
+            "--payload",
+            help="Path to a YAML / JSON / raw XACML JSON request file.",
+        ),
+    ],
+    payload_format: Annotated[
+        PayloadFormat,
+        typer.Option(
+            "--payload-format",
+            help="Force payload format (auto, yaml, json, xacml).",
+            case_sensitive=False,
+        ),
+    ] = PayloadFormat.AUTO,
+    action_filter: Annotated[
+        str | None,
+        typer.Option(
+            "--action",
+            help="Only show the result for this action name.",
+        ),
+    ] = None,
+    wire_format: Annotated[
+        str, typer.Option("--content-type", help="Wire format (json or xml)")
+    ] = "json",
+) -> None:
+    """Explain which policies produced the PDP decision for each action."""
+    cli_ctx: CliContext = ctx.obj
+    content_type = _resolve_content_type(wire_format)
+    client = _client_factory.make_pdp_client(cli_ctx)
+    loaded = run_payload_loader(load_eval_payload, payload_path, payload_format)
+    assert isinstance(loaded, LoadedPayload)
+    response = _run_explain(client, loaded, content_type=content_type)
+    _emit_explain(response, cli_ctx.output_format, action_filter=action_filter)
+
+
+def _run_explain(
+    client: PdpClient,
+    loaded: LoadedPayload,
+    *,
+    content_type: ContentType,
+) -> PermissionsResponse:
+    if loaded.kind == "raw_xacml":
+        assert loaded.body is not None
+        return client.permissions_raw(
+            _as_permissions_body(loaded.body),
+            content_type=content_type,
+        )
+    assert isinstance(loaded.request, (EvalRequest, PermissionsRequest))
+    request = _as_permissions_request(loaded.request)
+    return client.permissions(request, content_type=content_type)
+
+
+def _as_permissions_request(
+    source: EvalRequest | PermissionsRequest,
+) -> PermissionsRequest:
+    return PermissionsRequest(
+        subject=source.subject,
+        resource=source.resource,
+        application=source.application,
+        environment=source.environment,
+        return_policy_ids=source.return_policy_ids,
+        record_matching_policies=True,
+    )
+
+
+def _as_permissions_body(body: dict[str, object]) -> dict[str, object]:
+    return body
+
+
+def _emit_explain(
+    response: PermissionsResponse,
+    output_format: OutputFormat,
+    *,
+    action_filter: str | None,
+) -> None:
+    if output_format is OutputFormat.JSON:
+        render_json(response)
+        return
+    console = Console()
+    if action_filter is None:
+        _render_explain_all(response, console)
+    else:
+        _render_explain_action(response, action_filter, console)
+    if _has_no_matching_policies(response):
+        console.print(f"\n[yellow]{_EXPLAIN_EMPTY_HINT}[/yellow]")
+
+
+def _render_explain_all(response: PermissionsResponse, console: Console) -> None:
+    sections = [
+        ("Allowed", response.allowed),
+        ("Denied", response.denied),
+        ("Don't Care", response.dont_care),
+    ]
+    any_shown = False
+    for label, actions in sections:
+        if not actions:
+            continue
+        any_shown = True
+        console.print(f"\n{label} ({len(actions)}):")
+        console.print(_build_explain_table(actions))
+    if not any_shown:
+        console.print("No action permissions returned.")
+
+
+def _render_explain_action(
+    response: PermissionsResponse,
+    action_name: str,
+    console: Console,
+) -> None:
+    for label, actions in (
+        ("Allowed", response.allowed),
+        ("Denied", response.denied),
+        ("Don't Care", response.dont_care),
+    ):
+        match = next((act for act in actions if act.name == action_name), None)
+        if match is None:
+            continue
+        console.print(f"Action [bold]{action_name}[/bold]: {label}")
+        console.print(_build_explain_table([match]))
+        return
+    console.print(f"Action [bold]{action_name}[/bold] not found in response.")
+
+
+def _build_explain_table(actions: Sequence[ActionPermission]) -> Table:
+    table = Table()
+    table.add_column("Action")
+    table.add_column("Matching policies")
+    table.add_column("Obligations")
+    for action in actions:
+        policies = "\n".join(ref.id for ref in action.policy_refs) or "-"
+        obligations = _format_obligations_cell(action.obligations)
+        table.add_row(action.name, policies, obligations)
+    return table
+
+
+def _format_obligations_cell(obligations: Sequence[Obligation]) -> str:
+    if not obligations:
+        return "-"
+    return "\n".join(_format_obligation(obl) for obl in obligations)
+
+
+def _format_obligation(obl: Obligation) -> str:
+    if not obl.attributes:
+        return obl.id
+    pairs = ", ".join(f"{attr.id}={attr.attr_value}" for attr in obl.attributes)
+    return f"{obl.id}: {pairs}"
+
+
+def _has_no_matching_policies(response: PermissionsResponse) -> bool:
+    for bucket in (response.allowed, response.denied, response.dont_care):
+        for action in bucket:
+            if action.policy_refs:
+                return False
+    return True

--- a/src/nextlabs_sdk/_pdp/_async_client.py
+++ b/src/nextlabs_sdk/_pdp/_async_client.py
@@ -19,7 +19,8 @@ from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
-_PDP_ENDPOINT = "/dpc/authorization/pdp"
+_PDP_EVAL_ENDPOINT = "/dpc/authorization/pdp"
+_PDP_PERMISSIONS_ENDPOINT = "/dpc/authorization/pdppermissions"
 
 
 def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
@@ -73,7 +74,7 @@ class AsyncPdpClient:
         if content_type == ContentType.XML:
             body_bytes = xml_ser.serialize_eval_request(request)
             response = await self._client.post(
-                _PDP_ENDPOINT,
+                _PDP_EVAL_ENDPOINT,
                 content=body_bytes,
                 headers=build_pdp_headers(
                     content_type, service=self._service, version=self._version
@@ -84,7 +85,7 @@ class AsyncPdpClient:
 
         body = json_ser.serialize_eval_request(request)
         response = await self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_EVAL_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -106,7 +107,7 @@ class AsyncPdpClient:
         if content_type == ContentType.XML:
             body_bytes = xml_ser.serialize_permissions_request(request)
             response = await self._client.post(
-                _PDP_ENDPOINT,
+                _PDP_PERMISSIONS_ENDPOINT,
                 content=body_bytes,
                 headers=build_pdp_headers(
                     content_type, service=self._service, version=self._version
@@ -117,7 +118,7 @@ class AsyncPdpClient:
 
         body = json_ser.serialize_permissions_request(request)
         response = await self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_PERMISSIONS_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -139,7 +140,7 @@ class AsyncPdpClient:
         """POST a pre-built raw XACML JSON body to the PDP eval endpoint."""
         _require_json_content_type(content_type, method="evaluate_raw")
         response = await self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_EVAL_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -161,7 +162,7 @@ class AsyncPdpClient:
         """POST a pre-built raw XACML JSON body to the PDP permissions endpoint."""
         _require_json_content_type(content_type, method="permissions_raw")
         response = await self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_PERMISSIONS_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version

--- a/src/nextlabs_sdk/_pdp/_client.py
+++ b/src/nextlabs_sdk/_pdp/_client.py
@@ -19,7 +19,8 @@ from nextlabs_sdk._pdp._response_models import EvalResponse, PermissionsResponse
 from nextlabs_sdk._pdp._token_url import resolve_pdp_token_url
 from nextlabs_sdk.exceptions import NextLabsError, raise_for_status
 
-_PDP_ENDPOINT = "/dpc/authorization/pdp"
+_PDP_EVAL_ENDPOINT = "/dpc/authorization/pdp"
+_PDP_PERMISSIONS_ENDPOINT = "/dpc/authorization/pdppermissions"
 
 
 def _require_json_content_type(content_type: ContentType, *, method: str) -> None:
@@ -73,7 +74,7 @@ class PdpClient:
         if content_type == ContentType.XML:
             body_bytes = xml_ser.serialize_eval_request(request)
             response = self._client.post(
-                _PDP_ENDPOINT,
+                _PDP_EVAL_ENDPOINT,
                 content=body_bytes,
                 headers=build_pdp_headers(
                     content_type, service=self._service, version=self._version
@@ -84,7 +85,7 @@ class PdpClient:
 
         body = json_ser.serialize_eval_request(request)
         response = self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_EVAL_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -106,7 +107,7 @@ class PdpClient:
         if content_type == ContentType.XML:
             body_bytes = xml_ser.serialize_permissions_request(request)
             response = self._client.post(
-                _PDP_ENDPOINT,
+                _PDP_PERMISSIONS_ENDPOINT,
                 content=body_bytes,
                 headers=build_pdp_headers(
                     content_type, service=self._service, version=self._version
@@ -117,7 +118,7 @@ class PdpClient:
 
         body = json_ser.serialize_permissions_request(request)
         response = self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_PERMISSIONS_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -139,7 +140,7 @@ class PdpClient:
         """POST a pre-built raw XACML JSON body to the PDP eval endpoint."""
         _require_json_content_type(content_type, method="evaluate_raw")
         response = self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_EVAL_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version
@@ -161,7 +162,7 @@ class PdpClient:
         """POST a pre-built raw XACML JSON body to the PDP permissions endpoint."""
         _require_json_content_type(content_type, method="permissions_raw")
         response = self._client.post(
-            _PDP_ENDPOINT,
+            _PDP_PERMISSIONS_ENDPOINT,
             json=body,
             headers=build_pdp_headers(
                 content_type, service=self._service, version=self._version

--- a/src/nextlabs_sdk/_pdp/_json_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_json_serializer.py
@@ -77,19 +77,45 @@ def serialize_permissions_request(
         _serialize_resource(request.resource),
         _serialize_application(request.application),
     ]
-    if request.environment is not None:
-        categories.append(_serialize_environment(request.environment))
-    response: dict[str, object] = {
+    environment_category = _serialize_permissions_environment(
+        request.environment,
+        record_matching_policies=request.record_matching_policies,
+    )
+    if environment_category is not None:
+        categories.append(environment_category)
+    return {
         "Request": {
             "ReturnPolicyIdList": request.return_policy_ids,
             "Category": categories,
         },
     }
-    if request.record_matching_policies:
-        request_dict = response["Request"]
-        if isinstance(request_dict, dict):
-            request_dict["RecordMatchingPolicies"] = True
-    return response
+
+
+def _serialize_permissions_environment(
+    environment: Environment | None,
+    *,
+    record_matching_policies: bool,
+) -> dict[str, object] | None:
+    if environment is None and not record_matching_policies:
+        return None
+    if environment is None:
+        category = _build_category(urns.ENVIRONMENT_CATEGORY, [])
+    else:
+        category = _serialize_environment(environment)
+    if record_matching_policies:
+        attributes = category[_ATTRIBUTE_KEY]
+        assert isinstance(attributes, list)
+        attributes.append(_make_record_matching_attr())
+    return category
+
+
+def _make_record_matching_attr() -> dict[str, object]:
+    return {
+        "AttributeId": urns.RECORD_MATCHING_POLICIES_ATTR,
+        _VALUE_KEY: "true",
+        "DataType": urns.STRING_DATATYPE,
+        "IncludeInResult": False,
+    }
 
 
 def deserialize_eval_response(body: dict[str, object]) -> EvalResponse:
@@ -100,44 +126,73 @@ def deserialize_eval_response(body: dict[str, object]) -> EvalResponse:
     return EvalResponse(eval_results=parsed)
 
 
+_PermissionsBucket = tuple[str, list[ActionPermission]]
+
+
 def deserialize_permissions_response(
     body: dict[str, object],
 ) -> PermissionsResponse:
     allowed: list[ActionPermission] = []
     denied: list[ActionPermission] = []
     dont_care: list[ActionPermission] = []
-
-    raw_results = body["Response"]
-    if not isinstance(raw_results, list):
-        return PermissionsResponse(
-            allowed=allowed,
-            denied=denied,
-            dont_care=dont_care,
-        )
-
-    for raw_result in raw_results:
-        if not isinstance(raw_result, dict):
-            continue
-        action_name = _extract_action_name(raw_result)
-        obligations = _parse_obligations(raw_result.get("Obligations", []))
-        policy_refs = _parse_policy_refs(raw_result)
-        permission = ActionPermission(
-            name=action_name,
-            obligations=obligations,
-            policy_refs=policy_refs,
-        )
-        decision = Decision(raw_result["Decision"])
-        if decision == Decision.PERMIT:
-            allowed.append(permission)
-        elif decision == Decision.DENY:
-            denied.append(permission)
-        else:
-            dont_care.append(permission)
-
+    buckets: list[_PermissionsBucket] = [
+        ("allow", allowed),
+        ("deny", denied),
+        ("dontcare", dont_care),
+    ]
+    raw_results = body.get("Response")
+    if isinstance(raw_results, list):
+        _fill_permissions_buckets(raw_results, buckets)
     return PermissionsResponse(
         allowed=allowed,
         denied=denied,
         dont_care=dont_care,
+    )
+
+
+def _fill_permissions_buckets(
+    raw_results: list[object],
+    buckets: list[_PermissionsBucket],
+) -> None:
+    for raw_result in raw_results:
+        grouped = _extract_grouped(raw_result)
+        if grouped is None:
+            continue
+        for key, target in buckets:
+            for entry in _iter_bucket_items(grouped.get(key)):
+                target.append(_parse_action_permission(entry))
+
+
+def _extract_grouped(raw_result: object) -> dict[str, object] | None:
+    if not isinstance(raw_result, dict):
+        return None
+    grouped = raw_result.get("ActionsAndObligations")
+    if not isinstance(grouped, dict):
+        return None
+    return grouped
+
+
+def _iter_bucket_items(raw: object) -> list[dict[str, object]]:
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
+def _parse_action_permission(entry: dict[str, object]) -> ActionPermission:
+    obligations_raw = entry.get("Obligations", [])
+    obligations = _parse_obligations(
+        obligations_raw if isinstance(obligations_raw, list) else [],
+    )
+    matching_raw = entry.get("MatchingPolicies", [])
+    policy_refs: list[PolicyRef] = []
+    if isinstance(matching_raw, list):
+        policy_refs = [
+            PolicyRef(id=str(pid)) for pid in matching_raw if isinstance(pid, str)
+        ]
+    return ActionPermission(
+        name=str(entry.get("Action", "")),
+        obligations=obligations,
+        policy_refs=policy_refs,
     )
 
 
@@ -276,13 +331,19 @@ def _parse_obligations(
         attrs = [
             ObligationAttribute(
                 id=str(assignment["AttributeId"]),
-                attr_value=str(assignment[_VALUE_KEY]),
+                attr_value=_stringify_assignment_value(assignment[_VALUE_KEY]),
             )
             for assignment in raw.get("AttributeAssignment", [])
             if isinstance(assignment, dict)
         ]
         obligations.append(Obligation(id=str(raw["Id"]), attributes=attrs))
     return obligations
+
+
+def _stringify_assignment_value(raw: object) -> str:
+    if isinstance(raw, list):
+        return ", ".join(str(element) for element in raw)
+    return str(raw)
 
 
 def _parse_policy_refs(raw: dict[str, object]) -> list[PolicyRef]:
@@ -303,25 +364,3 @@ def _parse_policy_refs(raw: dict[str, object]) -> list[PolicyRef]:
             ),
         )
     return refs
-
-
-def _extract_action_name(raw_result: dict[str, object]) -> str:
-    categories = raw_result.get("Category", [])
-    if not isinstance(categories, list):
-        return ""
-    for category in categories:
-        if not isinstance(category, dict):
-            continue
-        if category[_CATEGORY_ID_KEY] == urns.ACTION_CATEGORY:
-            return _find_action_id_in_category(category)
-    return ""
-
-
-def _find_action_id_in_category(category: dict[str, object]) -> str:
-    attributes = category.get(_ATTRIBUTE_KEY, [])
-    if not isinstance(attributes, list):
-        return ""
-    for attr in attributes:
-        if isinstance(attr, dict) and attr["AttributeId"] == urns.ACTION_ID:
-            return str(attr[_VALUE_KEY])
-    return ""

--- a/src/nextlabs_sdk/_pdp/_payload/__init__.py
+++ b/src/nextlabs_sdk/_pdp/_payload/__init__.py
@@ -2,3 +2,16 @@
 
 See :mod:`nextlabs_sdk.pdp.payloads` for the public surface.
 """
+
+from nextlabs_sdk._pdp._payload._format import (
+    LoadedPayload as LoadedPayload,
+)
+from nextlabs_sdk._pdp._payload._format import (
+    PayloadFormat as PayloadFormat,
+)
+from nextlabs_sdk._pdp._payload._loader import (
+    load_eval_payload as load_eval_payload,
+)
+from nextlabs_sdk._pdp._payload._loader import (
+    load_permissions_payload as load_permissions_payload,
+)

--- a/src/nextlabs_sdk/_pdp/_urns.py
+++ b/src/nextlabs_sdk/_pdp/_urns.py
@@ -22,6 +22,8 @@ APPLICATION_PREFIX = "urn:nextlabs:names:evalsvc:1.0:application:"
 
 ENVIRONMENT_PREFIX = "urn:oasis:names:tc:xacml:3.0:environment:"
 
+RECORD_MATCHING_POLICIES_ATTR = "nextlabs-record-matching-policies-in-result"
+
 STRING_DATATYPE = "http://www.w3.org/2001/XMLSchema#string"
 INTEGER_DATATYPE = "http://www.w3.org/2001/XMLSchema#integer"
 DOUBLE_DATATYPE = "http://www.w3.org/2001/XMLSchema#double"

--- a/src/nextlabs_sdk/_pdp/_xml_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_xml_serializer.py
@@ -27,6 +27,9 @@ from nextlabs_sdk._pdp._response_models import (
 )
 
 _XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+_ATTRIBUTE_TAG = "Attribute"
+_ATTRIBUTE_VALUE_TAG = "AttributeValue"
+_ATTRIBUTE_ID_KEY = "AttributeId"
 
 
 def serialize_eval_request(request: EvalRequest) -> bytes:
@@ -45,9 +48,55 @@ def serialize_permissions_request(request: PermissionsRequest) -> bytes:
     _add_subject(root, request.subject)
     _add_resource(root, request.resource)
     _add_application(root, request.application)
-    if request.environment is not None:
-        _add_environment(root, request.environment)
+    _add_permissions_environment(
+        root,
+        request.environment,
+        record_matching_policies=request.record_matching_policies,
+    )
     return ET.tostring(root, encoding="unicode").encode("utf-8")
+
+
+def _add_permissions_environment(
+    parent: ET.Element,
+    environment: Environment | None,
+    *,
+    record_matching_policies: bool,
+) -> None:
+    if environment is None and not record_matching_policies:
+        return
+    attrs: list[AttrPair] = []
+    if environment is not None:
+        attrs.extend(
+            _collect_extra_attrs(environment.model_extra, urns.ENVIRONMENT_PREFIX),
+        )
+        attrs.extend(_collect_dict_attrs(environment.attributes))
+    attrs_el = ET.SubElement(parent, _ns("Attributes"))
+    attrs_el.set("Category", urns.ENVIRONMENT_CATEGORY)
+    for attr_id, attr_value in attrs:
+        _append_attribute(attrs_el, attr_id, attr_value)
+    if record_matching_policies:
+        _append_record_matching_attribute(attrs_el)
+
+
+def _append_attribute(
+    parent: ET.Element,
+    attr_id: str,
+    attr_value: AttrValue,
+) -> None:
+    attr_el = ET.SubElement(parent, _ns(_ATTRIBUTE_TAG))
+    attr_el.set(_ATTRIBUTE_ID_KEY, attr_id)
+    value_el = ET.SubElement(attr_el, _ns(_ATTRIBUTE_VALUE_TAG))
+    value_el.set("DataType", _infer_datatype(attr_value))
+    value_el.text = _serialize_value(attr_value)
+
+
+def _append_record_matching_attribute(parent: ET.Element) -> None:
+    attr_el = ET.SubElement(parent, _ns(_ATTRIBUTE_TAG))
+    attr_el.set(_ATTRIBUTE_ID_KEY, urns.RECORD_MATCHING_POLICIES_ATTR)
+    attr_el.set("IncludeInResult", "false")
+    value_el = ET.SubElement(attr_el, _ns(_ATTRIBUTE_VALUE_TAG))
+    value_el.set("DataType", urns.STRING_DATATYPE)
+    value_el.text = "true"
 
 
 def deserialize_eval_response(body: bytes) -> EvalResponse:
@@ -110,11 +159,7 @@ def _add_attributes_element(
     attrs_el = ET.SubElement(parent, _ns("Attributes"))
     attrs_el.set("Category", category)
     for attr_id, attr_value in attrs:
-        attr_el = ET.SubElement(attrs_el, _ns("Attribute"))
-        attr_el.set("AttributeId", attr_id)
-        value_el = ET.SubElement(attr_el, _ns("AttributeValue"))
-        value_el.set("DataType", _infer_datatype(attr_value))
-        value_el.text = _serialize_value(attr_value)
+        _append_attribute(attrs_el, attr_id, attr_value)
 
 
 AttrValue = str | int | float | bool
@@ -252,7 +297,7 @@ def _parse_obligations_xml(result_el: ET.Element) -> list[Obligation]:
         obl_id = obl_el.get("ObligationId", "")
         attrs = [
             ObligationAttribute(
-                id=aa_el.get("AttributeId", ""),
+                id=aa_el.get(_ATTRIBUTE_ID_KEY, ""),
                 attr_value=(aa_el.text or "").strip(),
             )
             for aa_el in obl_el.findall(_ns("AttributeAssignment"))
@@ -280,9 +325,9 @@ def _find_action_value_el(result_el: ET.Element) -> ET.Element | None:
     for attrs_el in result_el.findall(_ns("Attributes")):
         if attrs_el.get("Category") != urns.ACTION_CATEGORY:
             continue
-        for attr_el in attrs_el.findall(_ns("Attribute")):
-            if attr_el.get("AttributeId") == urns.ACTION_ID:
-                return attr_el.find(_ns("AttributeValue"))
+        for attr_el in attrs_el.findall(_ns(_ATTRIBUTE_TAG)):
+            if attr_el.get(_ATTRIBUTE_ID_KEY) == urns.ACTION_ID:
+                return attr_el.find(_ns(_ATTRIBUTE_VALUE_TAG))
     return None
 
 

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -23,6 +23,7 @@ from nextlabs_sdk.exceptions import ApiError
 
 BASE_URL = "https://pdp.example.com"
 PDP_ENDPOINT = "/dpc/authorization/pdp"
+PERMISSIONS_ENDPOINT = "/dpc/authorization/pdppermissions"
 
 JSON_HEADERS = MappingProxyType(
     {
@@ -93,21 +94,20 @@ def _permissions_response() -> httpx.Response:
     return httpx.Response(
         200,
         json={
+            "Status": {"StatusCode": {"Value": "ok"}},
             "Response": [
                 {
-                    "Decision": "Permit",
-                    "Status": {"StatusCode": {"Value": "ok"}},
-                    "Category": [
-                        {
-                            "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
-                            "Attribute": [
-                                {
-                                    "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
-                                    "Value": "VIEW",
-                                },
-                            ],
-                        },
-                    ],
+                    "ActionsAndObligations": {
+                        "allow": [
+                            {
+                                "Action": "VIEW",
+                                "MatchingPolicies": ["ROOT/VIEW Policy"],
+                                "Obligations": [],
+                            },
+                        ],
+                        "deny": [],
+                        "dontcare": [],
+                    },
                 },
             ],
         },
@@ -132,6 +132,14 @@ def _stub_post_json(mock_client: Any, response: httpx.Response) -> None:
     ).thenReturn(response)
 
 
+def _stub_post_permissions(mock_client: Any, response: httpx.Response) -> None:
+    when(mock_client).post(
+        PERMISSIONS_ENDPOINT,
+        json=any_value(),
+        headers=any_value(),
+    ).thenReturn(response)
+
+
 def test_async_evaluate_returns_permit():
     mock_client = _stub_transport()
     _stub_post_json(mock_client, _permit_response())
@@ -146,7 +154,7 @@ def test_async_evaluate_returns_permit():
 
 def test_async_permissions_returns_grouped():
     mock_client = _stub_transport()
-    _stub_post_json(mock_client, _permissions_response())
+    _stub_post_permissions(mock_client, _permissions_response())
     pdp = _make_pdp()
 
     async def run() -> None:
@@ -158,8 +166,31 @@ def test_async_permissions_returns_grouped():
         response = await pdp.permissions(request)
         assert len(response.allowed) == 1
         assert response.allowed[0].name == "VIEW"
+        assert response.allowed[0].policy_refs[0].id == "ROOT/VIEW Policy"
 
     _run_async(run())
+
+
+def test_async_permissions_posts_to_permissions_endpoint():
+    mock_client = _stub_transport()
+    _stub_post_permissions(mock_client, _permissions_response())
+    pdp = _make_pdp()
+
+    async def run() -> None:
+        await pdp.permissions(
+            PermissionsRequest(
+                subject=Subject(id="u"),
+                resource=Resource(id="r", type="t"),
+                application=Application(id="a"),
+            ),
+        )
+
+    _run_async(run())
+    verify(mock_client).post(
+        PERMISSIONS_ENDPOINT,
+        json=any_value(),
+        headers=any_value(),
+    )
 
 
 def test_async_context_manager_closes():
@@ -216,25 +247,26 @@ def test_async_evaluate_raises_api_error_on_non_json_response():
     _run_async(run())
 
 
-def test_async_permissions_raises_api_error_on_unexpected_shape():
+def test_async_permissions_tolerates_missing_actions_and_obligations():
     mock_client = _stub_transport()
-    _stub_post_json(
+    _stub_post_permissions(
         mock_client,
         httpx.Response(200, json={"nope": True}, request=_make_request()),
     )
     pdp = _make_pdp()
 
     async def run() -> None:
-        with pytest.raises(ApiError) as exc_info:
-            await pdp.permissions(
-                PermissionsRequest(
-                    subject=Subject(id="u"),
-                    action=Action(id="VIEW"),
-                    resource=Resource(id="r", type="doc"),
-                    application=Application(id="app"),
-                ),
-            )
-        assert "Unexpected PDP response shape" in exc_info.value.message
+        response = await pdp.permissions(
+            PermissionsRequest(
+                subject=Subject(id="u"),
+                action=Action(id="VIEW"),
+                resource=Resource(id="r", type="doc"),
+                application=Application(id="app"),
+            ),
+        )
+        assert response.allowed == []
+        assert response.denied == []
+        assert response.dont_care == []
 
     _run_async(run())
 
@@ -340,7 +372,7 @@ def test_async_evaluate_raw_posts_body_verbatim() -> None:
 def test_async_permissions_raw_posts_body_verbatim() -> None:
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=_raw_xacml_body(),
         headers=JSON_HEADERS,
     ).thenReturn(_permissions_response())
@@ -382,7 +414,7 @@ def test_async_permissions_raw_rejects_xml_content_type() -> None:
 def test_async_permissions_sends_service_and_version_headers() -> None:
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=JSON_HEADERS,
     ).thenReturn(_permissions_response())
@@ -398,7 +430,7 @@ def test_async_permissions_sends_service_and_version_headers() -> None:
 
     _run_async(run())
     verify(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=JSON_HEADERS,
     )

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -407,3 +407,149 @@ def test_pdp_permissions_json_format_returns_parseable_json() -> None:
     assert result.exit_code == 0
     parsed = json.loads(result.output)
     assert parsed["allowed"][0]["name"] == "VIEW"
+
+
+# --- pdp explain ---
+
+
+def _write_eval_payload(tmp_path: Any) -> Any:
+    payload = (
+        '{"subject":{"id":"u"},"action":{"id":"VIEW"},'
+        '"resource":{"id":"r","type":"doc"},"application":{"id":"app"}}'
+    )
+    path = tmp_path / "eval.json"
+    path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def _explain_args(payload_path: Any) -> tuple[str, ...]:
+    return ("pdp", "explain", "--payload", str(payload_path))
+
+
+def test_pdp_explain_renders_allowed_with_policies(tmp_path: Any) -> None:
+    mock_client = _stub_client()
+    response = _perm_response(
+        allowed=[
+            ActionPermission(
+                name="VIEW",
+                policy_refs=[PolicyRef(id="ROOT/VIEW Policy")],
+            ),
+        ],
+        denied=[
+            ActionPermission(
+                name="DELETE",
+                policy_refs=[PolicyRef(id="ROOT/DELETE Policy")],
+            ),
+        ],
+    )
+    when(mock_client).permissions(...).thenReturn(response)
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_explain_args(path)])
+
+    assert result.exit_code == 0
+    assert "Allowed" in result.output
+    assert "VIEW" in result.output
+    assert "ROOT/VIEW Policy" in result.output
+    assert "Denied" in result.output
+    assert "DELETE" in result.output
+
+
+def test_pdp_explain_sets_record_matching_policies_and_drops_action(
+    tmp_path: Any,
+) -> None:
+    mock_client = _stub_client()
+    captured: dict[str, Any] = {}
+
+    def _capture(request: Any, *, content_type: Any) -> PermissionsResponse:
+        captured["request"] = request
+        captured["content_type"] = content_type
+        return _perm_response()
+
+    when(mock_client).permissions(...).thenAnswer(_capture)
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_explain_args(path)])
+
+    assert result.exit_code == 0
+    request = captured["request"]
+    assert request.record_matching_policies is True
+    assert not hasattr(request, "action")
+
+
+def test_pdp_explain_action_filter_prints_matching_bucket(tmp_path: Any) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenReturn(
+        _perm_response(
+            allowed=[ActionPermission(name="VIEW")],
+            denied=[ActionPermission(name="DELETE")],
+        ),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, *_explain_args(path), "--action", "DELETE"],
+    )
+
+    assert result.exit_code == 0
+    assert "Denied" in result.output
+    assert "DELETE" in result.output
+    assert "VIEW" not in result.output
+
+
+def test_pdp_explain_action_filter_missing_action_still_succeeds(
+    tmp_path: Any,
+) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenReturn(
+        _perm_response(allowed=[ActionPermission(name="VIEW")]),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, *_explain_args(path), "--action", "OPEN"],
+    )
+
+    assert result.exit_code == 0
+    assert "OPEN" in result.output
+    assert "not found" in result.output
+
+
+def test_pdp_explain_empty_hint_when_no_matching_policies(tmp_path: Any) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenReturn(
+        _perm_response(allowed=[ActionPermission(name="VIEW")]),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_explain_args(path)])
+
+    assert result.exit_code == 0
+    assert "record_matching_policies" in result.output
+
+
+def test_pdp_explain_json_output(tmp_path: Any) -> None:
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenReturn(
+        _perm_response(
+            allowed=[
+                ActionPermission(
+                    name="VIEW",
+                    policy_refs=[PolicyRef(id="P1")],
+                ),
+            ],
+        ),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "json", *_explain_args(path)],
+    )
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["allowed"][0]["name"] == "VIEW"
+    assert parsed["allowed"][0]["policy_refs"][0]["id"] == "P1"

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -206,7 +206,39 @@ def test_serialize_permissions_request_with_record_matching():
             record_matching_policies=True,
         ),
     )
-    assert body["Request"]["RecordMatchingPolicies"] is True
+    assert "RecordMatchingPolicies" not in body["Request"]
+    env_cat = _find_category(body, urns.ENVIRONMENT_CATEGORY)
+    record_attr = _find_attribute(env_cat, urns.RECORD_MATCHING_POLICIES_ATTR)
+    assert record_attr["Value"] == "true"
+    assert record_attr["DataType"] == urns.STRING_DATATYPE
+    assert record_attr["IncludeInResult"] is False
+
+
+def test_serialize_permissions_request_merges_record_matching_into_env():
+    body = _perm_body(
+        PermissionsRequest(
+            subject=Subject(id="u"),
+            resource=Resource(id="r", type="t"),
+            application=Application(id="app"),
+            environment=Environment(attributes={"tenant": "acme"}),
+            record_matching_policies=True,
+        ),
+    )
+    env_cat = _find_category(body, urns.ENVIRONMENT_CATEGORY)
+    assert _find_attribute(env_cat, "tenant")["Value"] == "acme"
+    assert _find_attribute(env_cat, urns.RECORD_MATCHING_POLICIES_ATTR)
+
+
+def test_serialize_permissions_request_no_env_when_disabled():
+    body = _perm_body(
+        PermissionsRequest(
+            subject=Subject(id="u"),
+            resource=Resource(id="r", type="t"),
+            application=Application(id="app"),
+        ),
+    )
+    category_ids = [c["CategoryId"] for c in body["Request"]["Category"]]
+    assert urns.ENVIRONMENT_CATEGORY not in category_ids
 
 
 def test_serialize_data_type_float():
@@ -369,37 +401,81 @@ def test_deserialize_without_status_detail_defaults_empty():
 
 
 def test_deserialize_permissions_response():
-    action_cat = "urn:oasis:names:tc:xacml:3.0:attribute-category:action"
-    action_id = "urn:oasis:names:tc:xacml:1.0:action:action-id"
-
-    def _entry(decision: str, value: str) -> dict[str, Any]:
-        entry: dict[str, Any] = {
-            "Decision": decision,
-            "Status": {"StatusCode": {"Value": "ok"}},
-            "Category": [
-                {
-                    "CategoryId": action_cat,
-                    "Attribute": [{"AttributeId": action_id, "Value": value}],
-                },
-            ],
-        }
-        if decision == "Permit":
-            entry["Obligations"] = []
-        return entry
-
     body = {
+        "Status": {"StatusCode": {"Value": "ok"}},
         "Response": [
-            _entry("Permit", "VIEW"),
-            _entry("Deny", "DELETE"),
-            _entry("NotApplicable", "ARCHIVE"),
+            {
+                "ActionsAndObligations": {
+                    "allow": [
+                        {
+                            "Action": "OPEN",
+                            "MatchingPolicies": ["ROOT/OPEN Policy"],
+                            "Obligations": [],
+                        },
+                        {
+                            "Action": "SEND",
+                            "MatchingPolicies": [
+                                "ROOT/OPEN Policy",
+                                "ROOT/SEND Policy",
+                            ],
+                            "Obligations": [
+                                {
+                                    "Id": "Obligation 1",
+                                    "AttributeAssignment": [
+                                        {
+                                            "AttributeId": "arg1",
+                                            "Value": ["val1"],
+                                            "DataType": (
+                                                "http://www.w3.org/2001/"
+                                                "XMLSchema#string"
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "deny": [
+                        {
+                            "Action": "DELETE",
+                            "MatchingPolicies": ["ROOT/DELETE Policy"],
+                            "Obligations": [],
+                        },
+                    ],
+                    "dontcare": [],
+                },
+            },
         ],
     }
 
     response = deserialize_permissions_response(cast(dict[str, object], body))
 
-    assert len(response.allowed) == 1
-    assert response.allowed[0].name == "VIEW"
-    assert len(response.denied) == 1
-    assert response.denied[0].name == "DELETE"
-    assert len(response.dont_care) == 1
-    assert response.dont_care[0].name == "ARCHIVE"
+    assert [p.name for p in response.allowed] == ["OPEN", "SEND"]
+    assert response.allowed[0].policy_refs[0].id == "ROOT/OPEN Policy"
+    send = response.allowed[1]
+    assert [ref.id for ref in send.policy_refs] == [
+        "ROOT/OPEN Policy",
+        "ROOT/SEND Policy",
+    ]
+    assert send.obligations[0].id == "Obligation 1"
+    assert send.obligations[0].attributes[0].attr_value == "val1"
+    assert [p.name for p in response.denied] == ["DELETE"]
+    assert response.dont_care == []
+
+
+def test_deserialize_permissions_response_tolerates_missing_actions_and_obligations():
+    body = {"Status": {"StatusCode": {"Value": "ok"}}, "Response": [{}]}
+
+    response = deserialize_permissions_response(cast(dict[str, object], body))
+
+    assert response.allowed == []
+    assert response.denied == []
+    assert response.dont_care == []
+
+
+def test_deserialize_permissions_response_tolerates_missing_response_key():
+    body: dict[str, Any] = {"Status": {"StatusCode": {"Value": "ok"}}}
+
+    response = deserialize_permissions_response(cast(dict[str, object], body))
+
+    assert response.allowed == []

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -23,6 +23,7 @@ from nextlabs_sdk.exceptions import ApiError, NextLabsError, ValidationError
 
 BASE_URL = "https://pdp.example.com"
 PDP_ENDPOINT = "/dpc/authorization/pdp"
+PERMISSIONS_ENDPOINT = "/dpc/authorization/pdppermissions"
 
 JSON_HEADERS = MappingProxyType(
     {
@@ -64,30 +65,29 @@ def _make_permit_response() -> httpx.Response:
 
 
 def _make_permissions_response() -> httpx.Response:
-    def _category(action: str) -> dict[str, Any]:
-        return {
-            "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
-            "Attribute": [
-                {
-                    "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
-                    "Value": action,
-                },
-            ],
-        }
-
     return httpx.Response(
         200,
         json={
+            "Status": {"StatusCode": {"Value": "ok"}},
             "Response": [
                 {
-                    "Decision": "Permit",
-                    "Status": {"StatusCode": {"Value": "ok"}},
-                    "Category": [_category("VIEW")],
-                },
-                {
-                    "Decision": "Deny",
-                    "Status": {"StatusCode": {"Value": "ok"}},
-                    "Category": [_category("DELETE")],
+                    "ActionsAndObligations": {
+                        "allow": [
+                            {
+                                "Action": "VIEW",
+                                "MatchingPolicies": ["ROOT/VIEW Policy"],
+                                "Obligations": [],
+                            },
+                        ],
+                        "deny": [
+                            {
+                                "Action": "DELETE",
+                                "MatchingPolicies": ["ROOT/DELETE Policy"],
+                                "Obligations": [],
+                            },
+                        ],
+                        "dontcare": [],
+                    },
                 },
             ],
         },
@@ -178,7 +178,7 @@ def test_evaluate_sets_json_content_type_header():
 def test_permissions_returns_grouped_actions():
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=any_value(),
     ).thenReturn(_make_permissions_response())
@@ -187,8 +187,26 @@ def test_permissions_returns_grouped_actions():
 
     assert len(response.allowed) == 1
     assert response.allowed[0].name == "VIEW"
+    assert response.allowed[0].policy_refs[0].id == "ROOT/VIEW Policy"
     assert len(response.denied) == 1
     assert response.denied[0].name == "DELETE"
+
+
+def test_permissions_posts_to_permissions_endpoint():
+    mock_client = _stub_transport()
+    when(mock_client).post(
+        PERMISSIONS_ENDPOINT,
+        json=any_value(),
+        headers=any_value(),
+    ).thenReturn(_make_permissions_response())
+
+    _make_pdp().permissions(_make_permissions_request())
+
+    verify(mock_client).post(
+        PERMISSIONS_ENDPOINT,
+        json=any_value(),
+        headers=any_value(),
+    )
 
 
 def test_client_uses_custom_http_config():
@@ -280,7 +298,7 @@ def test_evaluate_error_dispatch(response, expected_exc, match):
 def test_permissions_raises_api_error_on_non_json_response():
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=any_value(),
     ).thenReturn(httpx.Response(200, content=b"x", request=_make_request()))
@@ -379,7 +397,7 @@ def test_evaluate_raw_posts_body_verbatim() -> None:
 def test_permissions_raw_posts_body_verbatim() -> None:
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=_raw_xacml_body(),
         headers=JSON_HEADERS,
     ).thenReturn(_make_permissions_response())
@@ -408,7 +426,7 @@ def test_permissions_raw_rejects_xml_content_type() -> None:
 def test_permissions_sends_service_and_version_headers() -> None:
     mock_client = _stub_transport()
     when(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=JSON_HEADERS,
     ).thenReturn(_make_permissions_response())
@@ -416,7 +434,7 @@ def test_permissions_sends_service_and_version_headers() -> None:
     _make_pdp().permissions(_make_permissions_request())
 
     verify(mock_client).post(
-        PDP_ENDPOINT,
+        PERMISSIONS_ENDPOINT,
         json=any_value(),
         headers=JSON_HEADERS,
     )

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -105,6 +105,42 @@ def test_xml_serialize_permissions_no_action():
     assert ACTION_CATEGORY not in category_ids
 
 
+def test_xml_serialize_permissions_with_record_matching_policies():
+    request = PermissionsRequest(
+        subject=Subject(id="u"),
+        resource=Resource(id="r", type="t"),
+        application=Application(id="app"),
+        record_matching_policies=True,
+    )
+    root = _parse_xml(serialize_permissions_request(request))
+
+    env_el = _find_env_attributes(root)
+    record_attr = _find_attribute_by_id(
+        env_el, "nextlabs-record-matching-policies-in-result"
+    )
+    assert record_attr.get("IncludeInResult") == "false"
+    value_el = record_attr.find(_ns("AttributeValue"))
+    assert value_el is not None
+    assert value_el.text == "true"
+    assert value_el.get("DataType") == "http://www.w3.org/2001/XMLSchema#string"
+
+
+def _find_env_attributes(root: ET.Element) -> ET.Element:
+    for attrs_el in root.findall(_ns("Attributes")):
+        if attrs_el.attrib["Category"] == (
+            "urn:oasis:names:tc:xacml:3.0:attribute-category:environment"
+        ):
+            return attrs_el
+    raise AssertionError("Environment Attributes element not found")
+
+
+def _find_attribute_by_id(parent: ET.Element, attr_id: str) -> ET.Element:
+    for attr_el in parent.findall(_ns("Attribute")):
+        if attr_el.get("AttributeId") == attr_id:
+            return attr_el
+    raise AssertionError(f"Attribute {attr_id} not found")
+
+
 def test_xml_deserialize_permit_response():
     xml_data = (
         f'<Response xmlns="{XACML_NS}">'


### PR DESCRIPTION
Closes #75.

## Summary

Fixes three bugs in `permissions()` and adds the new `nextlabs pdp explain` CLI subcommand.

### Part A — bug fixes

- **A1 Endpoint path**: `permissions()` / `permissions_raw()` now POST to `/dpc/authorization/pdppermissions` (sync + async).
- **A2 `record_matching_policies` serialization**: injected as an **environment attribute** (URN `nextlabs-record-matching-policies-in-result`, `DataType=string`, `Value="true"`, `IncludeInResult=false`), not a top-level key. Mirrored in JSON and XML serializers.
- **A3 Response parser**: rewritten for the actual NextLabs `ActionsAndObligations { allow, deny, dontcare }` shape. Tolerant: responses missing the grouping return an empty `PermissionsResponse` rather than raising.
- Obligation parser now handles list-form `Value` payloads used by the permissions response.

### Part B — `nextlabs pdp explain`

- New subcommand modeled after `pdp eval`; loads payload via `--payload`, always sets `record_matching_policies=True`, drops `action` if present.
- Renders bucketed Rich tables (Allowed / Denied / Don't Care) with matching policies and obligations per action.
- `--action NAME` filter; informative message if action missing.
- Hint when no bucket has matching policies.
- JSON output supported via top-level `--output json`.

### Docs

- README: new `pdp explain` subsection + note on the `ReturnPolicyIdList` quirk (server ignores it on the eval endpoint; policy-identifier introspection requires the permissions endpoint).

## TDD

Tests rewritten / added:
- `tests/test_json_serializer.py` — record-matching env attr + `ActionsAndObligations` parsing + tolerance.
- `tests/test_xml_serializer.py` — mirrored env attr coverage.
- `tests/test_pdp_client.py` / `tests/test_async_pdp_client.py` — new endpoint routing test; fixtures updated; tolerance test.
- `tests/test_cli_pdp.py` — 6 new `pdp explain` tests.

Unit suite: 1962 passed. `python ./tools/checks.py` green (black, flake8, mypy, pyright). No suppressions used.