### PR TITLE
fix(cloudaz): add FOLDER_TAG to TagType enum

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_models.py
@@ -18,6 +18,7 @@ class TagType(str, Enum):
     POLICY_MODEL = "POLICY_MODEL_TAG"
     COMPONENT = "COMPONENT_TAG"
     POLICY = "POLICY_TAG"
+    FOLDER = "FOLDER_TAG"
 
 
 class Tag(BaseModel):

--- a/tests/test_cloudaz_models.py
+++ b/tests/test_cloudaz_models.py
@@ -31,6 +31,20 @@ def test_tag_type_values() -> None:
     assert TagType.POLICY_MODEL.value == "POLICY_MODEL_TAG"
     assert TagType.COMPONENT.value == "COMPONENT_TAG"
     assert TagType.POLICY.value == "POLICY_TAG"
+    assert TagType.FOLDER.value == "FOLDER_TAG"
+
+
+def test_tag_accepts_folder_type() -> None:
+    tag = Tag.model_validate(
+        {
+            "id": 7,
+            "key": "folder",
+            "label": "Folder",
+            "type": "FOLDER_TAG",
+            "status": "ACTIVE",
+        },
+    )
+    assert tag.type == TagType.FOLDER
 
 
 def test_tag_from_api_payload() -> None:


### PR DESCRIPTION
Closes #87

## Summary
Adds the missing `FOLDER = "FOLDER_TAG"` member to `TagType`. The OpenAPI spec lists four enum values; the SDK exposed only three, so folder-typed tags failed Pydantic validation and `tags list FOLDER_TAG` was unreachable via the typed surface.

## Changes
- `src/nextlabs_sdk/_cloudaz/_models.py`: add `FOLDER` member.
- `tests/test_cloudaz_models.py`: assert enum value and round-trip Tag validation for `FOLDER_TAG`.

## Verification
- `python ./tools/tests.py --short` — 2035 passed, 96.15% coverage
- `python ./tools/checks.py --short` — black, flake8, mypy, pyright all pass