### PR TITLE
fix(cloudaz): parse bare Spring Pageable for reporter audit-logs search

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_reporter_audit_logs.py
+++ b/src/nextlabs_sdk/_cloudaz/_reporter_audit_logs.py
@@ -5,7 +5,7 @@ import functools
 import httpx
 
 from nextlabs_sdk._cloudaz._reporter_audit_log_models import ReporterAuditLogEntry
-from nextlabs_sdk._cloudaz._response import parse_reporter_paginated
+from nextlabs_sdk._cloudaz._response import parse_pageable
 from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 
 _SEARCH_PATH = "/nextlabs-reporter/api/activity-logs/search"
@@ -36,7 +36,7 @@ class ReporterAuditLogService:
             _SEARCH_PATH,
             params={"page": page_no, "size": page_size},
         )
-        raw_items, total_pages, total_records = parse_reporter_paginated(response)
+        raw_items, total_pages, total_records = parse_pageable(response)
         entries = [ReporterAuditLogEntry.model_validate(entry) for entry in raw_items]
         return PageResult(
             entries=entries,
@@ -72,7 +72,7 @@ class AsyncReporterAuditLogService:
             _SEARCH_PATH,
             params={"page": page_no, "size": page_size},
         )
-        raw_items, total_pages, total_records = parse_reporter_paginated(response)
+        raw_items, total_pages, total_records = parse_pageable(response)
         entries = [ReporterAuditLogEntry.model_validate(entry) for entry in raw_items]
         return PageResult(
             entries=entries,

--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -77,8 +77,15 @@ def parse_paginated(response: httpx.Response) -> tuple[Any, int, int]:
 def parse_reporter_paginated(response: httpx.Response) -> tuple[Any, int, int]:
     """Extract content, total_pages, total_records from a reporter-style response.
 
-    Reporter API nests pagination inside data:
-    {"statusCode": ..., "data": {"content": [...], "totalPages": N, "totalElements": N}}
+    Used by the ``/v1/`` Reporter endpoints (audit logs, activity logs, policy
+    activity reports) which nest pagination inside a CloudAz envelope::
+
+        {"statusCode": ..., "data": {"content": [...], "totalPages": N,
+         "totalElements": N}}
+
+    The newer ``/nextlabs-reporter/api/activity-logs/search`` endpoint returns
+    a bare Spring ``Page<T>`` without an envelope — use :func:`parse_pageable`
+    for that shape instead.
     """
     raise_for_status(response)
     body = decode_json_object(response)
@@ -95,6 +102,30 @@ def parse_reporter_paginated(response: httpx.Response) -> tuple[Any, int, int]:
         "totalElements",
         len(content_list) if isinstance(content_list, list) else 0,
     )
+    return content_list, total_pages, total_records
+
+
+def parse_pageable(response: httpx.Response) -> tuple[Any, int, int]:
+    """Extract content, total_pages, total_records from a bare Spring Pageable.
+
+    Shape::
+
+        {"content": [...], "totalPages": N, "totalElements": N, ...}
+
+    Unlike :func:`parse_reporter_paginated`, this response has no CloudAz
+    envelope and no ``statusCode`` — so the envelope-status check is skipped.
+    Used by ``/nextlabs-reporter/api/activity-logs/search``.
+    """
+    raise_for_status(response)
+    body = decode_json_object(response)
+    content_list = require_key(body, "content")
+    total_pages = require_key(body, "totalPages")
+    total_records = require_key(body, "totalElements")
+    if not isinstance(total_pages, int) or not isinstance(total_records, int):
+        raise ApiError(
+            "Unexpected response shape: pagination fields are not integers",
+            status_code=response.status_code,
+        )
     return content_list, total_pages, total_records
 
 

--- a/tests/e2e/test_cli_flows.py
+++ b/tests/e2e/test_cli_flows.py
@@ -194,13 +194,9 @@ def new_group_stubs(seeded_wiremock: str) -> str:
                 "status": 200,
                 "headers": {"Content-Type": "application/json"},
                 "jsonBody": {
-                    "statusCode": "100",
-                    "message": "OK",
-                    "data": {
-                        "content": [],
-                        "totalPages": 1,
-                        "totalElements": 0,
-                    },
+                    "content": [],
+                    "totalPages": 1,
+                    "totalElements": 0,
                 },
             },
         },

--- a/tests/test_async_reporter_audit_log_service.py
+++ b/tests/test_async_reporter_audit_log_service.py
@@ -19,13 +19,28 @@ def _make_request(path: str = "/api") -> httpx.Request:
     return httpx.Request("GET", f"{BASE_URL}{path}")
 
 
