### PR TITLE
feat(tools): accept targeted paths in checks.py and tests.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,26 @@ python ./tools/tests.py --short --e2e    # E2E only (needs Docker)
 python ./tools/tests.py --short --all    # Unit + E2E (needs Docker)
 ```
 
+Narrowed invocations (prefer over raw pytest/flake8/mypy/pyright —
+wrappers filter output and save tokens):
+
+```bash
+# one tool, project-wide
+python ./tools/checks.py --short flake8
+
+# one tool, one file (mypy auto-adds --follow-imports=silent)
+python ./tools/checks.py --short mypy src/nextlabs_sdk/_pdp/_client.py
+
+# all tools, narrowed to path(s)
+python ./tools/checks.py --short src/nextlabs_sdk/exceptions.py
+
+# single test by nodeid (coverage auto-disabled when targets given)
+python ./tools/tests.py --short tests/test_foo.py::TestX::test_y
+
+# explicit e2e file — marker auto-dropped, no need for --e2e
+python ./tools/tests.py --short tests/e2e/test_foo.py
+```
+
 Pre-commit hooks (black, flake8, mypy, pyright) on `git commit`. Timeout
 **120 s+** — pyright slow.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,8 +55,8 @@ notice — do not import from tests outside their own module, examples, or docs.
 
 | Script | Purpose |
 |---|---|
-| `checks.py` | Black + Flake8 + MyPy + Pyright. Use `--short` for terse output. |
-| `tests.py` | Pytest wrapper. `--short` filters output; `--e2e` / `--all` pick markers. |
+| `checks.py` | Black + Flake8 + MyPy + Pyright. `--short` for terse output. Accepts a tool name (`black` / `flake8` / `mypy` / `pyright`) and/or file paths to narrow the run; narrowed `mypy` auto-adds `--follow-imports=silent`. |
+| `tests.py` | Pytest wrapper. `--short` filters output; `--e2e` / `--all` pick markers. Accepts path/nodeid targets (e.g. `tests/foo.py::test_bar`); explicit targets drop the default `-m "not e2e"` marker and auto-disable coverage so single-file runs don't trip the 90% gate. |
 | `fetch_openapi_spec.py` | Refresh committed OpenAPI fixture (local only). |
 | `build.py` | Build tasks. |
 | `init_project.sh`, `setup_bare_metal.sh` | Setup helpers. |

--- a/tests/test_tools_tests_runner.py
+++ b/tests/test_tools_tests_runner.py
@@ -89,3 +89,79 @@ def test_all_and_e2e_are_mutually_exclusive():
         tests_runner._build_marker_args(["--all", "--e2e"])
 
     assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "arg,expected",
+    [
+        ("tests/unit/test_foo.py", True),
+        ("tests/e2e/test_foo.py::TestX::test_y", True),
+        ("src/foo.py", True),
+        ("some/path", True),
+        ("-k", False),
+        ("pagination", False),
+        ("--short", False),
+        ("", False),
+    ],
+)
+def test_looks_like_target(arg, expected):
+    assert tests_runner._looks_like_target(arg) is expected
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        ([], False),
+        (["-k", "pagination"], False),
+        (["tests/unit/test_foo.py"], True),
+        (["-k", "pagination", "tests/unit/"], True),
+        (["--no-cov"], False),
+        (["path/with/sep"], True),
+    ],
+)
+def test_has_explicit_targets(argv, expected):
+    assert tests_runner._has_explicit_targets(argv) is expected
+
+
+@pytest.mark.parametrize(
+    "argv,has_targets,expected_extra,expected_env",
+    [
+        pytest.param([], True, ["--no-cov"], "1", id="targets-drop-default-marker"),
+        pytest.param(
+            ["--no-cov"],
+            True,
+            ["--no-cov"],
+            "1",
+            id="targets-preserve-no-cov",
+        ),
+        pytest.param(
+            ["--e2e"],
+            True,
+            ["-m", "e2e", "--no-cov"],
+            "1",
+            id="targets-plus-e2e-still-applies-e2e-marker",
+        ),
+    ],
+)
+def test_build_marker_args_with_targets(
+    argv, has_targets, expected_extra, expected_env
+):
+    extra = tests_runner._build_marker_args(argv, has_targets=has_targets)
+
+    assert extra == expected_extra
+    assert os.environ.get("E2E_COLLECT") == expected_env
+
+
+def test_compose_cmd_drops_root_when_targets_present():
+    argv = ["tests/unit/test_foo.py"]
+    cmd = tests_runner._compose_cmd(argv, has_targets=True)
+
+    assert "." not in cmd
+    assert "tests/unit/test_foo.py" in cmd
+
+
+def test_compose_cmd_adds_root_when_no_targets():
+    argv: list[str] = []
+    cmd = tests_runner._compose_cmd(argv, has_targets=False)
+
+    assert "." in cmd

--- a/tools/checks.py
+++ b/tools/checks.py
@@ -1,8 +1,44 @@
 """Run quality checks (Black, Flake8, MyPy, Pyright).
 
 Default: live/verbose output (every tool streams to stdout).
-`--short`: one-line summary per tool on success; full output only for
+``--short``: one-line summary per tool on success; full output only for
 failures. Mirrors the convention used by ``tools/tests.py --short``.
+
+Targeted invocation
+-------------------
+Positional args select a specific tool and/or narrow the check to specific
+paths. ``--short`` / other flags may appear anywhere (parsed before
+positional parsing).
+
+Examples::
+
+    # all tools, project-wide (default)
+    python tools/checks.py
+    python tools/checks.py --short
+
+    # only one tool, project-wide
+    python tools/checks.py flake8
+    python tools/checks.py --short mypy
+
+    # only one tool, narrowed to paths
+    python tools/checks.py flake8 src/foo.py
+    python tools/checks.py --short mypy src/foo.py src/bar.py
+
+    # all tools, narrowed to paths
+    python tools/checks.py src/foo.py
+    python tools/checks.py --short src/foo.py tests/unit/test_foo.py
+
+Disambiguation: the first positional arg is treated as a tool selector iff
+it exactly matches one of ``black`` / ``flake8`` / ``mypy`` / ``pyright``.
+Otherwise every positional is a path. To pass a file literally named
+``black`` etc., prefix with ``./``.
+
+Notes
+-----
+* ``mypy`` run against explicit paths auto-injects
+  ``--follow-imports=silent`` so sibling-import cascades don't spam. Be
+  aware that narrowed mypy/pyright runs can miss errors from callers;
+  treat them as fast editor-loop feedback, not a merge gate.
 """
 
 import os
@@ -10,8 +46,7 @@ import subprocess  # noqa: S404
 import sys
 from typing import Callable
 
-# A "short" runner captures output and returns (return_code, combined_output).
-ToolRunner = Callable[[str, bool], int]
+ToolRunner = Callable[[list[str], bool], int]
 
 
 def _run_captured(cmd: list[str], env: dict[str, str] | None = None) -> tuple[int, str]:
@@ -24,6 +59,11 @@ def _run_captured(cmd: list[str], env: dict[str, str] | None = None) -> tuple[in
         env=env,
     )
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _run_streamed(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    proc = subprocess.run(cmd, check=False, env=env)  # noqa: S603
+    return proc.returncode
 
 
 def _emit_result(name: str, rc: int, output: str, short: bool) -> int:
@@ -40,83 +80,55 @@ def _emit_result(name: str, rc: int, output: str, short: bool) -> int:
     return rc
 
 
-def call_black(directory: str, short: bool = False) -> int:
+def _invoke(
+    name: str,
+    cmd: list[str],
+    short: bool,
+    env: dict[str, str] | None = None,
+) -> int:
+    try:
+        if short:
+            rc, out = _run_captured(cmd, env=env)
+        else:
+            rc, out = _run_streamed(cmd, env=env), ""
+    except FileNotFoundError:
+        print(f"[fail] {name} not installed")
+        return 127
+    return _emit_result(name, rc, out, short)
+
+
+def call_black(paths: list[str], short: bool = False) -> int:
     if not short:
         print("** BLACK **")
-    cmd = ["black", directory]
+    cmd = ["black", *paths]
     if short:
         cmd.insert(1, "--quiet")
-    try:
-        rc, out = (
-            _run_captured(cmd)
-            if short
-            else (
-                subprocess.run(cmd, check=False).returncode,  # noqa: S603
-                "",
-            )
-        )
-    except FileNotFoundError:
-        print("[fail] black not installed")
-        return 127
-    return _emit_result("black", rc, out, short)
+    return _invoke("black", cmd, short)
 
 
-def call_flake8(directory: str, short: bool = False) -> int:
+def call_flake8(paths: list[str], short: bool = False) -> int:
     if not short:
         print("** FLAKE8 **")
-    cmd = ["flake8", directory]
-    try:
-        rc, out = (
-            _run_captured(cmd)
-            if short
-            else (
-                subprocess.run(cmd, check=False).returncode,  # noqa: S603
-                "",
-            )
-        )
-    except FileNotFoundError:
-        print("[fail] flake8 not installed")
-        return 127
-    return _emit_result("flake8", rc, out, short)
+    cmd = ["flake8", *paths]
+    return _invoke("flake8", cmd, short)
 
 
-def call_pyright(directory: str, short: bool = False) -> int:
+def call_pyright(paths: list[str], short: bool = False) -> int:
     if not short:
         print("** PYRIGHT (Pylance) **")
-    cmd = ["pyright", "--warnings", directory]
-    try:
-        rc, out = (
-            _run_captured(cmd)
-            if short
-            else (
-                subprocess.run(cmd, check=False).returncode,  # noqa: S603
-                "",
-            )
-        )
-    except FileNotFoundError:
-        print("[fail] pyright not installed")
-        return 127
-    return _emit_result("pyright", rc, out, short)
+    cmd = ["pyright", "--warnings", *paths]
+    return _invoke("pyright", cmd, short)
 
 
-def call_mypy(directory: str, short: bool = False) -> int:
+def call_mypy(paths: list[str], short: bool = False) -> int:
     if not short:
         print("** MYPY **")
-    cmd = ["mypy", directory, "--cache-dir=/dev/null"]
+    narrowed = paths != ["."]
+    cmd = ["mypy", *paths, "--cache-dir=/dev/null"]
+    if narrowed:
+        cmd.append("--follow-imports=silent")
     env = {**os.environ, "MYPYPATH": "src"}
-    try:
-        rc, out = (
-            _run_captured(cmd, env=env)
-            if short
-            else (
-                subprocess.run(cmd, check=False, env=env).returncode,  # noqa: S603
-                "",
-            )
-        )
-    except FileNotFoundError:
-        print("[fail] mypy not installed")
-        return 127
-    return _emit_result("mypy", rc, out, short)
+    return _invoke("mypy", cmd, short, env=env)
 
 
 CHECKS: dict[str, ToolRunner] = {
@@ -127,22 +139,37 @@ CHECKS: dict[str, ToolRunner] = {
 }
 
 
-def main(argv: list[str]) -> int:
-    short = "--short" in argv
-    if short:
-        argv.remove("--short")
+def _parse_args(argv: list[str]) -> tuple[bool, ToolRunner | None, list[str]]:
+    """Parse argv into (short, selected_runner_or_None, paths).
 
-    if argv:
-        name = argv[0]
-        runner = CHECKS.get(name)
-        if runner is None:
-            print("Invalid argument. Specify 'black', 'flake8', 'mypy', or 'pyright'.")
-            return 2
-        return runner(".", short)
+    ``--short`` is stripped anywhere in argv. If the first remaining
+    positional is a CHECKS key, it becomes the selected runner; remaining
+    positionals are paths. Otherwise all positionals are paths.
+    """
+    args = list(argv)
+    short = False
+    if "--short" in args:
+        args.remove("--short")
+        short = True
+
+    runner: ToolRunner | None = None
+    if args and args[0] in CHECKS:
+        runner = CHECKS[args[0]]
+        args = args[1:]
+
+    paths = args if args else ["."]
+    return short, runner, paths
+
+
+def main(argv: list[str]) -> int:
+    short, runner, paths = _parse_args(argv)
+
+    if runner is not None:
+        return runner(paths, short)
 
     failures = 0
-    for runner in CHECKS.values():
-        if runner(".", short) != 0:
+    for r in CHECKS.values():
+        if r(paths, short) != 0:
             failures += 1
     if short:
         print(f"[summary] {len(CHECKS) - failures}/{len(CHECKS)} checks passed")

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -1,3 +1,49 @@
+"""Run pytest with marker presets and optional short mode.
+
+Flags (parsed and stripped from argv before pytest sees it):
+
+``--short``
+    Filter pytest output down to failures/summary lines only.
+``--e2e``
+    Run only ``e2e``-marked tests (coverage forced off).
+``--all``
+    Run unit + e2e tests in one pass (coverage stays on unless
+    ``--no-cov`` is also passed). Mutually exclusive with ``--e2e``.
+``--no-cov``
+    Disable coverage collection.
+
+Everything else in argv is forwarded to pytest unchanged.
+
+Targeted invocation
+-------------------
+Positional args that look like test targets (``*.py``, contain ``/`` or
+``::``) are forwarded to pytest as-is, and three things change:
+
+1. The default ``-m "not e2e"`` marker is dropped so an explicit
+   ``tests/e2e/test_foo.py`` actually runs without also passing ``--e2e``.
+2. The hardcoded project root (``.``) is omitted so pytest only collects
+   the requested targets.
+3. Coverage is auto-disabled (the project-wide 90% gate can't be met
+   from a single file). Pass ``--e2e`` / ``--all`` if you want different
+   marker behavior on top of this.
+
+``-k EXPR`` is unaffected because ``EXPR`` isn't path-shaped.
+
+Examples::
+
+    # full suite (unit only) with terse output
+    python tools/tests.py --short
+
+    # single test by nodeid
+    python tools/tests.py --short tests/unit/auth/test_x.py::TestY::test_z
+
+    # e2e file without --e2e (marker auto-dropped)
+    python tools/tests.py --short tests/e2e/test_foo.py
+
+    # filter by name; no target path → marker still applies
+    python tools/tests.py --short -k "pagination"
+"""
+
 import os
 import subprocess  # noqa: S404
 import sys
@@ -6,35 +52,38 @@ from strip_ansi import strip_ansi
 
 
 def _extract_no_cov(argv: list[str]) -> bool:
-    """Extract standalone --no-cov flag from argv.
-
-    Args:
-        argv: Command-line arguments (mutated to remove --no-cov).
-
-    Returns:
-        True if --no-cov was present.
-    """
     if "--no-cov" in argv:
         argv.remove("--no-cov")
         return True
     return False
 
 
-def _build_marker_args(argv: list[str]) -> list[str]:
-    """Build pytest marker arguments based on test-selection flags.
+def _looks_like_target(arg: str) -> bool:
+    """Return True if ``arg`` looks like a pytest path or nodeid.
 
-    Flags:
-        - ``--e2e``: run only e2e-marked tests (coverage forced off).
-        - ``--all``: run unit and e2e tests in a single run. Coverage
-          stays on unless ``--no-cov`` is also passed. Mutually
-          exclusive with ``--e2e``.
-        - neither: run unit tests only (exclude e2e).
+    Detection is lexical:
+    * contains ``::`` (nodeid)
+    * ends with ``.py``
+    * contains a path separator (``/`` or ``\\``)
 
-    Args:
-        argv: Command-line arguments (mutated to remove consumed flags).
+    Flag values like ``-k EXPR`` are not matched because ``EXPR``
+    typically has none of the above.
+    """
+    if arg.startswith("-"):
+        return False
+    return "::" in arg or arg.endswith(".py") or "/" in arg or "\\" in arg
 
-    Returns:
-        Extra pytest arguments for marker selection.
+
+def _has_explicit_targets(argv: list[str]) -> bool:
+    return any(_looks_like_target(a) for a in argv)
+
+
+def _build_marker_args(argv: list[str], has_targets: bool = False) -> list[str]:
+    """Build pytest marker/coverage flags based on selection flags.
+
+    When ``has_targets`` is True, no default marker is applied; the caller
+    explicitly named targets and the wrapper honors that choice.
+    ``--e2e`` / ``--all`` still override marker behavior when present.
     """
     no_cov = _extract_no_cov(argv)
     want_all = "--all" in argv
@@ -53,6 +102,9 @@ def _build_marker_args(argv: list[str]) -> list[str]:
         argv.remove("--e2e")
         os.environ["E2E_COLLECT"] = "1"
         return ["-m", "e2e", "--no-cov"]
+    if has_targets:
+        os.environ["E2E_COLLECT"] = "1"
+        return ["--no-cov"]
     extra = ["-m", "not e2e"]
     if no_cov:
         extra.append("--no-cov")
@@ -69,22 +121,21 @@ def _is_relevant_pytest_line(line: str) -> bool:
     return is_failure or is_test_result or is_coverage or is_error_detail
 
 
+def _compose_cmd(argv: list[str], has_targets: bool) -> list[str]:
+    marker_args = _build_marker_args(argv, has_targets)
+    base = ["python", "-m", "pytest"]
+    if not has_targets:
+        base.append(".")
+    return base + ["-rA"] + marker_args + argv
+
+
 def call_pytest_short(argv: list[str]) -> dict[str, str]:
-    """Run pytest in short mode with filtered output.
+    has_targets = _has_explicit_targets(argv)
+    cmd = _compose_cmd(argv, has_targets)
 
-    Args:
-        argv: Extra arguments to pass to pytest.
-
-    Returns:
-        Dict with 'status' ('passed'/'failed') and 'summary' text.
-    """
-    marker_args = _build_marker_args(argv)
-
-    cmd = ["python", "-m", "pytest", ".", "-rA"] + marker_args + (argv or [])
-
-    pytest_run = subprocess.run(
+    pytest_run = subprocess.run(  # noqa: S603
         cmd, check=False, capture_output=True, text=True
-    )  # noqa: S603
+    )
 
     lines = (pytest_run.stdout + pytest_run.stderr).splitlines()
     lines = [strip_ansi(line) for line in lines]
@@ -97,23 +148,16 @@ def call_pytest_short(argv: list[str]) -> dict[str, str]:
 
 
 def call_pytest(argv: list[str]) -> None:
-    """Run pytest with live output.
-
-    Args:
-        argv: Extra arguments to pass to pytest.
-    """
-    marker_args = _build_marker_args(argv)
+    has_targets = _has_explicit_targets(argv)
+    cmd = _compose_cmd(argv, has_targets)
+    cmd = [c for c in cmd if c != "-rA"]  # live mode uses pytest defaults
 
     print("** PYTEST **")
-    cmd_path = "python"
-    cmd = [cmd_path, "-m", "pytest", "."] + marker_args
-    if argv:
-        cmd.extend(argv)
     try:
         subprocess.run(cmd, check=True)  # noqa: S607, S603
     except FileNotFoundError:
         print("Module pytest not found. Please make sure it is installed.")
-        exit(1)
+        sys.exit(1)
 
     print("Calling PyTest completed successfully.")
 


### PR DESCRIPTION
Stacks on top of #80 (token-efficiency agent optimizations).

## Why

Phase 1 made `tools/checks.py --short` and `tools/tests.py --short` terse by filtering tool output. But agents still had to bypass the wrappers to check a single file or run a single test (wrappers only accepted whole-project). Raw `pytest`/`flake8`/`mypy`/`pyright` output is verbose → wasted input tokens.

This PR teaches both wrappers to accept positional path / nodeid targets so narrowed runs stay inside the terse wrappers.

## Behavior

### `tools/checks.py`

```
python tools/checks.py                         # all tools, project-wide
python tools/checks.py --short flake8          # only flake8
python tools/checks.py --short mypy src/foo.py # one tool, one file
python tools/checks.py --short src/foo.py      # all tools, narrowed
```

- First positional arg is a tool selector iff it matches `{black, flake8, mypy, pyright}`; otherwise every positional is a path.
- Narrowed `mypy` auto-injects `--follow-imports=silent` so sibling-import cascades don't spam.
- `--short` / flags parse from anywhere in argv.

### `tools/tests.py`

```
python tools/tests.py --short tests/foo.py::test_bar   # single test
python tools/tests.py --short tests/e2e/test_foo.py    # e2e, no --e2e needed
```

- Lexical target detection (ends with `.py`, contains `::` or path separator) — `-k EXPR` is not misdetected.
- When explicit targets are given: hardcoded `.` is dropped (no double-collection), default `-m "not e2e"` marker is dropped (e2e files just run), coverage is auto-disabled (project 90% gate can't be met per-file).
- Fixes pre-existing double-collection bug when user passed a test path.

## Files

- `tools/checks.py` — positional args, tool/path disambiguation, mypy flag injection.
- `tools/tests.py` — target detection, marker drop, compose helper, `.` drop.
- `tests/test_tools_tests_runner.py` — 3 new parametrized test groups covering `_looks_like_target`, `_has_explicit_targets`, `_build_marker_args` with targets, and `_compose_cmd`.
- `CLAUDE.md` — narrowed invocation examples in Commands section.
- `docs/architecture.md` — Scripts table reflects new behavior.

## Verified

- `python tools/checks.py --short` → 4/4 green.
- `python tools/tests.py --short` → 1988 passed, 97 xfailed, 96% coverage (new runner tests bring the total up from 1969).
- Narrowed invocations of each tool + single-test nodeid + `--short` position variations all exercise.

## Non-goals

- No changes to `setup.cfg`, pytest markers, or underlying tool configs.
- No new CLI affordances beyond raw pass-through (`-k`/`--lf`/`--ff` stay as raw pytest flags).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>