### PR TITLE
fix(retry): support RFC 7231 HTTP-date Retry-After header

### DIFF
--- a/src/nextlabs_sdk/_retry_policy.py
+++ b/src/nextlabs_sdk/_retry_policy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import math
 import random
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import httpx
 
@@ -14,7 +16,12 @@ _RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
 _RETRYABLE_STATUS_FLOOR = 500
 _RATE_LIMIT_STATUS = 429
 _BACKOFF_BASE = 2
+_NO_DELAY: float = 0
 _RNG = random.SystemRandom()
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=timezone.utc)
 
 
 class RetryPolicy:
@@ -70,14 +77,35 @@ class RetryPolicy:
         header = response.headers.get("retry-after")
         if header is None:
             return None
-        try:
-            parsed_value = float(header)
-        except ValueError:
-            return None
-        if not math.isfinite(parsed_value):
+        parsed_value = _parse_delay_seconds(header)
+        if parsed_value is None:
+            parsed_value = _parse_http_date_seconds(header)
+        if parsed_value is None or not math.isfinite(parsed_value):
             return None
         return parsed_value
 
     def _backoff_delay(self, attempt: int) -> float:
         exp_delay = min(self._base_delay * (_BACKOFF_BASE**attempt), self._max_delay)
         return _RNG.uniform(0, exp_delay)
+
+
+def _parse_delay_seconds(header: str) -> float | None:
+    try:
+        return float(header)
+    except ValueError:
+        return None
+
+
+def _parse_http_date_seconds(header: str) -> float | None:
+    """Parse an RFC 7231 HTTP-date and return seconds until that instant.
+
+    Returns ``None`` for malformed dates so the caller can fall back to
+    exponential backoff. Past dates are clamped to ``0`` per RFC 7231 §7.1.3.
+    """
+    try:
+        target = parsedate_to_datetime(header)
+    except (TypeError, ValueError):
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=timezone.utc)
+    return max(_NO_DELAY, (target - _now_utc()).total_seconds())

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import itertools
 import math
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
+from mockito import when
 
+from nextlabs_sdk import _retry_policy as retry_policy_module
 from nextlabs_sdk._retry_policy import RetryPolicy
 
 _MAX_DELAY = 10.0
@@ -74,6 +77,57 @@ def test_huge_retry_after_does_not_stall() -> None:
 def test_non_finite_retry_after_falls_through_to_backoff(value: str) -> None:
     policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
     response = _make_response(429, headers={"retry-after": value})
+
+    delay = policy.next_delay(0, response, None)
+
+    _assert_within_bounds(delay, _MAX_DELAY)
+
+
+# ── next_delay: HTTP-date Retry-After (RFC 7231 §7.1.3) ──
+
+
+def _freeze_now(now: datetime) -> None:
+    when(retry_policy_module)._now_utc().thenReturn(now)
+
+
+def test_http_date_retry_after_in_future_returns_delta_seconds() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    _freeze_now(now)
+    future = now + timedelta(seconds=7)
+    header = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": header})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(7.0)
+
+
+def test_http_date_retry_after_in_past_clamped_to_zero() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    _freeze_now(now)
+    past = now - timedelta(seconds=60)
+    header = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0)
+    response = _make_response(429, headers={"retry-after": header})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(0)
+
+
+def test_http_date_retry_after_far_future_clamped_to_max_delay() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    _freeze_now(now)
+    far = now + timedelta(hours=1)
+    header = far.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(429, headers={"retry-after": header})
+
+    assert policy.next_delay(0, response, None) == pytest.approx(_MAX_DELAY)
+
+
+def test_malformed_http_date_falls_through_to_backoff() -> None:
+    policy = RetryPolicy(max_retries=3, base_delay=1.0, max_delay=_MAX_DELAY)
+    response = _make_response(
+        429, headers={"retry-after": "Wed, 99 Foo 9999 99:99:99 GMT"}
+    )
 
     delay = policy.next_delay(0, response, None)
 


### PR DESCRIPTION
Closes #92

Adds support for the HTTP-date form of `Retry-After` (RFC 7231 §7.1.3) in `RetryPolicy._parse_retry_after`. Previously only `delay-seconds` was honoured; HTTP-date headers fell through to exponential backoff.

## Changes
- `_retry_policy.py`: parse HTTP-date via `email.utils.parsedate_to_datetime`, compute delta from injectable `_now_utc()`, clamp past dates to `0`.
- Tests: future date returns delta, past date clamped to 0, far-future clamped to `max_delay`, malformed date falls through to backoff.

Existing invariants (non-negative, bounded by `max_delay`, finite) still hold.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>