### PR TITLE
fix(cloudaz-auth): require id_token by default, opt-in access_token fallback

### DIFF
--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -206,9 +206,11 @@ class CloudAzAuth(httpx.Auth):
     ``id_token``; per the CloudAz documentation, the ``id_token`` is the
     value sent in the ``Authorization: Bearer …`` header. ``CloudAzAuth``
     uses ``id_token`` as the bearer credential and keeps ``refresh_token``
-    for silent re-auth. When a token response omits ``id_token``
-    (non-conforming server) the SDK logs a warning and falls back to
-    ``access_token`` for transport continuity.
+    for silent re-auth. By default, a token response that omits
+    ``id_token`` raises :class:`AuthenticationError` so misconfigured OIDC
+    deployments fail loudly. Set ``allow_access_token_fallback=True`` to
+    instead log a warning and fall back to ``access_token`` for transport
+    continuity against known-broken servers.
 
     Supports an optional pluggable :class:`TokenCache` backend. Expiry is
     tracked as absolute UTC epoch seconds so that cached tokens survive
@@ -246,6 +248,7 @@ class CloudAzAuth(httpx.Auth):
         self._cache_key = f"{token_url}|{username}|{client_id}|cloudaz"
         self._lock = threading.Lock()
         self.refresh_token_lifetime: int | None = None
+        self.allow_access_token_fallback: bool = False
 
         self._id_token: str | None = None
         self._access_token: str | None = None
@@ -474,13 +477,24 @@ class CloudAzAuth(httpx.Auth):
         id_token_raw = body.get("id_token")
         if isinstance(id_token_raw, str):
             id_token = id_token_raw
-        else:
+        elif self.allow_access_token_fallback:
             logger.warning(
                 "cloudaz auth: token response missing id_token;"
-                " falling back to access_token. The server is not"
-                " conforming to the CloudAz OIDC contract.",
+                " falling back to access_token (allow_access_token_fallback=True)."
+                " The server is not conforming to the CloudAz OIDC contract.",
             )
             id_token = access_token
+        else:
+            raise AuthenticationError(
+                "Token response missing id_token. The CloudAz API requires"
+                " the OIDC id_token as the bearer credential. Set"
+                " allow_access_token_fallback=True to permit using"
+                " access_token against non-conforming servers.",
+                status_code=response.status_code,
+                response_body=response.text,
+                request_method=_HTTP_POST,
+                request_url=self._token_url,
+            )
         refresh_token_raw = body.get("refresh_token")
         refresh_token = (
             refresh_token_raw

--- a/src/nextlabs_sdk/_cloudaz/_async_client.py
+++ b/src/nextlabs_sdk/_cloudaz/_async_client.py
@@ -40,6 +40,7 @@ class AsyncCloudAzClient:
         token_cache: TokenCache | None = None,
         auth: httpx.Auth | None = None,
         refresh_token_lifetime: int | None = None,
+        allow_access_token_fallback: bool = False,
     ) -> None:
         config = http_config or HttpConfig()
         if auth is None:
@@ -56,6 +57,7 @@ class AsyncCloudAzClient:
                 token_cache=cache,
             )
             auth.refresh_token_lifetime = refresh_token_lifetime
+            auth.allow_access_token_fallback = allow_access_token_fallback
         self._client = transport_mod.create_async_http_client(
             base_url=base_url,
             auth=auth,

--- a/src/nextlabs_sdk/_cloudaz/_client.py
+++ b/src/nextlabs_sdk/_cloudaz/_client.py
@@ -40,6 +40,7 @@ class CloudAzClient:
         token_cache: TokenCache | None = None,
         auth: httpx.Auth | None = None,
         refresh_token_lifetime: int | None = None,
+        allow_access_token_fallback: bool = False,
     ) -> None:
         config = http_config or HttpConfig()
         if auth is None:
@@ -56,6 +57,7 @@ class CloudAzClient:
                 token_cache=cache,
             )
             auth.refresh_token_lifetime = refresh_token_lifetime
