### PR TITLE
fix(pdp): emit IncludeInResult="false" on every request attribute

### DIFF
--- a/src/nextlabs_sdk/_pdp/_json_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_json_serializer.py
@@ -117,7 +117,7 @@ def _make_record_matching_attr() -> dict[str, object]:
         "AttributeId": urns.RECORD_MATCHING_POLICIES_ATTR,
         _VALUE_KEY: "true",
         "DataType": urns.STRING_DATATYPE,
-        "IncludeInResult": False,
+        "IncludeInResult": "false",
     }
 
 
@@ -309,6 +309,7 @@ def _make_attr(
         "AttributeId": attr_id,
         _VALUE_KEY: attr_value,
         "DataType": _infer_datatype(attr_value),
+        "IncludeInResult": "false",
     }
 
 

--- a/src/nextlabs_sdk/_pdp/_xml_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_xml_serializer.py
@@ -86,6 +86,7 @@ def _append_attribute(
     attr_value: AttrValue,
 ) -> None:
     attr_el = ET.SubElement(parent, _ns(_ATTRIBUTE_TAG))
+    attr_el.set("IncludeInResult", "false")
     attr_el.set(_ATTRIBUTE_ID_KEY, attr_id)
     value_el = ET.SubElement(attr_el, _ns(_ATTRIBUTE_VALUE_TAG))
     value_el.set("DataType", _infer_datatype(attr_value))

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -222,7 +222,7 @@ def test_serialize_permissions_request_with_record_matching():
     record_attr = _find_attribute(env_cat, urns.RECORD_MATCHING_POLICIES_ATTR)
     assert record_attr["Value"] == "true"
     assert record_attr["DataType"] == urns.STRING_DATATYPE
-    assert record_attr["IncludeInResult"] is False
+    assert record_attr["IncludeInResult"] == "false"
 
 
 def test_serialize_permissions_request_merges_record_matching_into_env():
@@ -608,3 +608,22 @@ def test_deserialize_carries_request_context_on_status_error():
         "https://pdp.example/dpc/authorization/pdppermissions"
     )
     assert excinfo.value.envelope_status_code == _MISSING_ATTR_URN
+
+
+def test_serialize_every_attribute_has_include_in_result_false():
+    body = _eval_body(
+        EvalRequest(
+            subject=Subject(id="u", department="IT"),
+            action=Action(id="VIEW"),
+            resource=Resource(id="r", type="t", attributes={"prod": "p"}),
+            application=Application(id="app", version="1.0"),
+            environment=Environment(attributes={"ip": "10.0.0.1"}),
+        ),
+    )
+
+    for category in body["Request"]["Category"]:
+        for attr in category["Attribute"]:
+            assert attr["IncludeInResult"] == "false", (
+                f"Attribute {attr['AttributeId']} in category "
+                f"{category['CategoryId']} missing IncludeInResult=\"false\""
+            )

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -272,3 +272,23 @@ def test_xml_deserialize_permissions_response():
     assert response.allowed[0].name == "VIEW"
     assert len(response.denied) == 1
     assert response.denied[0].name == "DELETE"
+
+
+def test_xml_serialize_every_attribute_has_include_in_result_false():
+    request = EvalRequest(
+        subject=Subject(id="u", department="IT"),
+        action=Action(id="VIEW"),
+        resource=Resource(id="r", type="t", attributes={"prod": "p"}),
+        application=Application(id="app", version="1.0"),
+    )
+    root = _parse_xml(serialize_eval_request(request))
+
+    attr_count = 0
+    for attrs_el in root.findall(_ns("Attributes")):
+        for attr_el in attrs_el.findall(_ns("Attribute")):
+            attr_count += 1
+            assert attr_el.get("IncludeInResult") == "false", (
+                f"Attribute {attr_el.get('AttributeId')!r} missing "
+                f'IncludeInResult="false"'
+            )
+    assert attr_count > 0


### PR DESCRIPTION
Closes #90

Aligns the PDP JSON and XML serializers with the canonical PDP API wire format by emitting `IncludeInResult="false"` on every per-attribute payload (previously only the special `record_matching_policies` attribute carried it).

Per XACML 3.0, `IncludeInResult` is optional and defaults to `false`, and the PDP tolerates omission — so this is a wire-format alignment rather than a behavior change. Strict validators that compare against the canonical samples will now match.

### Changes
- `_pdp/_json_serializer.py`: `_make_attr` now emits `"IncludeInResult": "false"`; `_make_record_matching_attr` normalized to string `"false"` for consistency.
- `_pdp/_xml_serializer.py`: `_append_attribute` sets `IncludeInResult="false"`.
- Added regression tests in both serializer test modules walking every attribute in every category.

### Notes
- Chose Option 1 (the "conservative fix") from the issue. Option 2 (per-attribute opt-in) would require a richer attribute model and is left as a follow-up.
- All 2054 unit tests pass; black, flake8, mypy, and pyright all green.