-def _make_reporter_envelope(content: list[object]) -> httpx.Response:
+def _make_bare_pageable(content: list[object]) -> httpx.Response:
     return httpx.Response(
         200,
         json={
-            "statusCode": "1003",
-            "message": "Data found successfully",
-            "data": {"content": content, "totalPages": 1, "totalElements": 1},
+            "content": content,
+            "pageable": {
+                "sort": {"unsorted": False, "sorted": True, "empty": False},
+                "pageSize": 20,
+                "pageNumber": 0,
+                "offset": 0,
+                "paged": True,
+                "unpaged": False,
+            },
+            "totalPages": 1,
+            "totalElements": 1,
+            "last": True,
+            "sort": {"unsorted": False, "sorted": True, "empty": False},
+            "first": True,
+            "numberOfElements": len(content),
+            "size": 20,
+            "number": 0,
+            "empty": not content,
         },
         request=_make_request(),
     )
@@ -57,7 +72,7 @@ def _collect(paginator: AsyncPaginator[T]) -> list[T]:
 def test_async_search_returns_paginator():
     client = mock(httpx.AsyncClient)
     service = AsyncReporterAuditLogService(client)
-    response = _make_reporter_envelope(content=[_make_entry_data()])
+    response = _make_bare_pageable(content=[_make_entry_data()])
     when(client).get(
         "/nextlabs-reporter/api/activity-logs/search",
         params={"page": 0, "size": 20},
@@ -71,3 +86,26 @@ def test_async_search_returns_paginator():
     assert isinstance(results[0], ReporterAuditLogEntry)
     assert results[0].component == "REPORTER"
     assert results[0].msg_code == "audit.export.generated.report"
+
+
+def test_async_search_parses_minimal_top_level_content_without_envelope():
+    """Regression: mirrors the sync test — bare Pageable must parse."""
+    client = mock(httpx.AsyncClient)
+    service = AsyncReporterAuditLogService(client)
+    response = httpx.Response(
+        200,
+        json={
+            "content": [_make_entry_data()],
+            "totalPages": 1,
+            "totalElements": 1,
+        },
+        request=_make_request(),
+    )
+    when(client).get(
+        "/nextlabs-reporter/api/activity-logs/search",
+        params={"page": 0, "size": 20},
+    ).thenReturn(response)
+
+    results = _collect(service.search())
+    assert len(results) == 1
+    assert results[0].id == 1339

--- a/tests/test_cloudaz_response.py
+++ b/tests/test_cloudaz_response.py
@@ -7,6 +7,7 @@ import pytest
 
 from nextlabs_sdk._cloudaz._response import (
     parse_data,
+    parse_pageable,
     parse_paginated,
     parse_raw,
     parse_reporter_paginated,
@@ -107,6 +108,103 @@ def test_parse_reporter_paginated_defaults_missing_totals():
     assert items == [{"id": 1}]
     assert total_pages == 1
     assert total_records == 1
+
+
+def _make_bare_pageable(
+    content: list[object],
+    total_pages: int = 1,
+    total_elements: int = 2,
+) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "content": content,
+            "pageable": {
+                "sort": {"unsorted": False, "sorted": True, "empty": False},
+                "pageSize": 20,
+                "pageNumber": 0,
+                "offset": 0,
+                "paged": True,
+                "unpaged": False,
+            },
+            "totalPages": total_pages,
+            "totalElements": total_elements,
+            "last": True,
+            "sort": {"unsorted": False, "sorted": True, "empty": False},
+            "first": True,
+            "numberOfElements": len(content),
+            "size": 20,
+            "number": 0,
+            "empty": not content,
+        },
+        request=_make_request(),
+    )
+
+
+def test_parse_pageable_extracts_content_and_totals():
+    response = _make_bare_pageable(
+        content=[{"id": 1}, {"id": 2}],
+        total_pages=3,
+        total_elements=42,
+    )
+    items, total_pages, total_records = parse_pageable(response)
+    assert items == [{"id": 1}, {"id": 2}]
+    assert total_pages == 3
+    assert total_records == 42
+
+
+def test_parse_pageable_ignores_envelope_status_code():
+    response = httpx.Response(
+        200,
+        json={
+            "statusCode": "5000",
+            "message": "ignored",
+            "content": [{"id": 1}],
+            "totalPages": 1,
+            "totalElements": 1,
+        },
+        request=_make_request(),
+    )
+    items, total_pages, total_records = parse_pageable(response)
+    assert items == [{"id": 1}]
+    assert total_pages == 1
+    assert total_records == 1
+
+
+def test_parse_pageable_raises_on_missing_content():
+    response = httpx.Response(
+        200,
+        json={"totalPages": 1, "totalElements": 0},
+        request=_make_request(),
+    )
+    with pytest.raises(ApiError) as exc_info:
+        parse_pageable(response)
+    assert "missing 'content'" in exc_info.value.message
+
+
+def test_parse_pageable_raises_on_non_integer_totals():
+    response = httpx.Response(
+        200,
+        json={
+            "content": [],
+            "totalPages": "1",
+            "totalElements": None,
+        },
+        request=_make_request(),
+    )
+    with pytest.raises(ApiError) as exc_info:
+        parse_pageable(response)
+    assert "pagination fields are not integers" in exc_info.value.message
+
+
+def test_parse_pageable_raises_on_http_error():
+    with pytest.raises(ServerError):
+        parse_pageable(_err_response(500, "boom"))
+
+
+def test_parse_pageable_raises_api_error_on_non_json():
+    with pytest.raises(ApiError):
+        parse_pageable(_non_json_response())
 
 
 def test_parse_raw_returns_json_body():

