### PR TITLE
style(token-cache): make NullTokenCache stub bodies explicit with ...

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_null_token_cache.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_null_token_cache.py
@@ -9,12 +9,15 @@ class NullTokenCache(TokenCache):
 
     def load(self, key: str) -> CachedToken | None:
         """Always return None."""
+        ...
 
     def save(self, key: str, token: CachedToken) -> None:
         """No-op."""
+        ...
 
     def delete(self, key: str) -> None:
         """No-op."""
+        ...
 
     def keys(self) -> list[str]:
         """Always return an empty list."""


### PR DESCRIPTION
Closes #97.

Replaces the implicit empty bodies of `NullTokenCache.load`, `.save`, and `.delete` with explicit `...` (Ellipsis) statements after their docstrings, so the stubs are visually consistent with the sibling `.keys()` method (which has an explicit `return []`).

### Why `...` and not `pass` / `return None`

The issue suggested either `pass` or `...`. Tried both alternatives first:

- `pass` after a docstring is redundant and no cleaner than the original.
- Explicit `return None` / bare `return` trips wemake's **WPS324** ("inconsistent return statement") because none of the surrounding methods need a return for correctness.

`...` is the conventional Python stub-body marker, satisfies the readability concern raised in the issue, and passes all linters (black, flake8 + wemake, mypy, pyright) without any `# noqa` / `type: ignore` suppressions — per CLAUDE.md.

### Behavior

No change. The methods still return `None` implicitly, exactly as before. Existing tests in `tests/test_null_token_cache.py` pass unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>