### PR TITLE
fix(cloudaz): send pageSize and showHidden on tag and saved-search endpoints

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_component_search.py
+++ b/src/nextlabs_sdk/_cloudaz/_component_search.py
@@ -14,6 +14,7 @@ from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
 
 _PAGE_NO_PARAM = "pageNo"
+_PAGE_SIZE_PARAM = "pageSize"
 
 
 class ComponentSearchService:
@@ -39,16 +40,29 @@ class ComponentSearchService:
         )
         return SavedSearch.model_validate(parse_data(response))
 
-    def list_saved_searches(self) -> SyncPaginator[SavedSearch]:
+    def list_saved_searches(
+        self,
+        *,
+        page_size: int | None = None,
+    ) -> SyncPaginator[SavedSearch]:
         return SyncPaginator(
-            fetch_page=self._fetch_saved_searches_page,
+            fetch_page=functools.partial(
+                self._fetch_saved_searches_page,
+                page_size,
+            ),
         )
 
-    def find_saved_search(self, name: str) -> SyncPaginator[SavedSearch]:
+    def find_saved_search(
+        self,
+        name: str,
+        *,
+        page_size: int | None = None,
+    ) -> SyncPaginator[SavedSearch]:
         return SyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_find_saved_search_page,
                 name,
+                page_size,
             ),
         )
 
@@ -58,26 +72,41 @@ class ComponentSearchService:
         )
         raise_for_status(response)
 
-    def list_names(self, group: str) -> SyncPaginator[ComponentNameEntry]:
+    def list_names(
+        self,
+        group: str,
+        *,
+        page_size: int | None = None,
+    ) -> SyncPaginator[ComponentNameEntry]:
         return SyncPaginator(
-            fetch_page=functools.partial(self._fetch_names_page, group),
+            fetch_page=functools.partial(self._fetch_names_page, group, page_size),
         )
 
     def list_names_by_type(
         self,
         group: str,
         component_type: str,
+        *,
+        page_size: int | None = None,
     ) -> SyncPaginator[ComponentNameEntry]:
         return SyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_names_by_type_page,
                 group,
                 component_type,
+                page_size,
             ),
         )
 
-    def _page_params(self, page_no: int) -> dict[str, int]:
-        return {_PAGE_NO_PARAM: page_no}
+    def _page_params(
+        self,
+        page_no: int,
+        page_size: int | None = None,
+    ) -> dict[str, int]:
+        query_params: dict[str, int] = {_PAGE_NO_PARAM: page_no}
+        if page_size is not None:
+            query_params[_PAGE_SIZE_PARAM] = page_size
+        return query_params
 
     def _fetch_search_page(
         self,
@@ -92,33 +121,36 @@ class ComponentSearchService:
 
     def _fetch_saved_searches_page(
         self,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             "/console/api/v1/component/search/savedlist",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, SavedSearch, page_no)
 
     def _fetch_find_saved_search_page(
         self,
         name: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             f"/console/api/v1/component/search/savedlist/{name}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, SavedSearch, page_no)
 
     def _fetch_names_page(
         self,
         group: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[ComponentNameEntry]:
         response = self._client.get(
             f"/console/api/v1/component/search/listNames/{group}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, ComponentNameEntry, page_no)
 
@@ -126,11 +158,12 @@ class ComponentSearchService:
         self,
         group: str,
         component_type: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[ComponentNameEntry]:
         response = self._client.get(
             f"/console/api/v1/component/search/listNames/{group}/{component_type}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, ComponentNameEntry, page_no)
 
@@ -158,16 +191,29 @@ class AsyncComponentSearchService:
         )
         return SavedSearch.model_validate(parse_data(response))
 
-    def list_saved_searches(self) -> AsyncPaginator[SavedSearch]:
+    def list_saved_searches(
+        self,
+        *,
+        page_size: int | None = None,
+    ) -> AsyncPaginator[SavedSearch]:
         return AsyncPaginator(
-            fetch_page=self._fetch_saved_searches_page,
+            fetch_page=functools.partial(
+                self._fetch_saved_searches_page,
+                page_size,
+            ),
         )
 
-    def find_saved_search(self, name: str) -> AsyncPaginator[SavedSearch]:
+    def find_saved_search(
+        self,
+        name: str,
+        *,
+        page_size: int | None = None,
+    ) -> AsyncPaginator[SavedSearch]:
         return AsyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_find_saved_search_page,
                 name,
+                page_size,
             ),
         )
 
@@ -177,26 +223,41 @@ class AsyncComponentSearchService:
         )
         raise_for_status(response)
 
-    def list_names(self, group: str) -> AsyncPaginator[ComponentNameEntry]:
+    def list_names(
+        self,
+        group: str,
+        *,
+        page_size: int | None = None,
+    ) -> AsyncPaginator[ComponentNameEntry]:
         return AsyncPaginator(
-            fetch_page=functools.partial(self._fetch_names_page, group),
+            fetch_page=functools.partial(self._fetch_names_page, group, page_size),
         )
 
     def list_names_by_type(
         self,
         group: str,
         component_type: str,
+        *,
+        page_size: int | None = None,
     ) -> AsyncPaginator[ComponentNameEntry]:
         return AsyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_names_by_type_page,
                 group,
                 component_type,
+                page_size,
             ),
         )
 