--- a/tests/test_reporter_audit_log_service.py
+++ b/tests/test_reporter_audit_log_service.py
@@ -16,7 +16,7 @@ def _make_request(path: str = "/api") -> httpx.Request:
     return httpx.Request("GET", f"{BASE_URL}{path}")
 
 
-def _make_reporter_envelope(
+def _make_bare_pageable(
     content: list[object],
     total_pages: int = 1,
     total_elements: int = 1,
@@ -24,13 +24,24 @@ def _make_reporter_envelope(
     return httpx.Response(
         200,
         json={
-            "statusCode": "1003",
-            "message": "Data found successfully",
-            "data": {
-                "content": content,
-                "totalPages": total_pages,
-                "totalElements": total_elements,
+            "content": content,
+            "pageable": {
+                "sort": {"unsorted": False, "sorted": True, "empty": False},
+                "pageSize": 20,
+                "pageNumber": 0,
+                "offset": 0,
+                "paged": True,
+                "unpaged": False,
             },
+            "totalPages": total_pages,
+            "totalElements": total_elements,
+            "last": True,
+            "sort": {"unsorted": False, "sorted": True, "empty": False},
+            "first": True,
+            "numberOfElements": len(content),
+            "size": 20,
+            "number": 0,
+            "empty": not content,
         },
         request=_make_request(),
     )
@@ -62,7 +73,7 @@ def _make_entry_data() -> dict[str, object]:
 def test_search_honors_page_size(page_size, kwargs):
     client = mock(httpx.Client)
     service = ReporterAuditLogService(client)
-    response = _make_reporter_envelope(content=[_make_entry_data()])
+    response = _make_bare_pageable(content=[_make_entry_data()])
     when(client).get(
         SEARCH_URL,
         params={"page": 0, "size": page_size},
@@ -81,13 +92,13 @@ def test_search_honors_page_size(page_size, kwargs):
 def test_search_paginates_multiple_pages():
     client = mock(httpx.Client)
     service = ReporterAuditLogService(client)
-    page0 = _make_reporter_envelope(
+    page0 = _make_bare_pageable(
         content=[_make_entry_data()],
         total_pages=2,
         total_elements=2,
     )
     entry1 = dict(_make_entry_data(), id=1340)
-    page1 = _make_reporter_envelope(
+    page1 = _make_bare_pageable(
         content=[entry1],
         total_pages=2,
         total_elements=2,
@@ -100,3 +111,25 @@ def test_search_paginates_multiple_pages():
     assert len(results) == 2
     assert results[0].id == 1339
     assert results[1].id == 1340
+
+
+def test_search_parses_minimal_top_level_content_without_envelope():
+    """Regression: the live server returns a bare Spring Pageable with no
+    ``statusCode`` / ``data`` envelope. The parser must not demand one."""
+    client = mock(httpx.Client)
+    service = ReporterAuditLogService(client)
+    response = httpx.Response(
+        200,
+        json={
+            "content": [_make_entry_data()],
+            "totalPages": 1,
+            "totalElements": 1,
+        },
+        request=_make_request(),
+    )
+    when(client).get(SEARCH_URL, params={"page": 0, "size": 20}).thenReturn(response)
+
+    results = list(service.search())
+
+    assert len(results) == 1
+    assert results[0].id == 1339


### PR DESCRIPTION
The live /nextlabs-reporter/api/activity-logs/search endpoint returns a
bare Spring Page<T> (top-level content/totalPages/totalElements), not a
CloudAz envelope. parse_reporter_paginated demanded the enveloped shape
and failed with "missing 'data'" against real servers.

Add parse_pageable for the bare shape and route only the reporter audit
log service (sync + async) through it. The /v1/ reporter endpoints still
use parse_reporter_paginated, which is correct per the OpenAPI spec.

Tests cover the OpenAPI example payload and a minimal top-level-content
regression for both sync and async services.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
