### PR TITLE
fix(cloudaz): align ComponentLite and Tag required fields with OpenAPI

### DIFF
--- a/src/nextlabs_sdk/_cli/_tags_cmd.py
+++ b/src/nextlabs_sdk/_cli/_tags_cmd.py
@@ -94,7 +94,7 @@ def _render_tag_detail(model: BaseModel, console: Console) -> None:
     console.print(f"[bold]Tag[/bold] {model.id}")
     console.print(f"  [bold]Key[/bold]:    {model.key}")
     console.print(f"  [bold]Label[/bold]:  {model.label}")
-    console.print(f"  [bold]Type[/bold]:   {model.type.value}")
+    console.print(f"  [bold]Type[/bold]:   {model.type.value if model.type else ''}")
     console.print(f"  [bold]Status[/bold]: {model.status}")
 
 

--- a/src/nextlabs_sdk/_cloudaz/_component_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_component_models.py
@@ -129,19 +129,19 @@ class PredicateData(BaseModel):
 class ComponentLite(BaseModel):
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    id: int  # noqa: WPS125
-    folder_id: int = Field(default=-1, alias="folderId")
+    id: int | None = None  # noqa: WPS125
+    folder_id: int | None = Field(default=None, alias="folderId")
     folder_path: str | None = Field(default=None, alias="folderPath")
     name: str
     lowercase_name: str = Field(default="", alias="lowercase_name")
     full_name: str = Field(default="", alias="fullName")
     description: str | None = None
     status: ComponentStatus
-    model_id: int = Field(alias="modelId")
-    model_type: str = Field(alias="modelType")
-    group: ComponentGroupType
-    last_updated_date: int = Field(alias="lastUpdatedDate")
-    created_date: int = Field(alias="createdDate")
+    model_id: int | None = Field(default=None, alias="modelId")
+    model_type: str | None = Field(default=None, alias="modelType")
+    group: ComponentGroupType | None = None
+    last_updated_date: int | None = Field(default=None, alias="lastUpdatedDate")
+    created_date: int | None = Field(default=None, alias="createdDate")
     owner_id: int = Field(default=0, alias="ownerId")
     owner_display_name: str = Field(default="", alias="ownerDisplayName")
     modified_by_id: int = Field(default=0, alias="modifiedById")

--- a/src/nextlabs_sdk/_cloudaz/_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_models.py
@@ -24,8 +24,8 @@ class TagType(str, Enum):
 class Tag(BaseModel):
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    id: int  # noqa: WPS125
-    key: str
-    label: str
-    type: TagType  # noqa: WPS125
-    status: str
+    id: int | None = None  # noqa: WPS125
+    key: str | None = None
+    label: str | None = None
+    type: TagType | None = None  # noqa: WPS125
+    status: str | None = None

--- a/tests/test_cloudaz_models.py
+++ b/tests/test_cloudaz_models.py
@@ -91,6 +91,24 @@ def test_operator_rejects_missing_fields() -> None:
         Operator.model_validate({"id": 1, "key": "eq"})
 
 
+def test_tag_accepts_empty_payload() -> None:
+    tag = Tag.model_validate({})
+    assert tag.id is None
+    assert tag.key is None
+    assert tag.label is None
+    assert tag.type is None
+    assert tag.status is None
+
+
+def test_tag_accepts_partial_payload() -> None:
+    tag = Tag.model_validate({"key": "dept", "status": "ACTIVE"})
+    assert tag.key == "dept"
+    assert tag.status == "ACTIVE"
+    assert tag.id is None
+    assert tag.label is None
+    assert tag.type is None
+
+
 def test_tag_rejects_invalid_type() -> None:
     with pytest.raises(ValidationError):
         Tag.model_validate(

--- a/tests/test_component_models.py
+++ b/tests/test_component_models.py
@@ -355,6 +355,26 @@ def test_component_lite_from_api_payload():
     assert cl.empty is False
 
 
+def test_component_lite_accepts_openapi_minimal_payload():
+    cl = ComponentLite.model_validate({"name": "Minimal", "status": "DRAFT"})
+    assert cl.name == "Minimal"
+    assert cl.status == ComponentStatus.DRAFT
+    assert cl.id is None
+    assert cl.model_id is None
+    assert cl.model_type is None
+    assert cl.group is None
+    assert cl.last_updated_date is None
+    assert cl.created_date is None
+    assert cl.tags == []
+
+
+def test_component_lite_rejects_missing_openapi_required():
+    with pytest.raises(ValidationError):
+        ComponentLite.model_validate({"name": "NoStatus"})
+    with pytest.raises(ValidationError):
+        ComponentLite.model_validate({"status": "DRAFT"})
+
+
 def test_push_result_from_api_payload():
     pr = PushResult.model_validate(
         {


### PR DESCRIPTION
Closes #88

## Summary
Two response models over-required fields relative to the OpenAPI spec, causing Pydantic `ValidationError` on valid partial responses.

- **`ComponentLite`**: OpenAPI requires only `name` and `status`. All other fields are now `Optional` with `None` defaults.
- **`Tag`** (TagDTO): OpenAPI lists no required fields. All fields are now `Optional` with `None` defaults.

Adjusted the tag detail CLI renderer to tolerate `type=None`.

## Tests
- New TDD tests covering empty/partial `Tag` and OpenAPI-minimal `ComponentLite` payloads, plus rejection tests for the required pair.
- Full unit suite green (2039 passed).
- Lint + type checks (black, flake8, mypy, pyright) all green.