### PR TITLE
fix(pdp): declare xmlns:xsi and xsi:schemaLocation on XACML Request

### DIFF
--- a/src/nextlabs_sdk/_pdp/_xml_serializer.py
+++ b/src/nextlabs_sdk/_pdp/_xml_serializer.py
@@ -29,6 +29,11 @@ from nextlabs_sdk._pdp._response_models import (
 from nextlabs_sdk._pdp._status_check import raise_if_not_ok
 
 _XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+_XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
+_XACML_SCHEMA_URL = (
+    "http://docs.oasis-open.org/xacml/3.0/xacml-core-v3-schema-wd-17.xsd"
+)
+_XACML_SCHEMA_LOCATION = f"{_XACML_NS} {_XACML_SCHEMA_URL}"
 _ATTRIBUTE_TAG = "Attribute"
 _ATTRIBUTE_VALUE_TAG = "AttributeValue"
 _ATTRIBUTE_ID_KEY = "AttributeId"
@@ -165,7 +170,9 @@ def _ns(tag: str) -> str:
 
 def _make_request_element(return_policy_ids: bool) -> ET.Element:
     ET.register_namespace("", _XACML_NS)
+    ET.register_namespace("xsi", _XSI_NS)
     root = ET.Element(_ns("Request"))
+    root.set(f"{{{_XSI_NS}}}schemaLocation", _XACML_SCHEMA_LOCATION)
     root.set(
         "ReturnPolicyIdList",
         "true" if return_policy_ids else "false",

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -31,6 +31,11 @@ from nextlabs_sdk._pdp._xml_serializer import (
 from nextlabs_sdk.exceptions import PdpStatusError
 
 XACML_NS = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
+XACML_SCHEMA_LOCATION = (
+    "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+    " http://docs.oasis-open.org/xacml/3.0/xacml-core-v3-schema-wd-17.xsd"
+)
 _OK_URN = "urn:oasis:names:tc:xacml:1.0:status:ok"
 
 
@@ -99,6 +104,29 @@ def test_xml_serialize_subject_attribute_values():
             assert value_el.text == "user@example.com"
             return
     raise AssertionError("Subject category not found")
+
+
+def test_xml_serialize_eval_request_declares_xsi_schema_location():
+    raw = serialize_eval_request(_make_eval_request())
+    root = _parse_xml(raw)
+
+    assert root.attrib.get(f"{{{XSI_NS}}}schemaLocation") == XACML_SCHEMA_LOCATION
+    assert b'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' in raw
+    assert b"xsi:schemaLocation=" in raw
+
+
+def test_xml_serialize_permissions_request_declares_xsi_schema_location():
+    request = PermissionsRequest(
+        subject=Subject(id="u"),
+        resource=Resource(id="r", type="t"),
+        application=Application(id="app"),
+    )
+    raw = serialize_permissions_request(request)
+    root = _parse_xml(raw)
+
+    assert root.attrib.get(f"{{{XSI_NS}}}schemaLocation") == XACML_SCHEMA_LOCATION
+    assert b'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' in raw
+    assert b"xsi:schemaLocation=" in raw
 
 
 def test_xml_serialize_permissions_no_action():


### PR DESCRIPTION
Closes #94

The PDP XML envelope now emits the `xmlns:xsi` namespace and the `xsi:schemaLocation` attribute pointing at the XACML 3.0 core schema, matching the canonical sample in `docs/nextlabs_official/pdp_api.md`.

No runtime impact on the PDP; restores the advisory hints that downstream XSD-based validators rely on.

## Changes
- `_pdp/_xml_serializer.py`: register `xsi` prefix and set `xsi:schemaLocation` on the root `<Request>` element (applies to both eval and permissions requests via shared `_make_request_element`).
- `tests/test_xml_serializer.py`: new tests asserting both attributes appear on the serialized envelope for eval and permissions requests.

## Verification
- `python ./tools/tests.py --short` → 2069 passed
- `python ./tools/checks.py --short` on changed files → black/flake8/mypy/pyright all green