### PR TITLE
fix(cloudaz): add shared field to DeleteReportsRequest

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_report_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_report_models.py
@@ -105,6 +105,7 @@ class DeleteReportsRequest(BaseModel):
         default=None, serialization_alias="policyDecision"
     )
     report_ids: list[int] | None = Field(default=None, serialization_alias="reportIds")
+    shared: bool | None = None
 
 
 class PolicyActivityReport(BaseModel):

--- a/tests/test_report_models.py
+++ b/tests/test_report_models.py
@@ -288,6 +288,18 @@ def test_report_request_serialization() -> None:
             ("reportIds",),
             id="with-query",
         ),
+        pytest.param(
+            {"title": "Deny", "shared": True},
+            {"title": "Deny", "shared": True},
+            ("reportIds", "policyDecision"),
+            id="with-shared",
+        ),
+        pytest.param(
+            {"report_ids": [1], "shared": False},
+            {"reportIds": [1], "shared": False},
+            ("title", "policyDecision"),
+            id="with-shared-false",
+        ),
     ],
 )
 def test_delete_request(


### PR DESCRIPTION
Fixes #85

Adds the missing `shared: bool | None` field to `DeleteReportsRequest` so it matches OpenAPI's `PolicyActivityReportDeleteDTO` (properties: title, policyDecision, reportIds, shared).

## Changes
- `src/nextlabs_sdk/_cloudaz/_report_models.py`: add `shared` field
- `tests/test_report_models.py`: add parametrized cases (`with-shared`, `with-shared-false`) to `test_delete_request`

## Verification
- `python ./tools/checks.py --short` → 4/4 passed
- `python ./tools/tests.py --short` → 2029 passed, 96.14% coverage

Developed test-first (RED verified with `KeyError: 'shared'` before implementation).