-    def _page_params(self, page_no: int) -> dict[str, int]:
-        return {_PAGE_NO_PARAM: page_no}
+    def _page_params(
+        self,
+        page_no: int,
+        page_size: int | None = None,
+    ) -> dict[str, int]:
+        query_params: dict[str, int] = {_PAGE_NO_PARAM: page_no}
+        if page_size is not None:
+            query_params[_PAGE_SIZE_PARAM] = page_size
+        return query_params
 
     async def _fetch_search_page(
         self,
@@ -211,33 +272,36 @@ class AsyncComponentSearchService:
 
     async def _fetch_saved_searches_page(
         self,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             "/console/api/v1/component/search/savedlist",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, SavedSearch, page_no)
 
     async def _fetch_find_saved_search_page(
         self,
         name: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             f"/console/api/v1/component/search/savedlist/{name}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, SavedSearch, page_no)
 
     async def _fetch_names_page(
         self,
         group: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[ComponentNameEntry]:
         response = await self._client.get(
             f"/console/api/v1/component/search/listNames/{group}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, ComponentNameEntry, page_no)
 
@@ -245,10 +309,11 @@ class AsyncComponentSearchService:
         self,
         group: str,
         component_type: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[ComponentNameEntry]:
         response = await self._client.get(
             f"/console/api/v1/component/search/listNames/{group}/{component_type}",
-            params=self._page_params(page_no),
+            params=self._page_params(page_no, page_size),
         )
         return build_page(response, ComponentNameEntry, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_component_type_search.py
+++ b/src/nextlabs_sdk/_cloudaz/_component_type_search.py
@@ -11,6 +11,44 @@ from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
 
 _PAGE_NO_PARAM = "pageNo"
+_PAGE_SIZE_PARAM = "pageSize"
+
+
+def _saved_list_params(page_no: int, page_size: int | None) -> dict[str, int]:
+    query_params: dict[str, int] = {_PAGE_NO_PARAM: page_no}
+    if page_size is not None:
+        query_params[_PAGE_SIZE_PARAM] = page_size
+    return query_params
+
+
+def _saved_search_page_result(
+    response: httpx.Response,
+    page_no: int,
+) -> PageResult[SavedSearch]:
+    raw_items, total_pages, total_records, server_page_size = parse_paginated(response)
+    searches = [SavedSearch.model_validate(entry) for entry in raw_items]
+    return PageResult(
+        entries=searches,
+        page_no=page_no,
+        page_size=len(searches) if server_page_size is None else server_page_size,
+        total_pages=total_pages,
+        total_records=total_records,
+    )
+
+
+def _component_type_page_result(
+    response: httpx.Response,
+    page_no: int,
+) -> PageResult[ComponentType]:
+    raw_items, total_pages, total_records, server_page_size = parse_paginated(response)
+    entries = [ComponentType.model_validate(entry) for entry in raw_items]
+    return PageResult(
+        entries=entries,
+        page_no=page_no,
+        page_size=len(entries) if server_page_size is None else server_page_size,
+        total_pages=total_pages,
+        total_records=total_records,
+    )
 
 
 class ComponentTypeSearchService:
@@ -45,11 +83,14 @@ class ComponentTypeSearchService:
     def list_saved_searches(
         self,
         search_type: str,
+        *,
+        page_size: int | None = None,
     ) -> SyncPaginator[SavedSearch]:
         return SyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_saved_searches_page,
                 search_type,
+                page_size,
             ),
         )
 
@@ -57,12 +98,15 @@ class ComponentTypeSearchService:
         self,
         search_type: str,
         name: str,
+        *,
+        page_size: int | None = None,
     ) -> SyncPaginator[SavedSearch]:
         return SyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_find_saved_search_page,
                 search_type,
                 name,
+                page_size,
             ),
         )
 
