### PR TITLE
feat(cloudaz)!: send access_token as bearer credential

### DIFF
--- a/src/nextlabs_sdk/_auth/_cloudaz_auth.py
+++ b/src/nextlabs_sdk/_auth/_cloudaz_auth.py
@@ -214,23 +214,20 @@ def _handle_refresh_failure(
 class CloudAzAuth(httpx.Auth):
     """OIDC password grant auth for the CloudAz Console API.
 
-    The OIDC token endpoint returns both ``access_token`` and
-    ``id_token``; per the CloudAz documentation, the ``id_token`` is the
-    value sent in the ``Authorization: Bearer …`` header. ``CloudAzAuth``
-    uses ``id_token`` as the bearer credential and keeps ``refresh_token``
-    for silent re-auth. By default, a token response that omits
-    ``id_token`` raises :class:`AuthenticationError` so misconfigured OIDC
-    deployments fail loudly. Set ``allow_access_token_fallback=True`` to
-    instead log a warning and fall back to ``access_token`` for transport
-    continuity against known-broken servers.
+    The OIDC token endpoint returns both ``access_token`` and, in some
+    deployments, ``id_token``. CloudAzAuth sends ``access_token`` in
+    the ``Authorization: Bearer …`` header: the Reporter microservice
+    under the same ``base_url`` rejects ``id_token`` with HTTP 403 and
+    accepts only ``access_token``, and the Console endpoints accept
+    either. This matches NextLabs' own developer portal "Try it out"
+    guidance, which documents pasting the ``access_token`` (prefixed
+    ``AT-``) as the bearer credential. Any ``id_token`` the server
+    returns is persisted to the cache for forward compatibility but
+    ignored for authentication.
 
     Supports an optional pluggable :class:`TokenCache` backend. Expiry is
     tracked as absolute UTC epoch seconds so that cached tokens survive
-    process restarts. Cache entries written by older SDK versions that
-    predate ``id_token`` support are restored without the bearer in
-    memory, so the next call silently refreshes and repopulates the
-    cache — a usable ``refresh_token`` is preserved to avoid an
-    interactive re-login.
+    process restarts.
 
     When ``refresh_token_lifetime`` is provided, the SDK records the
     refresh token's absolute expiry at every successful token
@@ -260,9 +257,7 @@ class CloudAzAuth(httpx.Auth):
         self._cache_key = f"{token_url}|{username}|{client_id}|cloudaz"
         self._lock = threading.Lock()
         self.refresh_token_lifetime: int | None = None
-        self.allow_access_token_fallback: bool = False
 
-        self._id_token: str | None = None
         self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._refresh_expires_at: float | None = None
@@ -275,11 +270,10 @@ class CloudAzAuth(httpx.Auth):
                 self._refresh_expires_at = _wall_to_monotonic(
                     cached.refresh_expires_at,
                 )
-            if cached.id_token is not None and not cached.is_expired(
+            if not cached.is_expired(
                 now=time.time(),
                 safety_margin=_EXPIRY_SAFETY_MARGIN,
             ):
-                self._id_token = cached.id_token
                 self._access_token = cached.access_token
                 self._expires_at = _wall_to_monotonic(cached.expires_at)
 
@@ -290,12 +284,12 @@ class CloudAzAuth(httpx.Auth):
         if not self._has_valid_token():
             yield from self._reauthenticate()
 
-        request.headers["Authorization"] = f"Bearer {self._id_token}"
+        request.headers["Authorization"] = f"Bearer {self._access_token}"
         response = yield request
 
         if response.status_code == _UNAUTHORIZED_STATUS or _is_spa_redirect(response):
             yield from self._reauthenticate()
-            request.headers["Authorization"] = f"Bearer {self._id_token}"
+            request.headers["Authorization"] = f"Bearer {self._access_token}"
             retried = yield request
             if _is_spa_redirect(retried):
                 raise AuthenticationError(
@@ -365,7 +359,9 @@ class CloudAzAuth(httpx.Auth):
 
     def _has_valid_token(self) -> bool:
         with self._lock:
-            return self._id_token is not None and time.monotonic() < self._expires_at
+            return (
+                self._access_token is not None and time.monotonic() < self._expires_at
+            )
 
     def _reauthenticate(self) -> Generator[httpx.Request, httpx.Response, None]:
         decision = self._refresh_decision()
@@ -492,26 +488,7 @@ class CloudAzAuth(httpx.Auth):
             context=" in token response",
         )
         id_token_raw = body.get("id_token")
-        if isinstance(id_token_raw, str):
-            id_token = id_token_raw
-        elif self.allow_access_token_fallback:
-            logger.warning(
-                "cloudaz auth: token response missing id_token;"
-                " falling back to access_token (allow_access_token_fallback=True)."
-                " The server is not conforming to the CloudAz OIDC contract.",
-            )
-            id_token = access_token
-        else:
-            raise AuthenticationError(
-                "Token response missing id_token. The CloudAz API requires"
-                " the OIDC id_token as the bearer credential. Set"
-                " allow_access_token_fallback=True to permit using"
-                " access_token against non-conforming servers.",
-                status_code=response.status_code,
-                response_body=response.text,
-                request_method=_HTTP_POST,
-                request_url=self._token_url,
-            )
+        id_token = id_token_raw if isinstance(id_token_raw, str) else None
         refresh_token_raw = body.get("refresh_token")
         refresh_token = (
             refresh_token_raw
@@ -534,7 +511,6 @@ class CloudAzAuth(httpx.Auth):
         )
 
         with self._lock:
-            self._id_token = id_token
             self._access_token = access_token
             self._refresh_token = refresh_token
             self._expires_at = mono_expires_at

--- a/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cached_token.py
@@ -46,17 +46,16 @@ class CachedToken:
     """A persisted OIDC token.
 
     Attributes:
-        access_token: The OAuth2 access_token returned by the token
-            endpoint. Retained for diagnostics and refresh flows;
-            CloudAz requests now authenticate with ``id_token``.
+        access_token: The OAuth2 ``access_token`` returned by the token
+            endpoint. Sent as the ``Authorization: Bearer …`` credential
+            on CloudAz API requests.
         refresh_token: Optional refresh_token for silent re-auth.
         expires_at: Absolute UTC epoch seconds at which the token expires.
         token_type: OAuth token type (typically ``"bearer"``).
         scope: Optional OAuth scope string.
-        id_token: OIDC ``id_token`` sent as the bearer credential on
-            CloudAz API requests. ``None`` on cache entries written by
-            older SDK versions; callers should treat such entries as
-            expired and trigger a refresh.
+        id_token: OIDC ``id_token`` echoed back by the token endpoint,
+            if any. Persisted for forward compatibility and diagnostics;
+            the SDK no longer uses it as the bearer credential.
         refresh_expires_at: Absolute UTC epoch seconds at which the
             refresh token is considered expired, or ``None`` when the
             SDK has no information (reactive mode).

--- a/src/nextlabs_sdk/_cloudaz/_async_client.py
+++ b/src/nextlabs_sdk/_cloudaz/_async_client.py
@@ -40,7 +40,6 @@ class AsyncCloudAzClient:  # noqa: WPS214
         token_cache: TokenCache | None = None,
         auth: httpx.Auth | None = None,
         refresh_token_lifetime: int | None = None,
-        allow_access_token_fallback: bool = False,
     ) -> None:
         config = http_config or HttpConfig()
         if auth is None:
