### PR TITLE
feat(pdp): surface non-ok XACML Status as PdpStatusError

### DIFF
--- a/src/nextlabs_sdk/_cli/_error_handler.py
+++ b/src/nextlabs_sdk/_cli/_error_handler.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import replace
 from typing import ParamSpec, TypeVar
 
+import click
 import typer
 from rich.console import Console
 
@@ -15,6 +16,7 @@ from nextlabs_sdk.exceptions import (
     AuthenticationError,
     NextLabsError,
     NotFoundError,
+    PdpStatusError,
     RefreshTokenExpiredError,
     RequestTimeoutError,
     TransportError,
@@ -33,6 +35,7 @@ _ERROR_PREFIXES: tuple[_ErrorPrefixPair, ...] = (
     (NotFoundError, "Not found"),
     (RequestTimeoutError, "Request timed out"),
     (TransportError, "Connection error"),
+    (PdpStatusError, "PDP rejected the request"),
 )
 
 
@@ -51,15 +54,24 @@ def _format_error_message(exc: BaseException) -> str:
     return f"Unexpected error: {exc}"
 
 
-def _extract_typer_context(args: tuple[object, ...]) -> typer.Context | None:
+def _extract_typer_context(
+    args: tuple[object, ...],
+    kwargs: dict[str, object] | None = None,
+) -> click.Context | None:
     for arg in args:
-        if isinstance(arg, typer.Context):
+        if isinstance(arg, click.Context):
             return arg
+    for ctx_value in (kwargs or {}).values():
+        if isinstance(ctx_value, click.Context):
+            return ctx_value
     return None
 
 
-def _extract_cli_context(args: tuple[object, ...]) -> CliContext | None:
-    ctx = _extract_typer_context(args)
+def _extract_cli_context(
+    args: tuple[object, ...],
+    kwargs: dict[str, object] | None = None,
+) -> CliContext | None:
+    ctx = _extract_typer_context(args, kwargs)
     if ctx is None or not isinstance(ctx.obj, CliContext):
         return None
     return ctx.obj
@@ -72,13 +84,16 @@ def _reauth_prompt_label(cli_ctx: CliContext) -> str:
     return f"Password for {target} (re-auth required)"
 
 
-def _prepare_reauth(args: tuple[object, ...]) -> bool:
+def _prepare_reauth(
+    args: tuple[object, ...],
+    kwargs: dict[str, object] | None = None,
+) -> bool:
     """Mutate the typer context with a freshly prompted password.
 
     Returns ``True`` if an inline re-auth retry should be attempted,
     ``False`` if the caller should let the original error propagate.
     """
-    typer_ctx = _extract_typer_context(args)
+    typer_ctx = _extract_typer_context(args, kwargs)
     if typer_ctx is None or not isinstance(typer_ctx.obj, CliContext):
         return False
     cli_ctx = typer_ctx.obj
@@ -115,10 +130,14 @@ def _print_verbose_context(exc: NextLabsError) -> None:
         stderr.print(f"  body:    {_format_body_preview(body, len(body))}")
 
 
-def _maybe_print_verbose(exc: BaseException, args: tuple[object, ...]) -> None:
+def _maybe_print_verbose(
+    exc: BaseException,
+    args: tuple[object, ...],
+    kwargs: dict[str, object] | None = None,
+) -> None:
     if not isinstance(exc, NextLabsError):
         return
-    cli_ctx = _extract_cli_context(args)
+    cli_ctx = _extract_cli_context(args, kwargs)
     if cli_ctx is None or cli_ctx.verbose < 1:
         return
     _print_verbose_context(exc)
@@ -127,9 +146,10 @@ def _maybe_print_verbose(exc: BaseException, args: tuple[object, ...]) -> None:
 def _handle_exception(
     exc: BaseException,
     args: tuple[object, ...],
+    kwargs: dict[str, object] | None = None,
 ) -> None:
     print_error(_format_error_message(exc))
-    _maybe_print_verbose(exc, args)
+    _maybe_print_verbose(exc, args, kwargs)
     raise typer.Exit(code=1) from exc
 
 
@@ -141,7 +161,7 @@ def _run_with_reauth(
     try:
         return func(*args, **kwargs)
     except RefreshTokenExpiredError:
-        if not _prepare_reauth(args):
+        if not _prepare_reauth(args, kwargs):
             raise
         return func(*args, **kwargs)
 
@@ -156,7 +176,7 @@ def cli_error_handler(
         except typer.Exit:
             raise
         except Exception as exc:
-            _handle_exception(exc, args)
+            _handle_exception(exc, args, kwargs)
             raise  # unreachable; _handle_exception always raises
 
     return wrapper

--- a/src/nextlabs_sdk/_pdp/_async_client.py
+++ b/src/nextlabs_sdk/_pdp/_async_client.py
@@ -81,7 +81,7 @@ class AsyncPdpClient:
                 ),
             )
             raise_for_status(response)
-            return xml_ser.deserialize_eval_response(response.content)
+            return xml_ser.deserialize_eval_response(response, response.content)
 
         body = json_ser.serialize_eval_request(request)
         response = await self._client.post(
@@ -114,7 +114,7 @@ class AsyncPdpClient:
                 ),
             )
             raise_for_status(response)