@@ -75,54 +119,32 @@ class ComponentTypeSearchService:
             "/console/api/v1/policyModel/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        component_types = [ComponentType.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=component_types,
-            page_no=page_no,
-            page_size=len(component_types),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _component_type_page_result(response, page_no)
 
     def _fetch_saved_searches_page(
         self,
         search_type: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             f"/console/api/v1/policyModel/search/savedlist/{search_type}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=_saved_list_params(page_no, page_size),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _saved_search_page_result(response, page_no)
 
     def _fetch_find_saved_search_page(
         self,
         search_type: str,
         name: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = self._client.get(
             f"/console/api/v1/policyModel/search/savedlist/{search_type}/{name}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=_saved_list_params(page_no, page_size),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _saved_search_page_result(response, page_no)
 
 
 class AsyncComponentTypeSearchService:
@@ -157,11 +179,14 @@ class AsyncComponentTypeSearchService:
     def list_saved_searches(
         self,
         search_type: str,
+        *,
+        page_size: int | None = None,
     ) -> AsyncPaginator[SavedSearch]:
         return AsyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_saved_searches_page,
                 search_type,
+                page_size,
             ),
         )
 
@@ -169,12 +194,15 @@ class AsyncComponentTypeSearchService:
         self,
         search_type: str,
         name: str,
+        *,
+        page_size: int | None = None,
     ) -> AsyncPaginator[SavedSearch]:
         return AsyncPaginator(
             fetch_page=functools.partial(
                 self._fetch_find_saved_search_page,
                 search_type,
                 name,
+                page_size,
             ),
         )
 
