### PR TITLE
fix(cli): preserve persisted verify_ssl on silent re-login

### DIFF
--- a/src/nextlabs_sdk/_cli/_account_resolver.py
+++ b/src/nextlabs_sdk/_cli/_account_resolver.py
@@ -73,6 +73,35 @@ def load_account_prefs(
     return store.load(legacy)
 
 
+def effective_verify_ssl(
+    store: AccountPreferencesStore,
+    account: ResolvedAccount | None,
+    ctx_verify: bool | None,
+) -> bool:
+    """Return the ``verify_ssl`` value the CLI should actually use.
+
+    Precedence — mirrored by both the runtime HTTP config and login
+    persistence so the two never disagree:
+
+    1. Explicit CLI flag (``ctx_verify`` / ``--verify`` / ``--no-verify``).
+    2. Persisted account preference (written by a previous login).
+    3. Default ``True``.
+
+    When login persists its result it must go through this helper so
+    a silent re-login (which uses the persisted preference to build
+    the HTTP client) does not then overwrite that same preference with
+    the default ``True``.
+    """
+    if ctx_verify is not None:
+        return ctx_verify
+    if account is None:
+        return True
+    entry = load_account_prefs(store, account)
+    if entry is None:
+        return True
+    return entry.verify_ssl
+
+
 def resolve_account(ctx: CliContext) -> ResolvedAccount | None:
     """Resolve the effective account identifiers for ``ctx``.
 

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -20,9 +20,11 @@ from nextlabs_sdk._cli._account_menu import (
 )
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_resolver import (
+    ResolvedAccount,
     build_active_store,
     build_file_cache,
     build_prefs_store,
+    effective_verify_ssl,
 )
 from nextlabs_sdk._cli._account_status_label import account_status_and_refreshable
 from nextlabs_sdk._cli._context import CliContext
@@ -309,8 +311,15 @@ def _prefs_key(account: AccountIdentifier) -> str:
 
 
 def _save_prefs(cli_ctx: CliContext, account: AccountIdentifier) -> None:
-    verify_ssl = True if cli_ctx.verify is None else cli_ctx.verify
-    build_prefs_store(cli_ctx).save(
+    resolved = ResolvedAccount(
+        base_url=account.base_url,
+        username=account.username,
+        client_id=account.client_id,
+        kind=account.kind,
+    )
+    prefs_store = build_prefs_store(cli_ctx)
+    verify_ssl = effective_verify_ssl(prefs_store, resolved, cli_ctx.verify)
+    prefs_store.save(
         _prefs_key(account),
         AccountPreferences(verify_ssl=verify_ssl),
     )

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -9,11 +9,11 @@ import typer
 from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
 from nextlabs_sdk._auth._static_token_auth import StaticTokenAuth
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
-from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
     build_file_cache,
     build_prefs_store,
+    effective_verify_ssl,
     load_account_prefs,
     resolve_account,
 )
@@ -106,31 +106,10 @@ def _prompt_url_if_tty(label: str) -> str | None:
     return typer.prompt(label)
 
 
-def _persisted_verify(
-    prefs: AccountPreferencesStore,
-    account: ResolvedAccount,
-) -> bool | None:
-    entry = load_account_prefs(prefs, account)
-    return None if entry is None else entry.verify_ssl
-
-
-def _effective_verify_ssl(
-    ctx: CliContext,
-    account: ResolvedAccount | None,
-) -> bool:
-    if ctx.verify is not None:
-        return ctx.verify
-    if account is not None:
-        persisted = _persisted_verify(build_prefs_store(ctx), account)
-        if persisted is not None:
-            return persisted
-    return True
-
-
 def _http_config(ctx: CliContext, account: ResolvedAccount | None) -> HttpConfig:
     return HttpConfig(
         timeout=ctx.timeout,
-        verify_ssl=_effective_verify_ssl(ctx, account),
+        verify_ssl=effective_verify_ssl(build_prefs_store(ctx), account, ctx.verify),
         verbose=ctx.verbose,
     )
 

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -14,9 +14,11 @@ from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._cli._account_menu import AccountIdentifier, cache_key_for
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_resolver import (
+    ResolvedAccount,
     build_active_store,
     build_file_cache,
     build_prefs_store,
+    effective_verify_ssl,
 )
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output import print_success
@@ -110,7 +112,23 @@ def _attempt_login(cli_ctx: CliContext) -> _PersistedLogin:
         auth_base_url=auth_base_url,
         token_url=None,
     )
-    verify_ssl = True if cli_ctx.verify is None else cli_ctx.verify
+    account = AccountIdentifier(
+        base_url=auth_base_url or pdp_url,
+        username="",
+        client_id=client_id,
+        kind=_KIND_PDP,
+    )
+    resolved = ResolvedAccount(
+        base_url=account.base_url,
+        username=account.username,
+        client_id=account.client_id,
+        kind=account.kind,
+    )
+    verify_ssl = effective_verify_ssl(
+        build_prefs_store(cli_ctx),
+        resolved,
+        cli_ctx.verify,
+    )
     payload = _mint_client_credentials_token(
         token_url=token_url,
         client_id=client_id,
@@ -119,12 +137,6 @@ def _attempt_login(cli_ctx: CliContext) -> _PersistedLogin:
         timeout=cli_ctx.timeout,
     )
 
-    account = AccountIdentifier(
-        base_url=auth_base_url or pdp_url,
-        username="",
-        client_id=client_id,
-        kind=_KIND_PDP,
-    )
     return _PersistedLogin(
         account=account,
         payload=payload,

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -284,6 +284,68 @@ def test_login_persists_verify_false_when_no_verify_passed(login_ctx):
     assert entry.verify_ssl is False
 
 
+_CLOUDAZ_PREFS_KEY = "https://example.com|admin|ControlCenterOIDCClient|cloudaz"
+
+_LOGIN_BASE_OPTS = (
+    "--base-url",
+    "https://example.com",
+    "--username",
+    "admin",
+    "--password",
+    "secret",
+    "auth",
+    "login",
+)
+
+
+def _load_cloudaz_prefs(cache_dir: str):
+    from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+
+    return AccountPreferencesStore(path=f"{cache_dir}/account_prefs.json").load(
+        _CLOUDAZ_PREFS_KEY,
+    )
+
+
+def test_login_without_flag_preserves_persisted_verify_ssl_false(login_ctx):
+    """Silent re-login must not overwrite a persisted ``verify_ssl=False``.
+
+    Regresses a bug where ``_save_prefs`` derived ``verify_ssl`` only
+    from the CLI flag, so a re-login on a self-signed host (whose
+    prior ``--no-verify`` had been remembered) silently flipped the
+    preference back to ``True`` — breaking the next CLI call.
+    """
+    import os
+
+    cache_dir = os.environ["NEXTLABS_CACHE_DIR"]
+
+    seed = runner.invoke(app, ["--no-verify", *_LOGIN_BASE_OPTS])
+    assert seed.exit_code == 0, seed.output
+
+    result = runner.invoke(app, list(_LOGIN_BASE_OPTS))
+
+    assert result.exit_code == 0, result.output
+    entry = _load_cloudaz_prefs(cache_dir)
+    assert entry is not None
+    assert entry.verify_ssl is False
+
+
+def test_login_with_explicit_verify_flag_overrides_persisted_false(login_ctx):
+    """An explicit ``--verify`` still wins over a persisted ``False``."""
+    import os
+
+    cache_dir = os.environ["NEXTLABS_CACHE_DIR"]
+
+    seed = runner.invoke(app, ["--no-verify", *_LOGIN_BASE_OPTS])
+    assert seed.exit_code == 0, seed.output
+
+    result = runner.invoke(app, ["--verify", *_LOGIN_BASE_OPTS])
+
+    assert result.exit_code == 0, result.output
+    entry = _load_cloudaz_prefs(cache_dir)
+    assert entry is not None
+    assert entry.verify_ssl is True
+
+
 def _wrap_ssl_transport_error() -> "Exception":
     import ssl
 

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -1028,3 +1028,116 @@ def test_pdp_login_ssl_retry_target_url_reflects_resolved_pdp_url(
 
     assert result.exit_code == 0, result.output
     assert observed_target == ["https://pdp.example"]
+
+
+_PDP_PREFS_KEY = "https://pdp.example||ccid|pdp"
+
+
+def _seed_pdp_prefs_verify_false(tmp_path: Path) -> AccountPreferencesStore:
+    from nextlabs_sdk._cli._account_preferences import AccountPreferences
+
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    store.save(
+        _PDP_PREFS_KEY,
+        AccountPreferences(
+            verify_ssl=False,
+            pdp_url="https://pdp.example",
+            pdp_auth_source="pdp",
+        ),
+    )
+    return store
+
+
+def test_pdp_login_without_flag_preserves_persisted_verify_ssl_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Silent PDP re-login must keep a persisted ``verify_ssl=False``.
+
+    Regresses the symmetric CloudAz bug: the PDP login derived the
+    ``verify_ssl`` it used for the token POST (and the pref it then
+    wrote) solely from the CLI flag, so a re-login without
+    ``--no-verify`` would attempt the request with TLS verification
+    on and then persist ``True`` even if the prior preference was
+    ``False``.
+    """
+    _isolate_cache(tmp_path, monkeypatch)
+    store = _seed_pdp_prefs_verify_false(tmp_path)
+    calls_verify: list[object] = []
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+
+    def _fake_post(*_args: object, **kwargs: object) -> object:
+        calls_verify.append(kwargs.get("verify"))
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls_verify == [False]
+    prefs = store.load(_PDP_PREFS_KEY)
+    assert prefs is not None
+    assert prefs.verify_ssl is False
+
+
+def test_pdp_login_with_explicit_verify_flag_overrides_persisted_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``--verify`` still wins over a persisted ``False``."""
+    _isolate_cache(tmp_path, monkeypatch)
+    store = _seed_pdp_prefs_verify_false(tmp_path)
+    calls_verify: list[object] = []
+    resp = _TokenResp(
+        {"access_token": "AT", "expires_in": 3600, "token_type": "bearer"},
+    )
+
+    def _fake_post(*_args: object, **kwargs: object) -> object:
+        calls_verify.append(kwargs.get("verify"))
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "--verify",
+            "--pdp-url",
+            "https://pdp.example",
+            "--client-id",
+            "ccid",
+            "--client-secret",
+            "S3cret",
+            "--pdp-auth",
+            "pdp",
+            "auth",
+            "login",
+            "--type",
+            "pdp",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls_verify == [True]
+    prefs = store.load(_PDP_PREFS_KEY)
+    assert prefs is not None
+    assert prefs.verify_ssl is True


### PR DESCRIPTION
Closes #118

## Problem

After a prior login persisted `verify_ssl=false` (via the SSL-retry
prompt or an explicit `--no-verify`), re-running `nextlabs auth login`
without a flag silently succeeded but overwrote the preference with
`true`. The next command (e.g. `nextlabs policies get`) then failed
with `CERTIFICATE_VERIFY_FAILED` against the same host.

## Root cause

`_auth_cmd._save_prefs` and `_pdp_login._attempt_login` derived the
persisted `verify_ssl` **only** from the CLI flag. On a silent
re-login, `_client_factory` had already consulted the persisted
`false` to build the HTTP client, so no SSL error occurred,
`SslRetryPrompter` never fired, and `used_ctx.verify` stayed
`None` — yet the save wrote `True`.

## Fix

Extract the precedence already used at runtime
(`ctx.verify` > persisted pref > `True`) into a single helper
`effective_verify_ssl` in `_account_resolver`. Use it from:

- `_client_factory._http_config` (unchanged behaviour; delegates to
  the helper)
- `_auth_cmd._save_prefs` (CloudAz login persistence)
- `_pdp_login._attempt_login` (PDP login persistence **and** the
  `httpx.post` verify argument)

One source of truth for runtime + persistence.

## Tests (TDD)

Four new tests. All were red before the fix:

- CloudAz: silent re-login keeps persisted `verify_ssl=False`.
- CloudAz: explicit `--verify` still overrides persisted `False`.
- PDP: silent re-login keeps persisted `verify_ssl=False` and uses
  `verify=False` for the token POST.
- PDP: explicit `--verify` overrides persisted `False`.

No `noqa` / `type: ignore` / `setup.cfg` changes.