### PR TITLE
fix(cloudaz): align ActivityLogQuery required fields with OpenAPI

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_activity_log_query_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_activity_log_query_models.py
@@ -11,13 +11,13 @@ class ActivityLogQuery(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    from_date: int = Field(serialization_alias="fromDate")
-    to_date: int = Field(serialization_alias="toDate")
     policy_decision: str = Field(serialization_alias="policyDecision")
     sort_by: str = Field(serialization_alias="sortBy")
     sort_order: str = Field(serialization_alias="sortOrder")
-    field_name: str | None = Field(default=None, serialization_alias="fieldName")
-    field_value: str | None = Field(default=None, serialization_alias="fieldValue")
+    field_name: str = Field(serialization_alias="fieldName")
+    field_value: str = Field(serialization_alias="fieldValue")
+    from_date: int | None = Field(default=None, serialization_alias="fromDate")
+    to_date: int | None = Field(default=None, serialization_alias="toDate")
     header: list[str] | None = None
     page: int | None = None
     size: int | None = None

--- a/tests/test_activity_log_query_models.py
+++ b/tests/test_activity_log_query_models.py
@@ -10,23 +10,23 @@ from nextlabs_sdk._cloudaz._activity_log_query_models import (
 
 def _required() -> dict[str, object]:
     return {
-        "from_date": 1716825600000,
-        "to_date": 1717516799999,
         "policy_decision": "AD",
         "sort_by": "time",
         "sort_order": "ascending",
+        "field_name": "host_name",
+        "field_value": "cloudaz.nextlabs.solutions",
     }
 
 
 def test_activity_log_query_required_fields():
     query = ActivityLogQuery(**_required())  # type: ignore[arg-type]
-    assert query.from_date == 1716825600000
-    assert query.to_date == 1717516799999
     assert query.policy_decision == "AD"
     assert query.sort_by == "time"
     assert query.sort_order == "ascending"
-    assert query.field_name is None
-    assert query.field_value is None
+    assert query.field_name == "host_name"
+    assert query.field_value == "cloudaz.nextlabs.solutions"
+    assert query.from_date is None
+    assert query.to_date is None
     assert query.header is None
     assert query.page is None
     assert query.size is None
@@ -35,8 +35,8 @@ def test_activity_log_query_required_fields():
 def test_activity_log_query_serialization_aliases():
     query = ActivityLogQuery(
         **_required(),  # type: ignore[arg-type]
-        field_name="host_name",
-        field_value="cloudaz.nextlabs.solutions",
+        from_date=1716825600000,
+        to_date=1717516799999,
         header=["ROW_ID", "TIME", "USER_NAME"],
         page=0,
         size=10,
@@ -59,8 +59,25 @@ def test_activity_log_query_excludes_none_optional_fields():
         by_alias=True,
         exclude_none=True,
     )
-    for key in ("fieldName", "fieldValue", "header", "page", "size"):
+    for key in ("fromDate", "toDate", "header", "page", "size"):
         assert key not in dumped
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["policy_decision", "sort_by", "sort_order", "field_name", "field_value"],
+)
+def test_activity_log_query_rejects_missing_required(missing: str):
+    payload = _required()
+    payload.pop(missing)
+    with pytest.raises(Exception):
+        ActivityLogQuery(**payload)  # type: ignore[arg-type]
+
+
+def test_activity_log_query_accepts_missing_dates():
+    query = ActivityLogQuery(**_required())  # type: ignore[arg-type]
+    assert query.from_date is None
+    assert query.to_date is None
 
 
 def test_activity_log_attribute_model_validate_and_null():

--- a/tests/test_activity_log_query_service.py
+++ b/tests/test_activity_log_query_service.py
@@ -84,6 +84,8 @@ def _make_query() -> ActivityLogQuery:
         policy_decision="AD",
         sort_by="time",
         sort_order="ascending",
+        field_name="host_name",
+        field_value="cloudaz.nextlabs.solutions",
     )
 
 

--- a/tests/test_async_activity_log_query_service.py
+++ b/tests/test_async_activity_log_query_service.py
@@ -70,6 +70,8 @@ def _make_query() -> ActivityLogQuery:
         policy_decision="AD",
         sort_by="time",
         sort_order="ascending",
+        field_name="host_name",
+        field_value="cloudaz.nextlabs.solutions",
     )
 
 

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -52,6 +52,8 @@ def query_file(tmp_path: Path) -> Path:
                 "policy_decision": "AD",
                 "sort_by": "TIME",
                 "sort_order": "descending",
+                "field_name": "user_name",
+                "field_value": "alice",
             },
         ),
     )


### PR DESCRIPTION
Closes #84

## Summary
`ActivityLogQuery` (OpenAPI `EnforcementQueryDTO`) had its required/optional set inverted:
- `field_name` / `field_value` were optional but OpenAPI requires them.
- `from_date` / `to_date` were required but OpenAPI marks them optional.

This let callers build queries the SDK accepted but the server rejected, and blocked legitimate 'all time' queries.

## Changes
- `_activity_log_query_models.py`: make `field_name`/`field_value` required, `from_date`/`to_date` optional (`int | None = None`).
- Updated existing fixtures in `test_activity_log_query_service.py`, `test_async_activity_log_query_service.py`, and `test_cli_activity_logs.py` to supply the newly-required fields.
- Added parametrised missing-required-field tests and an explicit no-dates test in `test_activity_log_query_models.py`.

## Verification
- `python ./tools/checks.py --short` → 4/4 passed
- `python ./tools/tests.py --short` → 2027 passed, coverage 96.14 %

Done test-first (RED confirmed before fix).