### PR TITLE
feat(cli): accept ISO and relative dates for time-range options

### DIFF
--- a/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
@@ -15,6 +15,7 @@ from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import ColumnDef, print_error, render
 from nextlabs_sdk._cli._payload_loader import load_payload
+from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
 from nextlabs_sdk._cloudaz._audit_log_models import (
     AuditLogEntry,
     AuditLogQuery,
@@ -39,12 +40,22 @@ _USER_COLUMNS = (
 )
 
 
+_DATE_HELP = (
+    "Accepts epoch milliseconds (e.g. 1737014400000), ISO 8601 datetime "
+    "(e.g. 2024-01-15 or 2024-01-15T10:30:00+02:00, naive values treated "
+    "as UTC), or a relative offset from now (e.g. 30s, 5m, 2h, 3d, 1w)."
+)
+
+
 @audit_logs_app.command()
 @cli_error_handler
 def search(
     ctx: typer.Context,
-    start_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    end_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    start_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    end_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
     entity_type: Annotated[
         str | None, typer.Option(help="Filter by entity type")
     ] = None,
@@ -56,9 +67,11 @@ def search(
     """Search entity audit logs."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
+    start_ms = parse_time(start_date)
+    end_ms = now_epoch_ms() if end_date is None else parse_time(end_date)
     query = AuditLogQuery(
-        start_date=start_date,
-        end_date=end_date,
+        start_date=start_ms,
+        end_date=end_ms,
         entity_type=entity_type,
         action=action,
         page_size=page_size,

--- a/src/nextlabs_sdk/_cli/_dashboard_cmd.py
+++ b/src/nextlabs_sdk/_cli/_dashboard_cmd.py
@@ -11,9 +11,23 @@ from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import ColumnDef, render
+from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
 from nextlabs_sdk._cloudaz._dashboard_models import PolicyActivity
 
 dashboard_app = typer.Typer(help="Reporter dashboard commands")
+
+_DATE_HELP = (
+    "Accepts epoch milliseconds (e.g. 1737014400000), ISO 8601 datetime "
+    "(e.g. 2024-01-15 or 2024-01-15T10:30:00+02:00, naive values treated "
+    "as UTC), or a relative offset from now (e.g. 30s, 5m, 2h, 3d, 1w)."
+)
+
+
+def _resolve_range(from_date: str, to_date: str | None) -> tuple[int, int]:
+    start_ms = parse_time(from_date)
+    end_ms = now_epoch_ms() if to_date is None else parse_time(to_date)
+    return start_ms, end_ms
+
 
 _ALERT_COLUMNS = (
     ColumnDef("Level", "level"),
@@ -48,13 +62,17 @@ _MONITOR_TAG_ALERT_COLUMNS = (
 @cli_error_handler
 def alerts(
     ctx: typer.Context,
-    from_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    to_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    from_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    to_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
 ) -> None:
     """Retrieve latest alerts."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
-    alerts_list = client.dashboard.latest_alerts(from_date, to_date)
+    start_ms, end_ms = _resolve_range(from_date, to_date)
+    alerts_list = client.dashboard.latest_alerts(start_ms, end_ms)
     render(cli_ctx, alerts_list, _ALERT_COLUMNS, title="Alerts")
 
 
@@ -62,14 +80,18 @@ def alerts(
 @cli_error_handler
 def top_users(
     ctx: typer.Context,
-    from_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    to_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    from_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    to_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
     decision: Annotated[str, typer.Option(help="Policy decision filter")] = "AD",
 ) -> None:
     """Retrieve top users by activity."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
-    users = client.dashboard.top_users(from_date, to_date, decision)
+    start_ms, end_ms = _resolve_range(from_date, to_date)
+    users = client.dashboard.top_users(start_ms, end_ms, decision)
     render(cli_ctx, users, _ACTIVITY_COLUMNS, title="Top Users")
 
 
@@ -77,14 +99,18 @@ def top_users(
 @cli_error_handler
 def top_resources(
     ctx: typer.Context,
-    from_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    to_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    from_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    to_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
     decision: Annotated[str, typer.Option(help="Policy decision filter")] = "AD",
 ) -> None:
     """Retrieve top resources by activity."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
-    resources = client.dashboard.top_resources(from_date, to_date, decision)
+    start_ms, end_ms = _resolve_range(from_date, to_date)
+    resources = client.dashboard.top_resources(start_ms, end_ms, decision)
     render(cli_ctx, resources, _ACTIVITY_COLUMNS, title="Top Resources")
 
 
@@ -92,14 +118,18 @@ def top_resources(
 @cli_error_handler
 def top_policies(
     ctx: typer.Context,
-    from_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    to_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    from_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    to_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
     decision: Annotated[str, typer.Option(help="Policy decision filter")] = "AD",
 ) -> None:
     """Retrieve top policies with daily trend data."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
-    policies = client.dashboard.top_policies(from_date, to_date, decision)
+    start_ms, end_ms = _resolve_range(from_date, to_date)
+    policies = client.dashboard.top_policies(start_ms, end_ms, decision)
     render(cli_ctx, policies, _TOP_POLICIES_COLUMNS, title="Top Policies")
 
 
@@ -107,8 +137,11 @@ def top_policies(
 @cli_error_handler
 def alerts_by_monitor_tags(
     ctx: typer.Context,
-    from_date: Annotated[int, typer.Option(help="Start date (epoch ms)")],
-    to_date: Annotated[int, typer.Option(help="End date (epoch ms)")],
+    from_date: Annotated[str, typer.Option(help=f"Start date. {_DATE_HELP}")],
+    to_date: Annotated[
+        str | None,
+        typer.Option(help=f"End date (defaults to now). {_DATE_HELP}"),
+    ] = None,
     tag: Annotated[
         list[str] | None,
         typer.Option(
@@ -120,7 +153,8 @@ def alerts_by_monitor_tags(
     """Retrieve alert counts grouped by monitor tag."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
-    alerts_list = client.dashboard.alerts_by_monitor_tags(from_date, to_date)
+    start_ms, end_ms = _resolve_range(from_date, to_date)
+    alerts_list = client.dashboard.alerts_by_monitor_tags(start_ms, end_ms)
     if tag:
         wanted = set(tag)
         alerts_list = [entry for entry in alerts_list if entry.tag_value in wanted]

--- a/src/nextlabs_sdk/_cli/_time_parser.py
+++ b/src/nextlabs_sdk/_cli/_time_parser.py
@@ -1,0 +1,81 @@
+"""Flexible time-range input parser for CLI commands.
+
+Accepts three input shapes and returns an epoch-millisecond integer:
+
+- Epoch milliseconds, e.g. ``1737014400000``.
+- Relative offsets, e.g. ``5m`` meaning "5 minutes before now". Supported
+  units are ``s``, ``m``, ``h``, ``d``, ``w``.
+- ISO 8601 datetimes parsed by :func:`datetime.fromisoformat`. Naive
+  values are interpreted as UTC.
+
+Exposes :func:`parse_time` as the sole public entry point. The function
+raises :class:`ValueError` with a user-facing message listing accepted
+formats for any input that does not match one of the three shapes.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime, timezone
+from types import MappingProxyType
+
+_ACCEPTED_FORMATS_MSG = (
+    "accepted formats: epoch milliseconds (e.g. 1737014400000), "
+    "ISO 8601 datetime (e.g. 2024-01-15T10:30:00 or 2024-01-15T10:30:00+02:00), "
+    "or relative offset (e.g. 30s, 5m, 2h, 3d, 1w)"
+)
+
+_EPOCH_MS_RE = re.compile(r"\A\d+\Z")
+_RELATIVE_RE = re.compile(r"\A(\d+)([smhdw])\Z")
+
+_UNIT_TO_MS: MappingProxyType[str, int] = MappingProxyType(
+    {
+        "s": 1_000,
+        "m": 60 * 1_000,
+        "h": 60 * 60 * 1_000,
+        "d": 24 * 60 * 60 * 1_000,
+        "w": 7 * 24 * 60 * 60 * 1_000,
+    },
+)
+
+
+def now_epoch_ms() -> int:
+    """Return the current wall-clock time as epoch milliseconds."""
+    return int(time.time() * 1000)
+
+
+def parse_time(text: str, now_ms: int | None = None) -> int:
+    """Parse a CLI date string to epoch milliseconds.
+
+    Args:
+        text: Date string in one of the accepted formats.
+        now_ms: Reference "now" in epoch ms used to resolve relative
+            offsets. Defaults to the wall clock when ``None``.
+
+    Returns:
+        The resolved instant as epoch milliseconds.
+
+    Raises:
+        ValueError: If ``text`` does not match any accepted format.
+    """
+    if _EPOCH_MS_RE.match(text):
+        return int(text)
+
+    relative = _RELATIVE_RE.match(text)
+    if relative is not None:
+        amount = int(relative.group(1))
+        unit_ms = _UNIT_TO_MS[relative.group(2)]
+        reference = now_epoch_ms() if now_ms is None else now_ms
+        return reference - amount * unit_ms
+
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid date value {text!r}; {_ACCEPTED_FORMATS_MSG}",
+        ) from exc
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)

--- a/tests/test_cli_audit_logs.py
+++ b/tests/test_cli_audit_logs.py
@@ -237,3 +237,80 @@ def test_audit_logs_list_users(stubbed_audit: Any) -> None:
 
     assert result.exit_code == 0, result.output
     assert "ada" in result.output
+
+
+_FROZEN_NOW_MS = 1_800_000_000_000
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr(
+        "nextlabs_sdk._cli._time_parser.time.time",
+        lambda: _FROZEN_NOW_MS / 1000,
+    )
+    return _FROZEN_NOW_MS
+
+
+def test_search_accepts_relative_start_date(
+    stubbed_audit: Any, frozen_clock: int
+) -> None:
+    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+
+    expected = AuditLogQuery(
+        start_date=frozen_clock - 5 * 60 * 1000,
+        end_date=frozen_clock,
+        entity_type=None,
+        action=None,
+        page_size=None,
+        sort_by=None,
+        sort_order=None,
+    )
+    when(stubbed_audit).search(expected).thenReturn(_make_paginator([_make_entry()]))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "audit-logs", "search", "--start-date", "5m"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_search_accepts_iso_dates(stubbed_audit: Any) -> None:
+    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+
+    # 2024-01-15T00:00:00Z = 1705276800000; 2024-01-16T00:00:00Z = 1705363200000
+    expected = AuditLogQuery(
+        start_date=1705276800000,
+        end_date=1705363200000,
+        entity_type=None,
+        action=None,
+        page_size=None,
+        sort_by=None,
+        sort_order=None,
+    )
+    when(stubbed_audit).search(expected).thenReturn(_make_paginator([_make_entry()]))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "audit-logs",
+            "search",
+            "--start-date",
+            "2024-01-15",
+            "--end-date",
+            "2024-01-16",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_search_rejects_unrecognized_date(stubbed_audit: Any) -> None:
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "audit-logs", "search", "--start-date", "yesterday"],
+    )
+
+    assert result.exit_code == 1
+    assert "accepted formats" in strip_ansi(result.output)

--- a/tests/test_cli_dashboard.py
+++ b/tests/test_cli_dashboard.py
@@ -270,3 +270,68 @@ def test_dashboard_alerts_by_monitor_tags_filter() -> None:
     assert result.exit_code == 0, result.output
     assert "red" in result.output
     assert "blue" not in result.output
+
+
+_FROZEN_NOW_MS = 1_800_000_000_000
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr(
+        "nextlabs_sdk._cli._time_parser.time.time",
+        lambda: _FROZEN_NOW_MS / 1000,
+    )
+    return _FROZEN_NOW_MS
+
+
+def test_alerts_accepts_relative_from_date_and_defaults_to_now(
+    frozen_clock: int,
+) -> None:
+    _, mock_dashboard = _stub_client()
+    expected_start = frozen_clock - 60 * 60 * 1000
+    when(mock_dashboard).latest_alerts(expected_start, frozen_clock).thenReturn(
+        [_make_alert()],
+    )
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "dashboard", "alerts", "--from-date", "1h"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_top_users_accepts_iso_dates() -> None:
+    _, mock_dashboard = _stub_client()
+    when(mock_dashboard).top_users(
+        1705276800000,
+        1705363200000,
+        "AD",
+    ).thenReturn([_make_activity()])
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "dashboard",
+            "top-users",
+            "--from-date",
+            "2024-01-15",
+            "--to-date",
+            "2024-01-16",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_dashboard_rejects_unrecognized_date() -> None:
+    _stub_client()
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "dashboard", "alerts", "--from-date", "yesterday"],
+    )
+
+    assert result.exit_code == 1
+    assert "accepted formats" in strip_ansi(result.output)

--- a/tests/test_cli_time_parser.py
+++ b/tests/test_cli_time_parser.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from nextlabs_sdk._cli._time_parser import parse_time
+
+_NOW_MS = 1_700_000_000_000
+
+
+def test_epoch_ms_returned_unchanged() -> None:
+    assert parse_time("1737014400000", now_ms=_NOW_MS) == 1737014400000
+
+
+def test_zero_epoch_is_preserved() -> None:
+    assert parse_time("0", now_ms=_NOW_MS) == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "offset_ms"),
+    [
+        ("30s", 30 * 1000),
+        ("5m", 5 * 60 * 1000),
+        ("2h", 2 * 60 * 60 * 1000),
+        ("3d", 3 * 24 * 60 * 60 * 1000),
+        ("1w", 7 * 24 * 60 * 60 * 1000),
+    ],
+)
+def test_relative_offsets_subtract_from_now(value: str, offset_ms: int) -> None:
+    assert parse_time(value, now_ms=_NOW_MS) == _NOW_MS - offset_ms
+
+
+def test_iso_date_parses_as_midnight_utc() -> None:
+    # 2024-01-15T00:00:00Z -> 1705276800000
+    assert parse_time("2024-01-15", now_ms=_NOW_MS) == 1705276800000
+
+
+def test_iso_datetime_naive_is_treated_as_utc() -> None:
+    # 2024-01-15T10:30:00Z -> 1705314600000
+    assert parse_time("2024-01-15T10:30:00", now_ms=_NOW_MS) == 1705314600000
+
+
+def test_iso_datetime_with_offset_respects_offset() -> None:
+    # 2024-01-15T10:30:00+02:00 == 2024-01-15T08:30:00Z -> 1705307400000
+    assert parse_time("2024-01-15T10:30:00+02:00", now_ms=_NOW_MS) == 1705307400000
+
+
+def test_now_defaults_to_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nextlabs_sdk._cli._time_parser.time.time",
+        lambda: _NOW_MS / 1000,
+    )
+
+    assert parse_time("5m") == _NOW_MS - 5 * 60 * 1000
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "yesterday",
+        "5x",
+        "",
+        "-100",
+        "not-a-date",
+        "1h2m",
+        "1.5h",
+    ],
+)
+def test_invalid_inputs_raise_value_error(value: str) -> None:
+    with pytest.raises(ValueError, match="accepted formats"):
+        parse_time(value, now_ms=_NOW_MS)


### PR DESCRIPTION
## Summary

Implements the plan in `plans/` (human-friendly date input for CLI time-range commands). Users can now pass `--start-date 5m`, `--start-date 2024-01-15`, or keep using epoch-ms integers — same flag, auto-detected by shape. End-date options are optional and default to *now*.

## What changed

- New deep module `_cli/_time_parser.py` with a single `parse_time(text, now_ms=None) -> int` plus a `now_epoch_ms()` helper. Stdlib only; raises `ValueError` listing accepted formats on bad input.
- Rewired `audit-logs search` and all five `dashboard` subcommands (`alerts`, `top-users`, `top-resources`, `top-policies`, `alerts-by-monitor-tags`) to take `str` date options parsed through `parse_time`. End-date flags became optional.
- Help text on every affected flag now lists all three accepted formats.
- Parsing errors flow through the existing `cli_error_handler`, producing a clean non-zero exit with no traceback.

## Accepted formats

- Epoch ms: `1737014400000` (unchanged)
- ISO 8601: `2024-01-15`, `2024-01-15T10:30:00`, `2024-01-15T10:30:00+02:00` (naive treated as UTC)
- Relative: `30s`, `5m`, `2h`, `3d`, `1w` (subtracted from *now*)

## Tests

TDD: `tests/test_cli_time_parser.py` covers all formats, boundary `0`, clock-injection, and invalid inputs. `tests/test_cli_audit_logs.py` and `tests/test_cli_dashboard.py` gain end-to-end assertions that the parsed epoch ms reach the service layer, that `--end-date` defaults to frozen-now, and that bad input surfaces the "accepted formats" error.

- `python ./tools/tests.py --short`: 2012 passed, 97 xfailed, coverage 96.12%
- `python ./tools/checks.py --short`: 4/4 (black, flake8, mypy, pyright)

## Compatibility

Purely additive at the CLI boundary. Existing scripts passing integer epoch ms keep working verbatim; no SDK public model changed.