### PR TITLE
fix(cloudaz): preserve aggregators, save_info, and widget key on report models

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/__init__.py
@@ -78,6 +78,9 @@ from nextlabs_sdk._cloudaz._report_models import (
     ResourceActions as ResourceActions,
 )
 from nextlabs_sdk._cloudaz._report_models import (
+    SaveInfo as SaveInfo,
+)
+from nextlabs_sdk._cloudaz._report_models import (
     UserGroup as UserGroup,
 )
 from nextlabs_sdk._cloudaz._report_models import (

--- a/src/nextlabs_sdk/_cloudaz/_report_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_report_models.py
@@ -58,10 +58,23 @@ class ReportOrderBy(BaseModel):
     sort_order: str
 
 
+class SaveInfo(BaseModel):
+    """Persistence metadata for a saved report (name, sharing, audience)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    report_name: str | None = None
+    report_desc: str | None = None
+    report_type: str | None = None
+    shared_mode: str | None = None
+    user_ids: list[str] | None = None
+    group_ids: list[int] | None = None
+
+
 class ReportCriteria(BaseModel):
     """Full report criteria including filters, headers, ordering, and paging."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     filters: ReportFilters | None = None
     header: list[str] | None = None
@@ -70,14 +83,17 @@ class ReportCriteria(BaseModel):
     max_rows: int | None = None
     grouping_mode: str | None = None
     group_by: list[str] | None = None
+    aggregators: list[FilterField] | None = None
+    save_info: SaveInfo | None = None
 
 
 class ReportWidget(BaseModel):
     """Widget configuration for a report."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     id: int | None = None  # noqa: WPS125
+    key: str | None = None
     name: str
     title: str
     enabled: bool | None = None

--- a/src/nextlabs_sdk/cloudaz/__init__.py
+++ b/src/nextlabs_sdk/cloudaz/__init__.py
@@ -83,6 +83,9 @@ from nextlabs_sdk._cloudaz._report_models import (
     ResourceActions as ResourceActions,
 )
 from nextlabs_sdk._cloudaz._report_models import (
+    SaveInfo as SaveInfo,
+)
+from nextlabs_sdk._cloudaz._report_models import (
     UserGroup as UserGroup,
 )
 from nextlabs_sdk._cloudaz._report_models import (

--- a/tests/test_report_models.py
+++ b/tests/test_report_models.py
@@ -25,6 +25,7 @@ from nextlabs_sdk._cloudaz._report_models import (
     ReportFilters,
     ReportOrderBy,
     ReportWidget,
+    SaveInfo,
     ResourceActions,
     UserGroup,
     WidgetData,
@@ -212,6 +213,63 @@ def test_report_criteria_round_trip_from_api_response() -> None:
     assert criteria.pagesize == 20
 
 
+# --- SaveInfo ---
+
+
+def test_save_info_round_trip() -> None:
+    raw = {
+        "report_name": "Q1 Enforcement",
+        "report_desc": "Quarterly review",
+        "report_type": "custom",
+        "shared_mode": "private",
+        "user_ids": ["alice", "bob"],
+        "group_ids": [1, 2, 3],
+    }
+    info = SaveInfo.model_validate(raw)
+    assert info.report_name == "Q1 Enforcement"
+    assert info.user_ids == ["alice", "bob"]
+    assert info.group_ids == [1, 2, 3]
+    assert info.model_dump(exclude_none=True) == raw
+
+
+def test_save_info_defaults_all_optional() -> None:
+    info = SaveInfo()
+    assert info.report_name is None
+    assert info.user_ids is None
+    assert info.group_ids is None
+
+
+# --- ReportCriteria: aggregators / save_info / extra ---
+
+
+def test_report_criteria_preserves_aggregators_and_save_info() -> None:
+    raw = {
+        "pagesize": 20,
+        "aggregators": [
+            {"name": "decision", "operator": "count"},
+            {"name": "user_name", "operator": "group"},
+        ],
+        "save_info": {
+            "report_name": "Audit",
+            "shared_mode": "shared",
+            "group_ids": [7],
+        },
+    }
+    criteria = ReportCriteria.model_validate(raw)
+    assert criteria.aggregators is not None
+    assert len(criteria.aggregators) == 2
+    assert criteria.aggregators[0].name == "decision"
+    assert criteria.save_info is not None
+    assert criteria.save_info.report_name == "Audit"
+    assert criteria.save_info.group_ids == [7]
+
+
+def test_report_criteria_allows_unknown_fields() -> None:
+    criteria = ReportCriteria.model_validate({"pagesize": 10, "future_field": "x"})
+    dumped = criteria.model_dump()
+    assert dumped.get("future_field") == "x"
+
+
 # --- ReportWidget ---
 
 
@@ -219,6 +277,7 @@ def test_report_widget_from_api_payload() -> None:
     widget = ReportWidget.model_validate(
         {
             "id": 1,
+            "key": "enforcements",
             "name": "enforcement",
             "title": "Enforcement Trend",
             "enabled": True,
@@ -227,9 +286,24 @@ def test_report_widget_from_api_payload() -> None:
             "maxSize": 10,
         }
     )
+    assert widget.key == "enforcements"
     assert widget.chart_type == "line"
     assert widget.attribute_name == "decision"
     assert widget.max_size == 10
+
+
+def test_report_widget_allows_unknown_fields() -> None:
+    widget = ReportWidget.model_validate(
+        {
+            "name": "enforcement",
+            "title": "Trend",
+            "chartType": "line",
+            "attributeName": "decision",
+            "new_server_field": 42,
+        }
+    )
+    dumped = widget.model_dump()
+    assert dumped.get("new_server_field") == 42
 
 
 def test_report_widget_python_construction() -> None:


### PR DESCRIPTION
Closes #86

`ReportCriteria` silently dropped `aggregators` and `save_info`; `ReportWidget` dropped `key`. Added a new `SaveInfo` model, the missing fields, and switched both models to `ConfigDict(extra="allow")` so future server-side additions are preserved.

### Changes
- New `SaveInfo` model mirroring OpenAPI `SaveInfo`.
- `ReportCriteria`: add `aggregators: list[FilterField] | None`, `save_info: SaveInfo | None`, `extra='allow'`.
- `ReportWidget`: add `key: str | None`, `extra='allow'`.
- Re-export `SaveInfo` from `nextlabs_sdk._cloudaz` and `nextlabs_sdk.cloudaz`.
- Tests added for round-trip, defaults, and extra-field preservation.

### Why existing tests missed it
Existing round-trip fixtures used only a subset of `SavedReportCriteria` properties and a `ReportWidget` payload without `key`. New tests cover each newly-added field and both models' `extra='allow'` behavior.