### PR TITLE
feat(cloudaz): publicly re-export ReporterAuditLogEntry, SavedSearch, SearchCriteria

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/__init__.py
@@ -81,10 +81,22 @@ from nextlabs_sdk._cloudaz._report_models import (
     SaveInfo as SaveInfo,
 )
 from nextlabs_sdk._cloudaz._report_models import (
+    SavedReportCriteria as SavedReportCriteria,
+)
+from nextlabs_sdk._cloudaz._report_models import (
     UserGroup as UserGroup,
 )
 from nextlabs_sdk._cloudaz._report_models import (
     WidgetData as WidgetData,
+)
+from nextlabs_sdk._cloudaz._reporter_audit_log_models import (
+    ReporterAuditLogEntry as ReporterAuditLogEntry,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SavedSearch as SavedSearch,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SearchCriteria as SearchCriteria,
 )
 from nextlabs_sdk._cloudaz._system_config_models import (
     SystemConfig as SystemConfig,

--- a/src/nextlabs_sdk/_cloudaz/_report_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_report_models.py
@@ -71,7 +71,7 @@ class SaveInfo(BaseModel):
     group_ids: list[int] | None = None
 
 
-class ReportCriteria(BaseModel):
+class SavedReportCriteria(BaseModel):
     """Full report criteria including filters, headers, ordering, and paging."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
@@ -85,6 +85,9 @@ class ReportCriteria(BaseModel):
     group_by: list[str] | None = None
     aggregators: list[FilterField] | None = None
     save_info: SaveInfo | None = None
+
+
+ReportCriteria = SavedReportCriteria
 
 
 class ReportWidget(BaseModel):
@@ -107,7 +110,7 @@ class PolicyActivityReportRequest(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    criteria: ReportCriteria
+    criteria: SavedReportCriteria
     widgets: list[ReportWidget] | None = None
 
 
@@ -147,7 +150,7 @@ class PolicyActivityReportDetail(BaseModel):
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    criteria: ReportCriteria
+    criteria: SavedReportCriteria
     widgets: list[ReportWidget]
 
 

--- a/src/nextlabs_sdk/cloudaz/__init__.py
+++ b/src/nextlabs_sdk/cloudaz/__init__.py
@@ -86,10 +86,22 @@ from nextlabs_sdk._cloudaz._report_models import (
     SaveInfo as SaveInfo,
 )
 from nextlabs_sdk._cloudaz._report_models import (
+    SavedReportCriteria as SavedReportCriteria,
+)
+from nextlabs_sdk._cloudaz._report_models import (
     UserGroup as UserGroup,
 )
 from nextlabs_sdk._cloudaz._report_models import (
     WidgetData as WidgetData,
+)
+from nextlabs_sdk._cloudaz._reporter_audit_log_models import (
+    ReporterAuditLogEntry as ReporterAuditLogEntry,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SavedSearch as SavedSearch,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SearchCriteria as SearchCriteria,
 )
 from nextlabs_sdk._cloudaz._system_config_models import (
     SystemConfig as SystemConfig,

--- a/tests/architecture/test_issue_95_invariants.py
+++ b/tests/architecture/test_issue_95_invariants.py
@@ -1,0 +1,56 @@
+"""Architectural invariants for issue #95.
+
+Pins the public CloudAz surface so the types that appear on
+``ReporterAuditLogService`` and ``PolicySearchService`` stay importable
+from ``nextlabs_sdk.cloudaz``, and keeps the OpenAPI-aligned name
+``SavedReportCriteria`` in sync with its backward-compatible alias
+``ReportCriteria``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_reporter_audit_log_entry_is_publicly_re_exported() -> None:
+    module = importlib.import_module("nextlabs_sdk.cloudaz")
+    from nextlabs_sdk._cloudaz._reporter_audit_log_models import (
+        ReporterAuditLogEntry as Internal,
+    )
+
+    assert module.ReporterAuditLogEntry is Internal
+
+
+def test_saved_search_is_publicly_re_exported() -> None:
+    module = importlib.import_module("nextlabs_sdk.cloudaz")
+    from nextlabs_sdk._cloudaz._search import SavedSearch as Internal
+
+    assert module.SavedSearch is Internal
+
+
+def test_search_criteria_is_publicly_re_exported() -> None:
+    module = importlib.import_module("nextlabs_sdk.cloudaz")
+    from nextlabs_sdk._cloudaz._search import SearchCriteria as Internal
+
+    assert module.SearchCriteria is Internal
+
+
+def test_saved_report_criteria_is_publicly_re_exported() -> None:
+    module = importlib.import_module("nextlabs_sdk.cloudaz")
+    from nextlabs_sdk._cloudaz._report_models import (
+        SavedReportCriteria as Internal,
+    )
+
+    assert module.SavedReportCriteria is Internal
+
+
+def test_report_criteria_is_alias_for_saved_report_criteria() -> None:
+    module = importlib.import_module("nextlabs_sdk.cloudaz")
+
+    assert module.ReportCriteria is module.SavedReportCriteria
+
+
+def test_saved_report_criteria_canonical_name_matches_openapi() -> None:
+    from nextlabs_sdk._cloudaz._report_models import SavedReportCriteria
+
+    assert SavedReportCriteria.__name__ == "SavedReportCriteria"


### PR DESCRIPTION
Closes #95.

## Changes

- Re-export from `nextlabs_sdk.cloudaz`:
  - `ReporterAuditLogEntry` (used by `ReporterAuditLogService`)
  - `SavedSearch` (used by `PolicySearchService.get_saved_search` / `list_saved_searches`)
  - `SearchCriteria` (required arg of `PolicySearchService.search`)
- Rename internal `ReportCriteria` → `SavedReportCriteria` to match OpenAPI schema `SavedReportCriteria`. A module-level alias `ReportCriteria = SavedReportCriteria` preserves backward compatibility for existing imports (including callers using `.model_validate` etc.).
- Both names are re-exported from `nextlabs_sdk.cloudaz`.

## Tests

New architectural invariants in `tests/architecture/test_issue_95_invariants.py` pin:

- All three re-exports resolve to the same object as the underscore-module definitions.
- `SavedReportCriteria` is publicly re-exported.
- `ReportCriteria is SavedReportCriteria` (alias).
- Canonical class name equals `"SavedReportCriteria"` for OpenAPI parity.

Full suite: 2075 passed, 96.22% coverage. Checks: black/flake8/mypy/pyright all green. No suppressions used.