### PR TITLE
fix(envelope): emit debug log naming each decode failure mode

### DIFF
--- a/src/nextlabs_sdk/_envelope.py
+++ b/src/nextlabs_sdk/_envelope.py
@@ -20,9 +20,16 @@ designed for use from both the success parsers in
 
 from __future__ import annotations
 
+import logging
 from typing import Mapping
 
 import httpx
+
+logger = logging.getLogger("nextlabs_sdk")
+
+
+def _log_reason(reason: str) -> None:
+    logger.debug("envelope decode failed: %s", reason, extra={"reason": reason})
 
 
 def envelope_from_mapping(
@@ -35,13 +42,25 @@ def envelope_from_mapping(
     string. Returns ``(status_code, None)`` when ``statusCode`` is a
     string but ``message`` is missing, not a string, or an empty string.
 
+    Each ``(None, None)`` return path emits a debug-level log record on
+    the ``nextlabs_sdk`` logger with a structured ``reason`` field
+    (``body_not_mapping``, ``missing_status_code``, or
+    ``status_code_not_string``) to aid diagnosis of surprising server
+    responses.
+
     Never raises.
     """
     if not isinstance(body, Mapping):
+        _log_reason("body_not_mapping")
+        return None, None
+
+    if "statusCode" not in body:
+        _log_reason("missing_status_code")
         return None, None
 
     raw_code = body.get("statusCode")
     if not isinstance(raw_code, str):
+        _log_reason("status_code_not_string")
         return None, None
 
     raw_message = body.get("message")
@@ -61,11 +80,17 @@ def envelope_from_response(
     is a string but ``message`` is missing, not a string, or an empty
     string.
 
+    Each ``(None, None)`` return path emits a debug-level log record on
+    the ``nextlabs_sdk`` logger with a structured ``reason`` field
+    (e.g. ``body_not_json``) — see :func:`envelope_from_mapping` for the
+    mapping-level reasons.
+
     Never raises; safe to call on any ``httpx.Response``.
     """
     try:
         body = response.json()
     except ValueError:
+        _log_reason("body_not_json")
         return None, None
 
     return envelope_from_mapping(body)

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import httpx
 import pytest
 
@@ -89,3 +91,40 @@ class TestEnvelopeFromMapping:
             None,
             None,
         )
+
+
+class TestEnvelopeDebugLogging:
+    """Each (None, None) path emits a distinct debug-level reason (issue #96)."""
+
+    def _reasons(self, caplog: pytest.LogCaptureFixture) -> list[str | None]:
+        return [
+            record.__dict__.get("reason")
+            for record in caplog.records
+            if record.name == "nextlabs_sdk" and record.levelno == logging.DEBUG
+        ]
+
+    def test_logs_body_not_json(self, caplog: pytest.LogCaptureFixture):
+        response = httpx.Response(500, text="<html>not json</html>")
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            envelope_from_response(response)
+        assert "body_not_json" in self._reasons(caplog)
+
+    def test_logs_body_not_mapping(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            envelope_from_mapping(["statusCode", "6000"])
+        assert "body_not_mapping" in self._reasons(caplog)
+
+    def test_logs_missing_status_code(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            envelope_from_mapping({"message": "no code"})
+        assert "missing_status_code" in self._reasons(caplog)
+
+    def test_logs_status_code_not_string(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            envelope_from_mapping({"statusCode": 1003, "message": "m"})
+        assert "status_code_not_string" in self._reasons(caplog)
+
+    def test_success_path_does_not_log(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG, logger="nextlabs_sdk"):
+            envelope_from_mapping({"statusCode": "6000", "message": "boom"})
+        assert self._reasons(caplog) == []


### PR DESCRIPTION
Closes #96.

Each `(None, None)` return path in `_envelope.py` now emits a `DEBUG` log record on the `nextlabs_sdk` logger with a structured `reason` extra field, making it possible to diagnose surprising server responses without changing the public return contract.

Reasons emitted:
- `body_not_json` — `envelope_from_response`, body failed JSON decode
- `body_not_mapping` — decoded body is not a JSON object
- `missing_status_code` — mapping has no `statusCode` key
- `status_code_not_string` — `statusCode` is present but not a `str`

This is issue #96's option 1 (minimally invasive). Public signature and existing call sites are unchanged. All 21 envelope tests pass (4 new), full suite green, all checks pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>