+            auth.allow_access_token_fallback = allow_access_token_fallback
         self._client = transport_mod.create_http_client(
             base_url=base_url,
             auth=auth,

--- a/tests/test_async_cloudaz_client.py
+++ b/tests/test_async_cloudaz_client.py
@@ -137,3 +137,26 @@ def test_async_authenticate_raises_when_custom_auth():
         assert "custom auth" in exc.message.lower()
     else:
         raise AssertionError("expected AuthenticationError")
+
+
+def test_async_client_forwards_allow_access_token_fallback():
+    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+
+    _stub_transport()
+    client = AsyncCloudAzClient(
+        base_url=BASE_URL,
+        username="admin",
+        password="secret",
+        allow_access_token_fallback=True,
+    )
+    assert isinstance(client._auth, CloudAzAuth)
+    assert client._auth.allow_access_token_fallback is True
+
+
+def test_async_client_default_disallows_access_token_fallback():
+    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+
+    _stub_transport()
+    client = _make_client()
+    assert isinstance(client._auth, CloudAzAuth)
+    assert client._auth.allow_access_token_fallback is False

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -26,6 +26,7 @@ def _make_auth(
     password: str | None = "secret",
     token_cache: TokenCache | None = None,
     lifetime: int | None = None,
+    allow_access_token_fallback: bool = False,
 ) -> CloudAzAuth:
     kwargs: dict[str, Any] = dict(
         token_url=TOKEN_URL,
@@ -38,6 +39,7 @@ def _make_auth(
     auth = CloudAzAuth(**kwargs)
     if lifetime is not None:
         auth.refresh_token_lifetime = lifetime
+    auth.allow_access_token_fallback = allow_access_token_fallback
     return auth
 
 
@@ -767,11 +769,25 @@ def test_cache_persists_both_access_and_id_token():
     assert saved.id_token == "IDT-1"
 
 
-def test_response_missing_id_token_falls_back_to_access_token_with_warning(
+def test_response_missing_id_token_raises_when_fallback_disabled():
+    when(time).time().thenReturn(float(0))
+    auth = _make_auth()
+
+    flow = auth.auth_flow(_api_request())
+    next(flow)
+    with pytest.raises(exceptions.AuthenticationError) as excinfo:
+        flow.send(
+            _make_token_response(access_token="AT-only", include_id_token=False),
+        )
+
+    assert "id_token" in str(excinfo.value)
+
+
+def test_response_missing_id_token_falls_back_when_opt_in(
     caplog: pytest.LogCaptureFixture,
 ):
     when(time).time().thenReturn(float(0))
-    auth = _make_auth()
+    auth = _make_auth(allow_access_token_fallback=True)
     caplog.set_level(logging.WARNING, logger="nextlabs_sdk")
 
     flow = auth.auth_flow(_api_request())

--- a/tests/test_cloudaz_client.py
+++ b/tests/test_cloudaz_client.py
@@ -127,3 +127,26 @@ def test_authenticate_raises_when_custom_auth_override():
         assert "custom auth" in exc.message.lower()
     else:
         raise AssertionError("expected AuthenticationError")
+
+
+def test_client_forwards_allow_access_token_fallback():
+    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+
+    _stub_transport()
+    client = CloudAzClient(
+        base_url=BASE_URL,
+        username="admin",
+        password="secret",
+        allow_access_token_fallback=True,
+    )
+    assert isinstance(client._auth, CloudAzAuth)
+    assert client._auth.allow_access_token_fallback is True
+
+
+def test_client_default_disallows_access_token_fallback():
+    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+
+    _stub_transport()
+    client = _make_client()
+    assert isinstance(client._auth, CloudAzAuth)
+    assert client._auth.allow_access_token_fallback is False


### PR DESCRIPTION
Closes #91

## Summary

`CloudAzAuth` previously silently fell back to `access_token` in the `Authorization: Bearer …` header when the OIDC token endpoint returned no `id_token` — only a warning log was emitted. Per the CloudAz docs, the `id_token` is what must be sent, so misconfigured OIDC deployments were invisible in production.

## Change (option 2 from the issue — recommended)

- Default behavior is now a hard error: missing `id_token` raises `AuthenticationError`.
- New opt-in flag `allow_access_token_fallback: bool = False` on `CloudAzClient` and `AsyncCloudAzClient`, mirrored as a public attribute on `CloudAzAuth` (same shape as `refresh_token_lifetime`). When set to `True`, the original warning + fallback to `access_token` is preserved as an escape hatch for known-broken servers.
- Docstring updated to reflect the new contract.

## Tests

- Existing fallback test split into two:
  - missing `id_token` + flag off → raises `AuthenticationError` (default)
  - missing `id_token` + flag on → warns + uses `access_token`
- New tests verify both clients forward the flag to `CloudAzAuth`.

```
[ok] black / flake8 / mypy / pyright
2059 passed, 97 xfailed
```