### PR TITLE
fix(cli): apply reporter-required defaults on audit-logs search

### DIFF
--- a/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
@@ -60,11 +60,17 @@ def search(
         str | None, typer.Option(help="Filter by entity type")
     ] = None,
     action: Annotated[str | None, typer.Option(help="Filter by action")] = None,
-    page_size: Annotated[int | None, typer.Option(help="Results per page")] = None,
-    sort_by: Annotated[str | None, typer.Option(help="Sort field")] = None,
-    sort_order: Annotated[str | None, typer.Option(help="Sort order")] = None,
+    page_size: Annotated[int, typer.Option(help="Results per page")] = 20,
+    sort_by: Annotated[str, typer.Option(help="Sort field")] = "timestamp",
+    sort_order: Annotated[str, typer.Option(help="Sort order")] = "DESC",
 ) -> None:
-    """Search entity audit logs."""
+    """Search entity audit logs.
+
+    ``--sort-by``, ``--sort-order``, and ``--page-size`` default to values
+    accepted by live reporter deployments. The server rejects requests that
+    omit these fields (observed 400/500 responses) even though the OpenAPI
+    spec marks them optional.
+    """
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     start_ms = parse_time(start_date)
@@ -92,7 +98,14 @@ def export(
     ],
     query_path: Annotated[
         Path | None,
-        typer.Option("--query", help="Path to a JSON AuditLogQuery payload"),
+        typer.Option(
+            "--query",
+            help=(
+                "Path to a JSON AuditLogQuery payload. Live reporter servers "
+                "require 'sortBy', 'sortOrder', and 'pageSize' to be present "
+                "in the payload."
+            ),
+        ),
     ] = None,
     ids: Annotated[
         list[int] | None,
@@ -107,7 +120,12 @@ def export(
         typer.Option("--overwrite/--no-overwrite", help="Replace existing file"),
     ] = False,
 ) -> None:
-    """Export audit logs as bytes to ``--output``."""
+    """Export audit logs as bytes to ``--output``.
+
+    The ``--query`` JSON file is forwarded verbatim; live reporter servers
+    reject queries missing ``sortBy``, ``sortOrder``, or ``pageSize``, so
+    include those fields in the payload.
+    """
     resolved_ids: list[int] | None = None
     if ids or ids_csv:
         resolved_ids = parse_bulk_ids(ids, ids_csv)

--- a/src/nextlabs_sdk/_cloudaz/_audit_log_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_audit_log_models.py
@@ -20,7 +20,15 @@ class AuditLogEntry(BaseModel):
 
 
 class AuditLogQuery(BaseModel):
-    """Query parameters for entity audit log search."""
+    """Query parameters for entity audit log search.
+
+    Note:
+        Although ``sortBy``, ``sortOrder``, and ``pageSize`` are marked
+        optional in the OpenAPI spec, live reporter deployments reject
+        requests that omit them (observed 400/500 responses). Callers should
+        set these fields explicitly; the CLI applies sensible defaults
+        (``sortBy="timestamp"``, ``sortOrder="DESC"``, ``pageSize=20``).
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/tests/test_cli_audit_logs.py
+++ b/tests/test_cli_audit_logs.py
@@ -261,9 +261,33 @@ def test_search_accepts_relative_start_date(
         end_date=frozen_clock,
         entity_type=None,
         action=None,
-        page_size=None,
-        sort_by=None,
-        sort_order=None,
+        page_size=20,
+        sort_by="timestamp",
+        sort_order="DESC",
+    )
+    when(stubbed_audit).search(expected).thenReturn(_make_paginator([_make_entry()]))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "audit-logs", "search", "--start-date", "5m"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_search_applies_default_sort_and_page_size(
+    stubbed_audit: Any, frozen_clock: int
+) -> None:
+    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+
+    expected = AuditLogQuery(
+        start_date=frozen_clock - 5 * 60 * 1000,
+        end_date=frozen_clock,
+        entity_type=None,
+        action=None,
+        page_size=20,
+        sort_by="timestamp",
+        sort_order="DESC",
     )
     when(stubbed_audit).search(expected).thenReturn(_make_paginator([_make_entry()]))
 
@@ -284,9 +308,9 @@ def test_search_accepts_iso_dates(stubbed_audit: Any) -> None:
         end_date=1705363200000,
         entity_type=None,
         action=None,
-        page_size=None,
-        sort_by=None,
-        sort_order=None,
+        page_size=20,
+        sort_by="timestamp",
+        sort_order="DESC",
     )
     when(stubbed_audit).search(expected).thenReturn(_make_paginator([_make_entry()]))
 


### PR DESCRIPTION
Closes #100.

## Why

Live NextLabs reporter deployments reject
`POST /nextlabs-reporter/api/v1/auditLogs/search` when the JSON body is
missing `sortBy`, `sortOrder`, or `pageSize` (observed 400/500, and 403
for some combinations — reproduced in Postman), despite the OpenAPI spec
marking those fields optional.

Before this change, `nextlabs audit-logs search --start-date 5m` sent
only `{startDate, endDate, pageNumber}` and failed against real servers.

## What

Per guiding principle, keep the model faithful to the OpenAPI spec and
fix ergonomics at the CLI layer:

- **`audit-logs search`** — defaults `--sort-by=timestamp`,
  `--sort-order=DESC`, `--page-size=20` (matches the browser UI and curl
  examples). Users can still override any of them.
- **`audit-logs export --query`** — does not mutate user-provided JSON.
  The `--query` help text and command docstring now warn that
  `sortBy`/`sortOrder`/`pageSize` must be present in the payload.
- **`AuditLogQuery`** — docstring records the server quirk so library
  callers know to set the fields explicitly.

No library-side behavior change: `EntityAuditLogService._fetch_page`
still `model_dump(exclude_none=True)`; async parity unaffected (no
separate audit-logs async CLI path).

## Test plan

- Updated `test_search_accepts_relative_start_date` and
  `test_search_accepts_iso_dates` to assert the new default query fields
  reach the service.
- Added `test_search_applies_default_sort_and_page_size` covering the
  exact repro case from the issue.
- Full unit suite green (2021 passed), coverage 96.13%.
- `tools/checks.py --short` green (black, flake8, mypy, pyright).

## Out of scope / follow-ups (tracked in #100)

- Upstream server/spec mismatch.
- Occasional 403 (UI-session vs OAuth/id_token) — separate investigation.
- Broader reporter-endpoint survey for drop-if-none required fields.