-            return xml_ser.deserialize_permissions_response(response.content)
+            return xml_ser.deserialize_permissions_response(response, response.content)
 
         body = json_ser.serialize_permissions_request(request)
         response = await self._client.post(

--- a/src/nextlabs_sdk/_pdp/_client.py
+++ b/src/nextlabs_sdk/_pdp/_client.py
@@ -81,7 +81,7 @@ class PdpClient:
                 ),
             )
             raise_for_status(response)
-            return xml_ser.deserialize_eval_response(response.content)
+            return xml_ser.deserialize_eval_response(response, response.content)
 
         body = json_ser.serialize_eval_request(request)
         response = self._client.post(
@@ -114,7 +114,7 @@ class PdpClient:
                 ),
             )
             raise_for_status(response)
-            return xml_ser.deserialize_permissions_response(response.content)
+            return xml_ser.deserialize_permissions_response(response, response.content)
 
         body = json_ser.serialize_permissions_request(request)
         response = self._client.post(

--- a/src/nextlabs_sdk/_pdp/_json_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_json_serializer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import httpx
+
 from nextlabs_sdk._pdp import _urns as urns
 from nextlabs_sdk._pdp._enums import Decision
 from nextlabs_sdk._pdp._request_models import (
@@ -21,6 +23,7 @@ from nextlabs_sdk._pdp._response_models import (
     PolicyRef,
     Status,
 )
+from nextlabs_sdk._pdp._status_check import raise_if_not_ok
 
 _CATEGORY_ID_KEY = "CategoryId"
 _ATTRIBUTE_KEY = "Attribute"
@@ -118,10 +121,15 @@ def _make_record_matching_attr() -> dict[str, object]:
     }
 
 
-def deserialize_eval_response(body: dict[str, object]) -> EvalResponse:
+def deserialize_eval_response(
+    response: httpx.Response,
+    body: dict[str, object],
+) -> EvalResponse:
+    _check_top_level_status(response, body)
     raw_results = body["Response"]
     parsed: list[EvalResult] = []
     if isinstance(raw_results, list):
+        _check_result_statuses(response, raw_results)
         parsed = [_parse_eval_result(entry) for entry in raw_results]
     return EvalResponse(eval_results=parsed)
 
@@ -130,8 +138,10 @@ _PermissionsBucket = tuple[str, list[ActionPermission]]
 
 
 def deserialize_permissions_response(
+    response: httpx.Response,
     body: dict[str, object],
 ) -> PermissionsResponse:
+    _check_top_level_status(response, body)
     allowed: list[ActionPermission] = []
     denied: list[ActionPermission] = []
     dont_care: list[ActionPermission] = []
@@ -142,12 +152,50 @@ def deserialize_permissions_response(
     ]
     raw_results = body.get("Response")
     if isinstance(raw_results, list):
+        _check_result_statuses(response, raw_results)
         _fill_permissions_buckets(raw_results, buckets)
     return PermissionsResponse(
         allowed=allowed,
         denied=denied,
         dont_care=dont_care,
     )
+
+
+def _check_top_level_status(
+    response: httpx.Response,
+    body: dict[str, object],
+) -> None:
+    status = body.get("Status")
+    if not isinstance(status, dict):
+        return
+    code, message = _extract_status_code_and_message(status)
+    raise_if_not_ok(response, code=code, message=message)
+
+
+def _check_result_statuses(
+    response: httpx.Response,
+    raw_results: list[object],
+) -> None:
+    for entry in raw_results:
+        if not isinstance(entry, dict):
+            continue
+        status = entry.get("Status")
+        if not isinstance(status, dict):
+            continue
+        code, message = _extract_status_code_and_message(status)
+        raise_if_not_ok(response, code=code, message=message)
+
+
+def _extract_status_code_and_message(
+    status: dict[str, object],
+) -> tuple[str, str]:
+    status_code_raw = status.get("StatusCode")
+    code = ""
+    if isinstance(status_code_raw, dict):
+        code = str(status_code_raw.get("Value", ""))
+    message_raw = status.get("StatusMessage", "")
+    message = str(message_raw) if message_raw else ""
+    return code, message
 
 
 def _fill_permissions_buckets(

--- a/src/nextlabs_sdk/_pdp/_response_decode.py
+++ b/src/nextlabs_sdk/_pdp/_response_decode.py
@@ -5,14 +5,14 @@ from typing import Callable, TypeVar
 import httpx
 
 from nextlabs_sdk._json_response import decode_json
-from nextlabs_sdk.exceptions import ApiError
+from nextlabs_sdk.exceptions import ApiError, PdpStatusError
 
 T_Payload = TypeVar("T_Payload")
 
 
 def decode_pdp_response(
     response: httpx.Response,
-    deserializer: Callable[[dict[str, object]], T_Payload],
+    deserializer: Callable[[httpx.Response, dict[str, object]], T_Payload],
     *,
     what: str,
 ) -> T_Payload:
@@ -24,7 +24,9 @@ def decode_pdp_response(
             status_code=response.status_code,
         )
     try:
-        return deserializer(body)
+        return deserializer(response, body)
+    except PdpStatusError:
+        raise
     except (KeyError, TypeError, ValueError) as exc:
         raise ApiError(
             f"Unexpected PDP response shape while decoding {what}: {exc}",

--- a/src/nextlabs_sdk/_pdp/_status_check.py
+++ b/src/nextlabs_sdk/_pdp/_status_check.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import httpx
+
+from nextlabs_sdk.exceptions import PdpStatusError
+
+XACML_STATUS_OK = "urn:oasis:names:tc:xacml:1.0:status:ok"
+
+_BODY_PREVIEW_LIMIT = 4096
+
+
+def raise_if_not_ok(
+    response: httpx.Response,
+    *,
+    code: str,
+    message: str,
+) -> None:
+    """Raise ``PdpStatusError`` when ``code`` is set and not the ok URN.
+
+    Empty or missing codes are treated as ok; only an explicit non-ok
+    XACML status code triggers the exception.
+    """
+    if not code or code == XACML_STATUS_OK:
+        return
+    friendly = message or f"PDP returned status {code}"
+    request = response.request
+    raise PdpStatusError(
+        friendly,
+        xacml_status_code=code,
+        xacml_status_message=message,
+        status_code=response.status_code,
+        response_body=_body_preview(response),
+        request_method=request.method,
+        request_url=str(request.url),
+    )
+
+
+def _body_preview(response: httpx.Response) -> str:
+    text = response.text
+    if len(text) > _BODY_PREVIEW_LIMIT:
+        return text[:_BODY_PREVIEW_LIMIT]
+    return text

--- a/src/nextlabs_sdk/_pdp/_xml_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_xml_serializer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from xml.etree import ElementTree as ET
 
+import httpx
 from defusedxml import ElementTree as DefusedET
 
 from nextlabs_sdk._pdp import _urns as urns
@@ -25,6 +26,7 @@ from nextlabs_sdk._pdp._response_models import (
     PolicyRef,
     Status,
 )
+from nextlabs_sdk._pdp._status_check import raise_if_not_ok
 
 _XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
 _ATTRIBUTE_TAG = "Attribute"
@@ -99,19 +101,29 @@ def _append_record_matching_attribute(parent: ET.Element) -> None:
     value_el.text = "true"
 
 
-def deserialize_eval_response(body: bytes) -> EvalResponse:
+def deserialize_eval_response(
+    response: httpx.Response,
+    body: bytes,
+) -> EvalResponse:
     root = DefusedET.fromstring(body)
-    parsed = [_parse_result(result_el) for result_el in root.findall(_ns("Result"))]
+    result_els = root.findall(_ns("Result"))
+    _raise_on_non_ok_result(response, result_els)
+    parsed = [_parse_result(result_el) for result_el in result_els]
     return EvalResponse(eval_results=parsed)
 
 
-def deserialize_permissions_response(body: bytes) -> PermissionsResponse:
+def deserialize_permissions_response(
+    response: httpx.Response,
+    body: bytes,
+) -> PermissionsResponse:
     root = DefusedET.fromstring(body)
+    result_els = root.findall(_ns("Result"))
+    _raise_on_non_ok_result(response, result_els)
     allowed: list[ActionPermission] = []
     denied: list[ActionPermission] = []
     dont_care: list[ActionPermission] = []
 
-    for result_el in root.findall(_ns("Result")):
+    for result_el in result_els:
         action_name = _extract_action_name_xml(result_el)
         obligations = _parse_obligations_xml(result_el)
         policy_refs = _parse_policy_refs_xml(result_el)
@@ -135,6 +147,15 @@ def deserialize_permissions_response(body: bytes) -> PermissionsResponse:
         denied=denied,
         dont_care=dont_care,
     )
+
+
+def _raise_on_non_ok_result(
+    response: httpx.Response,
+    result_els: list[ET.Element],
+) -> None:
+    for result_el in result_els:
+        status = _parse_status_xml(result_el)
+        raise_if_not_ok(response, code=status.code, message=status.message)
 
 
 def _ns(tag: str) -> str:

--- a/src/nextlabs_sdk/exceptions.py
+++ b/src/nextlabs_sdk/exceptions.py
@@ -85,6 +85,37 @@ class PdpPayloadError(NextLabsError):
     """Raised for invalid or unreadable PDP request payload files."""
 
 
+class PdpStatusError(ApiError):
+    """Raised when the PDP returns a non-ok XACML Status on HTTP 200.
+
+    Inherits from :class:`ApiError` so existing callers that catch
+    ``ApiError`` continue to work.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        xacml_status_code: str,
+        xacml_status_message: str = "",
+        status_code: int | None = None,
+        response_body: str | None = None,
+        request_method: str | None = None,
+        request_url: str | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            status_code=status_code,
+            response_body=response_body,
+            request_method=request_method,
+            request_url=request_url,
+            envelope_status_code=xacml_status_code,
+            envelope_message=xacml_status_message or message,
+        )
+        self.xacml_status_code = xacml_status_code
+        self.xacml_status_message = xacml_status_message
+
+
 class RateLimitError(ApiError):
     """HTTP 429 after retries exhausted."""
 

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -94,7 +94,9 @@ def _permissions_response() -> httpx.Response:
     return httpx.Response(
         200,
         json={
-            "Status": {"StatusCode": {"Value": "ok"}},
+            "Status": {
+                "StatusCode": {"Value": "urn:oasis:names:tc:xacml:1.0:status:ok"}
+            },
             "Response": [
                 {
                     "ActionsAndObligations": {

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -581,6 +581,8 @@ def test_pdp_explain_surfaces_pdp_status_error(tmp_path: Any) -> None:
 
 
 def test_pdp_explain_verbose_pdp_status_error_shows_xacml_code(tmp_path: Any) -> None:
+    from strip_ansi import strip_ansi
+
     from nextlabs_sdk.exceptions import PdpStatusError
 
     urn = "urn:oasis:names:tc:xacml:1.0:status:missing-attribute"
@@ -598,8 +600,14 @@ def test_pdp_explain_verbose_pdp_status_error_shows_xacml_code(tmp_path: Any) ->
     )
 
     path = _write_eval_payload(tmp_path)
-    result = runner.invoke(app, [*_GLOBAL_OPTS, "-v", *_explain_args(path)])
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "-v", *_explain_args(path)],
+        terminal_width=240,
+    )
 
     assert result.exit_code == 1
     assert "PDP rejected the request" in result.output
-    assert urn in result.stderr
+    stderr_plain = strip_ansi(result.stderr)
+    assert urn in stderr_plain
+    assert "envelope" in stderr_plain

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -553,3 +553,53 @@ def test_pdp_explain_json_output(tmp_path: Any) -> None:
     parsed = json.loads(result.output)
     assert parsed["allowed"][0]["name"] == "VIEW"
     assert parsed["allowed"][0]["policy_refs"][0]["id"] == "P1"
+
+
+def test_pdp_explain_surfaces_pdp_status_error(tmp_path: Any) -> None:
+    from nextlabs_sdk.exceptions import PdpStatusError
+
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenRaise(
+        PdpStatusError(
+            "Invalid Request :: One or more mandatory attributes are missing",
+            xacml_status_code=("urn:oasis:names:tc:xacml:1.0:status:missing-attribute"),
+            xacml_status_message=(
+                "Invalid Request :: One or more mandatory attributes are missing"
+            ),
+            status_code=200,
+            request_method="POST",
+            request_url="https://pdp.example.com/dpc/authorization/pdppermissions",
+        ),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(app, [*_GLOBAL_OPTS, *_explain_args(path)])
+
+    assert result.exit_code == 1
+    assert "PDP rejected the request" in result.output
+    assert "mandatory attributes" in result.output
+
+
+def test_pdp_explain_verbose_pdp_status_error_shows_xacml_code(tmp_path: Any) -> None:
+    from nextlabs_sdk.exceptions import PdpStatusError
+
+    urn = "urn:oasis:names:tc:xacml:1.0:status:missing-attribute"
+    mock_client = _stub_client()
+    when(mock_client).permissions(...).thenRaise(
+        PdpStatusError(
+            "missing attrs",
+            xacml_status_code=urn,
+            xacml_status_message="missing attrs",
+            status_code=200,
+            request_method="POST",
+            request_url="https://pdp.example.com/dpc/authorization/pdppermissions",
+            response_body='{"Status":{}}',
+        ),
+    )
+
+    path = _write_eval_payload(tmp_path)
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "-v", *_explain_args(path)])
+
+    assert result.exit_code == 1
+    assert "PDP rejected the request" in result.output
+    assert urn in result.stderr

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import httpx
+import pytest
+
 from nextlabs_sdk._pdp._enums import Decision, ResourceDimension
 from nextlabs_sdk._pdp._json_serializer import (
     deserialize_eval_response,
@@ -19,6 +22,14 @@ from nextlabs_sdk._pdp._request_models import (
     Subject,
 )
 from nextlabs_sdk._pdp import _urns as urns
+from nextlabs_sdk.exceptions import PdpStatusError
+
+_OK_URN = "urn:oasis:names:tc:xacml:1.0:status:ok"
+
+
+def _fake_response() -> httpx.Response:
+    request = httpx.Request("POST", "https://pdp.example/dpc/authorization/pdp")
+    return httpx.Response(200, request=request, json={})
 
 
 def _find_category(body: Any, category_id: str) -> dict[str, object]:
@@ -262,7 +273,9 @@ def test_deserialize_permit_eval_response():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    response = deserialize_eval_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert len(response.eval_results) == 1
     assert response.first_result.decision == Decision.PERMIT
@@ -291,7 +304,9 @@ def test_deserialize_deny_with_obligations():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    response = deserialize_eval_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert response.first_result.decision == Decision.DENY
     assert len(response.first_result.obligations) == 1
@@ -305,7 +320,7 @@ def test_deserialize_with_policy_refs():
         "Response": [
             {
                 "Decision": "Permit",
-                "Status": {"StatusCode": {"Value": "ok"}},
+                "Status": {"StatusCode": {"Value": _OK_URN}},
                 "PolicyIdentifierList": {
                     "PolicyIdReference": [
                         {"Id": "allow-view", "Version": "1.0"},
@@ -316,7 +331,9 @@ def test_deserialize_with_policy_refs():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    response = deserialize_eval_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert len(response.first_result.policy_refs) == 2
     assert response.first_result.policy_refs[0].id == "allow-view"
@@ -324,7 +341,7 @@ def test_deserialize_with_policy_refs():
     assert response.first_result.policy_refs[1].id == "allow-edit"
 
 
-def test_deserialize_with_status_message():
+def test_deserialize_raises_on_per_result_non_ok_status_with_message():
     body = {
         "Response": [
             {
@@ -337,14 +354,15 @@ def test_deserialize_with_status_message():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_eval_response(_fake_response(), cast(dict[str, object], body))
 
-    assert response.first_result.decision == Decision.INDETERMINATE
-    assert response.first_result.status.message == "Policy evaluation error"
-    assert response.first_result.status.detail == ""
+    assert excinfo.value.xacml_status_code == "processing-error"
+    assert excinfo.value.xacml_status_message == "Policy evaluation error"
+    assert excinfo.value.message == "Policy evaluation error"
 
 
-def test_deserialize_with_status_detail_string():
+def test_deserialize_raises_on_missing_attribute_status_urn():
     body = {
         "Response": [
             {
@@ -360,12 +378,16 @@ def test_deserialize_with_status_detail_string():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_eval_response(_fake_response(), cast(dict[str, object], body))
 
-    assert response.first_result.status.detail == "Service, Version"
+    assert excinfo.value.xacml_status_code == (
+        "urn:oasis:names:tc:xacml:1.0:status:missing-attribute"
+    )
+    assert "missing" in excinfo.value.message
 
 
-def test_deserialize_with_status_detail_dict():
+def test_deserialize_raises_on_short_non_ok_status_code():
     body = {
         "Response": [
             {
@@ -378,11 +400,10 @@ def test_deserialize_with_status_detail_dict():
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_eval_response(_fake_response(), cast(dict[str, object], body))
 
-    detail = response.first_result.status.detail
-    assert "Service" in detail
-    assert "Version" in detail
+    assert excinfo.value.xacml_status_code == "missing-attribute"
 
 
 def test_deserialize_without_status_detail_defaults_empty():
@@ -390,19 +411,21 @@ def test_deserialize_without_status_detail_defaults_empty():
         "Response": [
             {
                 "Decision": "Permit",
-                "Status": {"StatusCode": {"Value": "ok"}},
+                "Status": {"StatusCode": {"Value": _OK_URN}},
             },
         ],
     }
 
-    response = deserialize_eval_response(cast(dict[str, object], body))
+    response = deserialize_eval_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert response.first_result.status.detail == ""
 
 
 def test_deserialize_permissions_response():
     body = {
-        "Status": {"StatusCode": {"Value": "ok"}},
+        "Status": {"StatusCode": {"Value": _OK_URN}},
         "Response": [
             {
                 "ActionsAndObligations": {
@@ -448,7 +471,9 @@ def test_deserialize_permissions_response():
         ],
     }
 
-    response = deserialize_permissions_response(cast(dict[str, object], body))
+    response = deserialize_permissions_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert [p.name for p in response.allowed] == ["OPEN", "SEND"]
     assert response.allowed[0].policy_refs[0].id == "ROOT/OPEN Policy"
@@ -464,9 +489,11 @@ def test_deserialize_permissions_response():
 
 
 def test_deserialize_permissions_response_tolerates_missing_actions_and_obligations():
-    body = {"Status": {"StatusCode": {"Value": "ok"}}, "Response": [{}]}
+    body = {"Status": {"StatusCode": {"Value": _OK_URN}}, "Response": [{}]}
 
-    response = deserialize_permissions_response(cast(dict[str, object], body))
+    response = deserialize_permissions_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert response.allowed == []
     assert response.denied == []
@@ -474,8 +501,110 @@ def test_deserialize_permissions_response_tolerates_missing_actions_and_obligati
 
 
 def test_deserialize_permissions_response_tolerates_missing_response_key():
-    body: dict[str, Any] = {"Status": {"StatusCode": {"Value": "ok"}}}
+    body: dict[str, Any] = {"Status": {"StatusCode": {"Value": _OK_URN}}}
 
-    response = deserialize_permissions_response(cast(dict[str, object], body))
+    response = deserialize_permissions_response(
+        _fake_response(), cast(dict[str, object], body)
+    )
 
     assert response.allowed == []
+
+
+_MISSING_ATTR_URN = "urn:oasis:names:tc:xacml:1.0:status:missing-attribute"
+
+
+def test_deserialize_permissions_response_raises_on_top_level_non_ok_status():
+    body = {
+        "Status": {
+            "StatusMessage": (
+                "Invalid Request :: One or more mandatory attributes are missing"
+            ),
+            "StatusCode": {"Value": _MISSING_ATTR_URN},
+        },
+        "Response": [
+            {
+                "Status": {
+                    "StatusMessage": (
+                        "Invalid Request :: One or more mandatory attributes are missing"
+                    ),
+                    "StatusCode": {"Value": _MISSING_ATTR_URN},
+                },
+                "ActionsAndObligations": {"allow": [], "deny": [], "dontcare": []},
+            },
+        ],
+    }
+
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_permissions_response(
+            _fake_response(),
+            cast(dict[str, object], body),
+        )
+
+    assert excinfo.value.xacml_status_code == _MISSING_ATTR_URN
+    assert "mandatory attributes are missing" in excinfo.value.xacml_status_message
+    assert "mandatory attributes are missing" in excinfo.value.message
+
+
+def test_deserialize_eval_response_raises_on_top_level_non_ok_status_without_decision():
+    body = {
+        "Status": {
+            "StatusMessage": "Invalid Request :: missing attrs",
+            "StatusCode": {"Value": _MISSING_ATTR_URN},
+        },
+        "Response": [
+            {
+                "Status": {
+                    "StatusMessage": "Invalid Request :: missing attrs",
+                    "StatusCode": {"Value": _MISSING_ATTR_URN},
+                },
+            },
+        ],
+    }
+
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_eval_response(_fake_response(), cast(dict[str, object], body))
+
+    assert excinfo.value.xacml_status_code == _MISSING_ATTR_URN
+
+
+def test_deserialize_permissions_response_raises_on_per_result_only_non_ok_status():
+    body = {
+        "Response": [
+            {
+                "Status": {
+                    "StatusMessage": "missing attrs",
+                    "StatusCode": {"Value": _MISSING_ATTR_URN},
+                },
+                "ActionsAndObligations": {"allow": [], "deny": [], "dontcare": []},
+            },
+        ],
+    }
+
+    with pytest.raises(PdpStatusError):
+        deserialize_permissions_response(
+            _fake_response(),
+            cast(dict[str, object], body),
+        )
+
+
+def test_deserialize_carries_request_context_on_status_error():
+    body = {
+        "Status": {
+            "StatusMessage": "bad",
+            "StatusCode": {"Value": _MISSING_ATTR_URN},
+        },
+    }
+    request = httpx.Request(
+        "POST", "https://pdp.example/dpc/authorization/pdppermissions"
+    )
+    response = httpx.Response(200, request=request, json={})
+
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_permissions_response(response, cast(dict[str, object], body))
+
+    assert excinfo.value.status_code == 200
+    assert excinfo.value.request_method == "POST"
+    assert excinfo.value.request_url == (
+        "https://pdp.example/dpc/authorization/pdppermissions"
+    )
+    assert excinfo.value.envelope_status_code == _MISSING_ATTR_URN

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -68,7 +68,9 @@ def _make_permissions_response() -> httpx.Response:
     return httpx.Response(
         200,
         json={
-            "Status": {"StatusCode": {"Value": "ok"}},
+            "Status": {
+                "StatusCode": {"Value": "urn:oasis:names:tc:xacml:1.0:status:ok"}
+            },
             "Response": [
                 {
                     "ActionsAndObligations": {

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from xml.etree import ElementTree as ET
 
+import httpx
 import pytest
 
 from nextlabs_sdk._pdp._enums import Decision
@@ -27,8 +28,15 @@ from nextlabs_sdk._pdp._xml_serializer import (
     serialize_eval_request,
     serialize_permissions_request,
 )
+from nextlabs_sdk.exceptions import PdpStatusError
 
 XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+_OK_URN = "urn:oasis:names:tc:xacml:1.0:status:ok"
+
+
+def _fake_response() -> httpx.Response:
+    request = httpx.Request("POST", "https://pdp.example/dpc/authorization/pdp")
+    return httpx.Response(200, request=request, content=b"")
 
 
 def _parse_xml(data: bytes) -> ET.Element:
@@ -152,7 +160,7 @@ def test_xml_deserialize_permit_response():
         f"</Response>"
     ).encode()
 
-    response = deserialize_eval_response(xml_data)
+    response = deserialize_eval_response(_fake_response(), xml_data)
 
     assert len(response.eval_results) == 1
     assert response.first_result.decision == Decision.PERMIT
@@ -175,7 +183,7 @@ def test_xml_deserialize_with_obligations():
         f"</Response>"
     ).encode()
 
-    response = deserialize_eval_response(xml_data)
+    response = deserialize_eval_response(_fake_response(), xml_data)
 
     assert response.first_result.decision == Decision.DENY
     assert len(response.first_result.obligations) == 1
@@ -183,7 +191,7 @@ def test_xml_deserialize_with_obligations():
     assert response.first_result.obligations[0].attributes[0].attr_value == "warn"
 
 
-def test_xml_deserialize_with_status_detail():
+def test_xml_deserialize_raises_on_non_ok_status_with_detail():
     xml_data = (
         f'<Response xmlns="{XACML_NS}">'
         f"<Result>"
@@ -197,10 +205,30 @@ def test_xml_deserialize_with_status_detail():
         f"</Response>"
     ).encode()
 
-    response = deserialize_eval_response(xml_data)
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_eval_response(_fake_response(), xml_data)
 
-    assert response.first_result.decision == Decision.INDETERMINATE
-    assert response.first_result.status.detail == "Service, Version"
+    assert excinfo.value.xacml_status_code == (
+        "urn:oasis:names:tc:xacml:1.0:status:missing-attribute"
+    )
+    assert "missing" in excinfo.value.xacml_status_message
+
+
+def test_xml_deserialize_raises_on_non_ok_permissions_result():
+    xml_data = (
+        f'<Response xmlns="{XACML_NS}">'
+        f"<Result>"
+        f"<Decision>Indeterminate</Decision>"
+        f'<Status><StatusCode Value="processing-error"/>'
+        f"<StatusMessage>broken</StatusMessage></Status>"
+        f"</Result>"
+        f"</Response>"
+    ).encode()
+
+    with pytest.raises(PdpStatusError) as excinfo:
+        deserialize_permissions_response(_fake_response(), xml_data)
+
+    assert excinfo.value.xacml_status_code == "processing-error"
 
 
 def test_xml_deserialize_without_status_detail_defaults_empty():
@@ -208,12 +236,12 @@ def test_xml_deserialize_without_status_detail_defaults_empty():
         f'<Response xmlns="{XACML_NS}">'
         f"<Result>"
         f"<Decision>Permit</Decision>"
-        f'<Status><StatusCode Value="ok"/></Status>'
+        f'<Status><StatusCode Value="{_OK_URN}"/></Status>'
         f"</Result>"
         f"</Response>"
     ).encode()
 
-    response = deserialize_eval_response(xml_data)
+    response = deserialize_eval_response(_fake_response(), xml_data)
 
     assert response.first_result.status.detail == ""
 
@@ -223,7 +251,7 @@ def test_xml_deserialize_permissions_response():
         return (
             f"<Result>"
             f"<Decision>{decision}</Decision>"
-            f'<Status><StatusCode Value="ok"/></Status>'
+            f'<Status><StatusCode Value="{_OK_URN}"/></Status>'
             f'<Attributes Category="{ACTION_CATEGORY}">'
             f'<Attribute AttributeId="{ACTION_ID}">'
             f"<AttributeValue>{action}</AttributeValue>"
@@ -238,7 +266,7 @@ def test_xml_deserialize_permissions_response():
         f"</Response>"
     ).encode()
 
-    response = deserialize_permissions_response(xml_data)
+    response = deserialize_permissions_response(_fake_response(), xml_data)
 
     assert len(response.allowed) == 1
     assert response.allowed[0].name == "VIEW"


### PR DESCRIPTION
Implements the approved design in `docs/superpowers/specs/2026-04-22-pdp-surface-xacml-status-errors-design.md`.

## What

- New `PdpStatusError` in `nextlabs_sdk.exceptions` (subclass of `ApiError`), carrying the XACML status code/message alongside the usual HTTP context.
- New `_pdp/_status_check.py` helper (`XACML_STATUS_OK`, `raise_if_not_ok`) used by both serializers.
- JSON and XML deserializers now take `(response, body)` and raise `PdpStatusError` on:
  - top-level `Status` (JSON permissions envelope), and
  - per-`Response` / per-`<Result>` `Status`,
  before touching the body — so the cryptic `KeyError('Decision')` on malformed eval responses is gone too.
- `_response_decode` re-raises `PdpStatusError` without wrapping and passes the response through.
- `PdpClient` / `AsyncPdpClient` updated for the new XML signatures (sync/async parity).
- CLI: registers `PdpStatusError` → `"PDP rejected the request"` prefix; the existing `envelope: statusCode=…` verbose line now actually fires (see below).

## Drive-by fix

While wiring up the CLI verbose path I noticed `_cli_error_handler` scanned only `args` for the Typer context, but Typer passes it as a keyword (`ctx=`) at runtime. That meant `_maybe_print_verbose` never had a `CliContext` under real invocations — the verbose branch only worked in unit tests that called the wrapped function positionally. `_extract_typer_context` now checks both `args` and `kwargs` and matches `click.Context` (Typer passes the plain click subclass). Covered by a new CLI test running the real Typer app with `-v`.

## Tests

- `tests/test_json_serializer.py`: new cases for top-level / per-result non-ok status, the full bug-report body, missing `Decision`, and HTTP-context propagation; existing fixtures using the short-form `"ok"` updated to the full URN.
- `tests/test_xml_serializer.py`: non-ok `<Status>` on eval + permissions; happy path updated.
- `tests/test_pdp_client.py` / `test_async_pdp_client.py`: fixture status codes updated to the canonical URN.
- `tests/test_cli_pdp.py`: `pdp explain` exits 1 with `PDP rejected the request`, and `-v` shows the XACML URN on stderr.

All checks green locally:
```
python ./tools/checks.py      # black + flake8 + mypy + pyright
python ./tools/tests.py --short  # 1969 passed, 97 xfailed, 96% coverage
```

## CLI before / after

Before:
```
$ nextlabs pdp explain --payload bad.json
                   Allowed                     Denied                 Don't Care
──────────────────────────────────────────────────────────────────────────────────
No action permissions returned.
$ echo $?
0
```

After:
```
$ nextlabs pdp explain --payload bad.json
✗ PDP rejected the request: Invalid Request :: One or more mandatory attributes are missing
$ echo $?
1
```