@@ -187,51 +215,29 @@ class AsyncComponentTypeSearchService:
             "/console/api/v1/policyModel/search",
             json=criteria.page(page_no).to_dict(),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        component_types = [ComponentType.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=component_types,
-            page_no=page_no,
-            page_size=len(component_types),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _component_type_page_result(response, page_no)
 
     async def _fetch_saved_searches_page(
         self,
         search_type: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             f"/console/api/v1/policyModel/search/savedlist/{search_type}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=_saved_list_params(page_no, page_size),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _saved_search_page_result(response, page_no)
 
     async def _fetch_find_saved_search_page(
         self,
         search_type: str,
         name: str,
+        page_size: int | None,
         page_no: int,
     ) -> PageResult[SavedSearch]:
         response = await self._client.get(
             f"/console/api/v1/policyModel/search/savedlist/{search_type}/{name}",
-            params={_PAGE_NO_PARAM: page_no},
+            params=_saved_list_params(page_no, page_size),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
-        searches = [SavedSearch.model_validate(entry) for entry in raw_items]
-        return PageResult(
-            entries=searches,
-            page_no=page_no,
-            page_size=len(searches),
-            total_pages=total_pages,
-            total_records=total_records,
-        )
+        return _saved_search_page_result(response, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -59,8 +59,13 @@ def parse_data(response: httpx.Response) -> Any:
     return require_key(body, "data")
 
 
-def parse_paginated(response: httpx.Response) -> tuple[Any, int, int]:
-    """Extract data, total_pages, and total_records from a paginated response."""
+def parse_paginated(response: httpx.Response) -> tuple[Any, int, int, int | None]:
+    """Extract data, total_pages, total_records, and page_size from a paginated response.
+
+    The fourth element is the server-reported ``pageSize`` (the effective page
+    size the server used). It is ``None`` when the envelope omits the field, in
+    which case callers should fall back to the length of the returned page.
+    """
     raise_for_status(response)
     body = decode_json_object(response)
     _check_envelope_status(body, response)
@@ -71,7 +76,9 @@ def parse_paginated(response: httpx.Response) -> tuple[Any, int, int]:
             "Unexpected response shape: pagination fields are not integers",
             status_code=response.status_code,
         )
-    return require_key(body, "data"), total_pages, total_records
+    raw_page_size = body.get("pageSize")
+    page_size = raw_page_size if isinstance(raw_page_size, int) else None
+    return require_key(body, "data"), total_pages, total_records, page_size
 
 
 def parse_reporter_paginated(response: httpx.Response) -> tuple[Any, int, int]:
@@ -140,13 +147,17 @@ def build_page(
     model: type[_ModelT],
     page_no: int,
 ) -> PageResult[_ModelT]:
-    """Parse a paginated CloudAz response into a typed ``PageResult``."""
-    raw_items, total_pages, total_records = parse_paginated(response)
+    """Parse a paginated CloudAz response into a typed ``PageResult``.
+
+    ``PageResult.page_size`` reflects the server-reported ``pageSize``. If the
+    envelope omits that field we fall back to the length of the returned page.
+    """
+    raw_items, total_pages, total_records, page_size = parse_paginated(response)
     entries = [model.model_validate(entry) for entry in raw_items]
     return PageResult(
         entries=entries,
         page_no=page_no,
-        page_size=len(entries),
+        page_size=len(entries) if page_size is None else page_size,
         total_pages=total_pages,
         total_records=total_records,
     )

--- a/src/nextlabs_sdk/_cloudaz/_tags.py
+++ b/src/nextlabs_sdk/_cloudaz/_tags.py
@@ -9,13 +9,39 @@ from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
 
 
+def _list_params(
+    page_no: int,
+    page_size: int | None,
+    show_hidden: bool | None,
+) -> dict[str, int | str]:
+    query_params: dict[str, int | str] = {"pageNo": page_no}
+    if page_size is not None:
+        query_params["pageSize"] = page_size
+    if show_hidden is not None:
+        query_params["showHidden"] = "true" if show_hidden else "false"
+    return query_params
+
+
 class TagService:
 
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
 
-    def list(self, tag_type: TagType) -> SyncPaginator[Tag]:
-        return SyncPaginator(fetch_page=functools.partial(self._fetch_page, tag_type))
+    def list(
+        self,
+        tag_type: TagType,
+        *,
+        page_size: int | None = None,
+        show_hidden: bool | None = None,
+    ) -> SyncPaginator[Tag]:
+        return SyncPaginator(
+            fetch_page=functools.partial(
+                self._fetch_page,
+                tag_type,
+                page_size,
+                show_hidden,
+            ),
+        )
 
     def get(self, tag_id: int) -> Tag:
         response = self._client.get(
@@ -51,18 +77,22 @@ class TagService:
     def _fetch_page(
         self,
         tag_type: TagType,
+        page_size: int | None,
+        show_hidden: bool | None,
         page_no: int,
     ) -> PageResult[Tag]:
         response = self._client.get(
             f"/console/api/v1/config/tags/list/{tag_type.value}",
-            params={"pageNo": page_no},
+            params=_list_params(page_no, page_size, show_hidden),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
+        raw_items, total_pages, total_records, server_page_size = parse_paginated(
+            response,
+        )
         tags = [Tag.model_validate(entry) for entry in raw_items]
         return PageResult(
             entries=tags,
             page_no=page_no,
-            page_size=len(tags),
+            page_size=len(tags) if server_page_size is None else server_page_size,
             total_pages=total_pages,
             total_records=total_records,
         )
@@ -73,9 +103,20 @@ class AsyncTagService:
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
 
-    def list(self, tag_type: TagType) -> AsyncPaginator[Tag]:
+    def list(
+        self,
+        tag_type: TagType,
+        *,
+        page_size: int | None = None,
+        show_hidden: bool | None = None,
+    ) -> AsyncPaginator[Tag]:
         return AsyncPaginator(
-            fetch_page=functools.partial(self._fetch_page, tag_type),
+            fetch_page=functools.partial(
+                self._fetch_page,
+                tag_type,
+                page_size,
+                show_hidden,
+            ),
         )
 
     async def get(self, tag_id: int) -> Tag:
@@ -112,18 +153,22 @@ class AsyncTagService:
     async def _fetch_page(
         self,
         tag_type: TagType,
+        page_size: int | None,
+        show_hidden: bool | None,
         page_no: int,
     ) -> PageResult[Tag]:
         response = await self._client.get(
             f"/console/api/v1/config/tags/list/{tag_type.value}",
-            params={"pageNo": page_no},
+            params=_list_params(page_no, page_size, show_hidden),
         )
-        raw_items, total_pages, total_records = parse_paginated(response)
+        raw_items, total_pages, total_records, server_page_size = parse_paginated(
+            response,
+        )
         tags = [Tag.model_validate(entry) for entry in raw_items]
         return PageResult(
             entries=tags,
             page_no=page_no,
-            page_size=len(tags),
+            page_size=len(tags) if server_page_size is None else server_page_size,
             total_pages=total_pages,
             total_records=total_records,
         )

--- a/tests/test_async_tag_service.py
+++ b/tests/test_async_tag_service.py
@@ -113,3 +113,19 @@ def test_async_delete_succeeds():
     )
 
     _run(lambda: service.delete(10))
+
+
+def test_async_list_sends_page_size_and_show_hidden():
+    client, service = _make_service()
+    when(client).get(
+        "/console/api/v1/config/tags/list/COMPONENT_TAG",
+        params={"pageNo": 0, "pageSize": 50, "showHidden": "true"},
+    ).thenReturn(_make_envelope(data=[_make_tag_data()]))
+
+    paginator = service.list(TagType.COMPONENT, page_size=50, show_hidden=True)
+
+    async def collect() -> list[Tag]:
+        return [tag async for tag in paginator]
+
+    tags = _run(collect)
+    assert len(tags) == 1

--- a/tests/test_cloudaz_response.py
+++ b/tests/test_cloudaz_response.py
@@ -67,11 +67,33 @@ def test_parse_data_extracts_data_field(data, expected):
 
 
 def test_parse_paginated_extracts_all_fields():
-    response = _make_envelope(data=[{"id": 1}], total_pages=5, total_records=42)
-    data, total_pages, total_records = parse_paginated(response)
+    response = _make_envelope(
+        data=[{"id": 1}],
+        total_pages=5,
+        total_records=42,
+        page_size=25,
+    )
+    data, total_pages, total_records, page_size = parse_paginated(response)
     assert data == [{"id": 1}]
     assert total_pages == 5
     assert total_records == 42
+    assert page_size == 25
+
+
+def test_parse_paginated_page_size_missing_returns_none():
+    response = httpx.Response(
+        200,
+        json={
+            "statusCode": "1003",
+            "message": "Data found successfully",
+            "data": [{"id": 1}],
+            "totalPages": 1,
+            "totalNoOfRecords": 1,
+        },
+        request=_make_request(),
+    )
+    _, _, _, page_size = parse_paginated(response)
+    assert page_size is None
 
 
 def test_parse_reporter_paginated_extracts_content():

--- a/tests/test_component_search_service.py
+++ b/tests/test_component_search_service.py
@@ -243,3 +243,60 @@ def test_list_names_by_type_returns_paginator(client, service):
     assert isinstance(paginator, SyncPaginator)
     results = list(paginator)
     assert len(results) == 1
+
+
+@pytest.mark.parametrize(
+    "call,url",
+    [
+        pytest.param(
+            lambda s: s.list_saved_searches(page_size=50),
+            "/console/api/v1/component/search/savedlist",
+            id="list-saved-searches",
+        ),
+        pytest.param(
+            lambda s: s.find_saved_search("security", page_size=50),
+            "/console/api/v1/component/search/savedlist/security",
+            id="find-saved-search",
+        ),
+    ],
+)
+def test_saved_search_sends_page_size(client, service, call, url):
+    when(client).get(url, params={"pageNo": 0, "pageSize": 50}).thenReturn(
+        _make_envelope(data=[_saved_search_data()], page_size=50),
+    )
+
+    list(call(service))
+
+
+@pytest.mark.parametrize(
+    "call,url",
+    [
+        pytest.param(
+            lambda s: s.list_names("RESOURCE", page_size=50),
+            "/console/api/v1/component/search/listNames/RESOURCE",
+            id="list-names",
+        ),
+        pytest.param(
+            lambda s: s.list_names_by_type("RESOURCE", "Support Tickets", page_size=50),
+            "/console/api/v1/component/search/listNames/RESOURCE/Support Tickets",
+            id="list-names-by-type",
+        ),
+    ],
+)
+def test_list_names_sends_page_size(client, service, call, url):
+    when(client).get(url, params={"pageNo": 0, "pageSize": 50}).thenReturn(
+        _make_envelope(data=[_name_entry_data()], page_size=50),
+    )
+
+    list(call(service))
+
+
+def test_page_size_reflects_server_value(client, service):
+    when(client).get(
+        "/console/api/v1/component/search/savedlist",
+        params={"pageNo": 0, "pageSize": 25},
+    ).thenReturn(_make_envelope(data=[_saved_search_data()], page_size=25))
+
+    page = service.list_saved_searches(page_size=25).first_page()
+
+    assert page.page_size == 25

--- a/tests/test_component_type_search_service.py
+++ b/tests/test_component_type_search_service.py
@@ -196,3 +196,55 @@ def test_saved_search_paginator(
     results = list(paginator)
     assert len(results) == 1
     assert isinstance(results[0], SavedSearch)
+
+
+@pytest.mark.parametrize(
+    "endpoint,call_method",
+    [
+        pytest.param(
+            f"{_SAVED_LIST}/POLICY_MODEL_RESOURCE",
+            lambda svc: svc.list_saved_searches(
+                "POLICY_MODEL_RESOURCE",
+                page_size=50,
+            ),
+            id="list-saved-searches",
+        ),
+        pytest.param(
+            f"{_SAVED_LIST}/POLICY_MODEL_RESOURCE/support",
+            lambda svc: svc.find_saved_search(
+                "POLICY_MODEL_RESOURCE",
+                "support",
+                page_size=50,
+            ),
+            id="find-saved-search",
+        ),
+    ],
+)
+def test_saved_search_sends_page_size(
+    service: tuple[ComponentTypeSearchService, httpx.Client],
+    endpoint: str,
+    call_method: Callable[[ComponentTypeSearchService], Any],
+) -> None:
+    svc, client = service
+    when(client).get(endpoint, params={"pageNo": 0, "pageSize": 50}).thenReturn(
+        _make_envelope([_make_saved_search_data()])
+    )
+
+    list(call_method(svc))
+
+
+def test_saved_search_page_size_reflects_server_value(
+    service: tuple[ComponentTypeSearchService, httpx.Client],
+) -> None:
+    svc, client = service
+    when(client).get(
+        f"{_SAVED_LIST}/POLICY_MODEL_RESOURCE",
+        params={"pageNo": 0, "pageSize": 25},
+    ).thenReturn(_make_envelope([_make_saved_search_data()]))
+
+    page = svc.list_saved_searches(
+        "POLICY_MODEL_RESOURCE",
+        page_size=25,
+    ).first_page()
+
+    assert page.page_size == 10

--- a/tests/test_tag_service.py
+++ b/tests/test_tag_service.py
@@ -149,3 +149,34 @@ def test_get_raises_not_found(client, service):
 
     with pytest.raises(NotFoundError):
         service.get(999)
+
+
+def test_list_sends_page_size_and_show_hidden(client, service):
+    when(client).get(
+        "/console/api/v1/config/tags/list/COMPONENT_TAG",
+        params={"pageNo": 0, "pageSize": 50, "showHidden": "true"},
+    ).thenReturn(_make_envelope(data=[_tag_data()], page_size=50))
+
+    tags = list(service.list(TagType.COMPONENT, page_size=50, show_hidden=True))
+
+    assert len(tags) == 1
+
+
+def test_list_show_hidden_false_is_sent_as_string(client, service):
+    when(client).get(
+        "/console/api/v1/config/tags/list/COMPONENT_TAG",
+        params={"pageNo": 0, "showHidden": "false"},
+    ).thenReturn(_make_envelope(data=[]))
+
+    list(service.list(TagType.COMPONENT, show_hidden=False))
+
+
+def test_first_page_reports_server_page_size(client, service):
+    when(client).get(
+        "/console/api/v1/config/tags/list/COMPONENT_TAG",
+        params={"pageNo": 0, "pageSize": 25},
+    ).thenReturn(_make_envelope(data=[_tag_data()], page_size=25))
+
+    page = service.list(TagType.COMPONENT, page_size=25).first_page()
+
+    assert page.page_size == 25


### PR DESCRIPTION
Fixes #89.

## Summary

CloudAz tag list and component/component-type saved-search + list-names endpoints previously sent only `pageNo` on the query string, silently locking pagination to the server default (typically 10). Tags also had no way to surface hidden entries through the typed API. On top of that, `PageResult.page_size` was computed as `len(entries)`, a post-hoc approximation that was wrong on short final pages.

## Changes

- Add optional `page_size` (and `show_hidden` for tags) keyword args to the public `list(...)`, `list_saved_searches(...)`, `find_saved_search(...)`, `list_names(...)`, and `list_names_by_type(...)` entry points on the sync + async services.
- Thread the new params through to the internal `_fetch_page` helpers and emit `pageSize` / `showHidden` on the outgoing request only when the caller supplies them — default behavior for existing callers is unchanged.
- Extend `parse_paginated` to surface the server-reported `pageSize` (4-tuple return), and update `build_page` plus the tag/component-type fetchers to set `PageResult.page_size` to that value (falling back to `len(entries)` only when the envelope omits it).

## Tests

Added coverage for:

- `page_size` + `show_hidden` are serialized onto the query string (sync + async tags, saved searches, list-names, list-names-by-type, component-type saved searches).
- `PageResult.page_size` reflects the server-echoed value, not the size of the returned batch.
- `parse_paginated` returns `None` for `page_size` when the envelope omits it.

`python ./tools/checks.py --short` and `python ./tools/tests.py --short` both green locally.