@@ -57,7 +56,6 @@ class AsyncCloudAzClient:  # noqa: WPS214
                 token_cache=cache,
             )
             auth.refresh_token_lifetime = refresh_token_lifetime
-            auth.allow_access_token_fallback = allow_access_token_fallback
         self._client = transport_mod.create_async_http_client(
             base_url=base_url,
             auth=auth,

--- a/src/nextlabs_sdk/_cloudaz/_client.py
+++ b/src/nextlabs_sdk/_cloudaz/_client.py
@@ -40,7 +40,6 @@ class CloudAzClient:  # noqa: WPS214
         token_cache: TokenCache | None = None,
         auth: httpx.Auth | None = None,
         refresh_token_lifetime: int | None = None,
-        allow_access_token_fallback: bool = False,
     ) -> None:
         config = http_config or HttpConfig()
         if auth is None:
@@ -57,7 +56,6 @@ class CloudAzClient:  # noqa: WPS214
                 token_cache=cache,
             )
             auth.refresh_token_lifetime = refresh_token_lifetime
-            auth.allow_access_token_fallback = allow_access_token_fallback
         self._client = transport_mod.create_http_client(
             base_url=base_url,
             auth=auth,

--- a/tests/test_async_cloudaz_client.py
+++ b/tests/test_async_cloudaz_client.py
@@ -139,24 +139,8 @@ def test_async_authenticate_raises_when_custom_auth():
         raise AssertionError("expected AuthenticationError")
 
 
-def test_async_client_forwards_allow_access_token_fallback():
-    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+def test_async_client_rejects_allow_access_token_fallback_kwarg():
+    import inspect
 
-    _stub_transport()
-    client = AsyncCloudAzClient(
-        base_url=BASE_URL,
-        username="admin",
-        password="secret",
-        allow_access_token_fallback=True,
-    )
-    assert isinstance(client._auth, CloudAzAuth)
-    assert client._auth.allow_access_token_fallback is True
-
-
-def test_async_client_default_disallows_access_token_fallback():
-    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
-
-    _stub_transport()
-    client = _make_client()
-    assert isinstance(client._auth, CloudAzAuth)
-    assert client._auth.allow_access_token_fallback is False
+    sig = inspect.signature(AsyncCloudAzClient)
+    assert "allow_access_token_fallback" not in sig.parameters

--- a/tests/test_cloudaz_auth.py
+++ b/tests/test_cloudaz_auth.py
@@ -26,7 +26,6 @@ def _make_auth(
     password: str | None = "secret",
     token_cache: TokenCache | None = None,
     lifetime: int | None = None,
-    allow_access_token_fallback: bool = False,
 ) -> CloudAzAuth:
     kwargs: dict[str, Any] = dict(
         token_url=TOKEN_URL,
@@ -39,7 +38,6 @@ def _make_auth(
     auth = CloudAzAuth(**kwargs)
     if lifetime is not None:
         auth.refresh_token_lifetime = lifetime
-    auth.allow_access_token_fallback = allow_access_token_fallback
     return auth
 
 
@@ -537,7 +535,7 @@ def test_ensure_token_uses_password_grant_when_no_refresh():
     assert len(sent) == 1
     assert str(sent[0].url) == TOKEN_URL
     assert "grant_type=password" in sent[0].content.decode()
-    assert auth._id_token == "fresh"
+    assert auth._access_token == "fresh"
 
 
 def test_ensure_token_prefers_refresh_token_when_available():
@@ -551,7 +549,7 @@ def test_ensure_token_prefers_refresh_token_when_available():
     body = sent[0].content.decode()
     assert "grant_type=refresh_token" in body
     assert "refresh_token=RT-cached" in body
-    assert auth._id_token == "refreshed"
+    assert auth._access_token == "refreshed"
 
 
 def test_ensure_token_falls_back_to_password_when_refresh_fails():
@@ -570,7 +568,7 @@ def test_ensure_token_falls_back_to_password_when_refresh_fails():
     assert len(sent) == 2
     assert "grant_type=refresh_token" in sent[0].content.decode()
     assert "grant_type=password" in sent[1].content.decode()
-    assert auth._id_token == "pwd-grant"
+    assert auth._access_token == "pwd-grant"
 
 
 def test_ensure_token_raises_when_no_password_and_refresh_fails():
@@ -609,7 +607,7 @@ def test_ensure_token_async_fetches_and_caches():
     asyncio.run(auth.ensure_token_async(send))
 
     assert len(sent) == 1
-    assert auth._id_token == "async-fresh"
+    assert auth._access_token == "async-fresh"
 
 
 # ─────────────── Proactive refresh-token-lifetime tracking ───────────────
@@ -753,10 +751,10 @@ def test_logs_warning_on_terminal_refresh_failure(caplog: pytest.LogCaptureFixtu
         assert "RT-dead" not in record.getMessage()
 
 
-# ────────────────────────── id_token bearer (OIDC) ──────────────────────────
+# ──────────────────────── bearer credential (OAuth2) ────────────────────────
 
 
-def test_authorization_header_uses_id_token_not_access_token():
+def test_authorization_header_uses_access_token():
     _stub_clock(float(0))
     auth = _make_auth()
 
@@ -766,8 +764,8 @@ def test_authorization_header_uses_id_token_not_access_token():
         _make_token_response(access_token="AT-value", id_token="IDT-value"),
     )
 
-    assert api_request.headers["Authorization"] == "Bearer IDT-value"
-    assert "AT-value" not in api_request.headers["Authorization"]
+    assert api_request.headers["Authorization"] == "Bearer AT-value"
+    assert "IDT-value" not in api_request.headers["Authorization"]
 
 
 def test_cache_persists_both_access_and_id_token():
@@ -784,26 +782,10 @@ def test_cache_persists_both_access_and_id_token():
     assert saved.id_token == "IDT-1"
 
 
-def test_response_missing_id_token_raises_when_fallback_disabled():
+def test_response_missing_id_token_is_accepted():
     _stub_clock(float(0))
-    auth = _make_auth()
-
-    flow = auth.auth_flow(_api_request())
-    next(flow)
-    with pytest.raises(exceptions.AuthenticationError) as excinfo:
-        flow.send(
-            _make_token_response(access_token="AT-only", include_id_token=False),
-        )
-
-    assert "id_token" in str(excinfo.value)
-
-
-def test_response_missing_id_token_falls_back_when_opt_in(
-    caplog: pytest.LogCaptureFixture,
-):
-    _stub_clock(float(0))
-    auth = _make_auth(allow_access_token_fallback=True)
-    caplog.set_level(logging.WARNING, logger="nextlabs_sdk")
+    cache = _InMemoryTokenCache()
+    auth = _make_auth(token_cache=cache)
 
     flow = auth.auth_flow(_api_request())
     next(flow)
@@ -812,33 +794,24 @@ def test_response_missing_id_token_falls_back_when_opt_in(
     )
 
     assert api_request.headers["Authorization"] == "Bearer AT-only"
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("missing id_token" in r.getMessage().lower() for r in warnings)
+    assert cache.entries[_DERIVED_KEY].id_token is None
 
 
-def test_legacy_cache_without_id_token_triggers_silent_refresh_not_relogin():
+def test_cache_entry_without_id_token_is_used_directly():
     _stub_clock(100.0)
     cache = _InMemoryTokenCache()
     cache.entries[_DERIVED_KEY] = _cached(
-        access_token="legacy-at",
-        refresh_token="RT-legacy",
+        access_token="cached-at",
+        refresh_token="RT-cached",
         expires_at=10_000.0,
         id_token=None,
     )
     auth = _make_auth(password=None, token_cache=cache)
 
     flow = auth.auth_flow(_api_request())
-    token_req = next(flow)
+    api_request = next(flow)
 
-    body = bytes(token_req.content).decode()
-    assert "grant_type=refresh_token" in body
-    assert "refresh_token=RT-legacy" in body
-
-    api_request = flow.send(
-        _make_token_response(access_token="AT-new", id_token="IDT-new"),
-    )
-    assert api_request.headers["Authorization"] == "Bearer IDT-new"
-    assert cache.entries[_DERIVED_KEY].id_token == "IDT-new"
+    assert api_request.headers["Authorization"] == "Bearer cached-at"
 
 
 # ──────────────── Wall-clock vs monotonic-clock consistency (#93) ────────────────

--- a/tests/test_cloudaz_client.py
+++ b/tests/test_cloudaz_client.py
@@ -129,24 +129,8 @@ def test_authenticate_raises_when_custom_auth_override():
         raise AssertionError("expected AuthenticationError")
 
 
-def test_client_forwards_allow_access_token_fallback():
-    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
+def test_client_rejects_allow_access_token_fallback_kwarg():
+    import inspect
 
-    _stub_transport()
-    client = CloudAzClient(
-        base_url=BASE_URL,
-        username="admin",
-        password="secret",
-        allow_access_token_fallback=True,
-    )
-    assert isinstance(client._auth, CloudAzAuth)
-    assert client._auth.allow_access_token_fallback is True
-
-
-def test_client_default_disallows_access_token_fallback():
-    from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth
-
-    _stub_transport()
-    client = _make_client()
-    assert isinstance(client._auth, CloudAzAuth)
-    assert client._auth.allow_access_token_fallback is False
+    sig = inspect.signature(CloudAzClient)
+    assert "allow_access_token_fallback" not in sig.parameters


### PR DESCRIPTION
## Why

CloudAz endpoints under `base_url` accept either `id_token` or `access_token`,
but the Reporter microservice (`/nextlabs-reporter/...`) rejects `id_token`
with HTTP 403 and accepts only `access_token`. That broke every
Reporter-backed command: `audit-logs search`, `reporter-audit-logs`,
`activity-logs`, `reports`, `dashboard`, `system-config`.

NextLabs' own developer-portal "Try it out" instructs pasting the
`access_token` (prefixed `AT-`) as the bearer — confirmed empirically.

## What

- `CloudAzAuth` now injects `Bearer <access_token>` on every request.
- Token responses that omit `id_token` are accepted; any `id_token` the
  server returns is still persisted to the cache (forward compat) but
  ignored for authentication.
- **Breaking (pre-1.0):** drop `allow_access_token_fallback` kwarg from
  `CloudAzClient` and `AsyncCloudAzClient` — meaningless now.
- `CachedToken` schema version stays at v3; existing `tokens.json`
  entries load as-is and use `access_token` directly — no forced re-login.

## Verification

- `python ./tools/checks.py --short` → 4/4 green.
- `python ./tools/tests.py --short` → 2115 passed, coverage 95.87%.
