### PR TITLE
fix(cli): add wide-output columns to cloudaz table commands

### DIFF
--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -27,6 +27,14 @@ _ENFORCEMENT_COLUMNS = (
     ColumnDef("Action", "action"),
 )
 
+_ENFORCEMENT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Resource", "from_resource_name"),
+    ColumnDef("From Resource Path", "from_resource_path"),
+    ColumnDef("To Resource", "to_resource_name"),
+    ColumnDef("Short Code", "action_short_code"),
+    ColumnDef("Log Level", "log_level"),
+)
+
 _ATTRIBUTE_COLUMNS = (
     ColumnDef("Name", "name"),
     ColumnDef("Value", "value"),
@@ -64,7 +72,13 @@ def search(
     client = _client_factory.make_cloudaz_client(cli_ctx)
     paginator = client.activity_logs.search(log_query, page_size=page_size)
     page = paginator.first_page()
-    render(cli_ctx, page.entries, _ENFORCEMENT_COLUMNS, title="Activity Logs")
+    render(
+        cli_ctx,
+        page.entries,
+        _ENFORCEMENT_COLUMNS,
+        title="Activity Logs",
+        wide_columns=_ENFORCEMENT_WIDE_COLUMNS,
+    )
 
 
 @activity_logs_app.command(name="get-by-row-id")

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -101,7 +101,8 @@ def main(
         "--output",
         case_sensitive=False,
         help=(
-            "Output format: table (default compact), wide (extra columns), "
+            "Output format: table (default compact), "
+            "wide (extra columns where available), "
             "detail (sectioned per-item), json (raw JSON)."
         ),
     ),

--- a/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
@@ -33,6 +33,12 @@ _AUDIT_LOG_COLUMNS = (
     ColumnDef("Entity ID", "entity_id"),
 )
 
+_AUDIT_LOG_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Actor ID", "actor_id"),
+    ColumnDef("Old Value", "old_value"),
+    ColumnDef("New Value", "new_value"),
+)
+
 _USER_COLUMNS = (
     ColumnDef("Username", "username"),
     ColumnDef("First Name", "first_name"),
@@ -85,7 +91,13 @@ def search(  # noqa: WPS211
         sort_order=sort_order,
     )
     entries = list(client.audit_logs.search(query))
-    render(cli_ctx, entries, _AUDIT_LOG_COLUMNS, title="Audit Logs")
+    render(
+        cli_ctx,
+        entries,
+        _AUDIT_LOG_COLUMNS,
+        title="Audit Logs",
+        wide_columns=_AUDIT_LOG_WIDE_COLUMNS,
+    )
 
 
 @audit_logs_app.command()

--- a/src/nextlabs_sdk/_cli/_component_types_cmd.py
+++ b/src/nextlabs_sdk/_cli/_component_types_cmd.py
@@ -27,12 +27,25 @@ _CT_COLUMNS = (
     ColumnDef("Status", "status"),
 )
 
+_CT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Description", "description"),
+    ColumnDef("Owner", "owner_display_name"),
+    ColumnDef("Created", "created_date"),
+    ColumnDef("Updated", "last_updated_date"),
+    ColumnDef("Version", "version"),
+)
+
 _ATTRIBUTE_CONFIG_COLUMNS = (
     ColumnDef("ID", "id"),
     ColumnDef("Name", "name"),
     ColumnDef("Short Name", "short_name"),
     ColumnDef("Data Type", "data_type"),
     ColumnDef("Sort Order", "sort_order"),
+)
+
+_ATTRIBUTE_CONFIG_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Regex Pattern", "reg_ex_pattern"),
+    ColumnDef("Version", "version"),
 )
 
 
@@ -46,7 +59,7 @@ def get(
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)  # noqa: WPS204
     ct = client.component_types.get(component_type_id)
-    render(cli_ctx, ct, _CT_COLUMNS)
+    render(cli_ctx, ct, _CT_COLUMNS, wide_columns=_CT_WIDE_COLUMNS)
 
 
 @component_types_app.command(name="get-active")
@@ -59,7 +72,7 @@ def get_active(  # noqa: WPS463
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     ct = client.component_types.get_active(component_type_id)
-    render(cli_ctx, ct, _CT_COLUMNS)
+    render(cli_ctx, ct, _CT_COLUMNS, wide_columns=_CT_WIDE_COLUMNS)
 
 
 @component_types_app.command(name="bulk-delete")
@@ -113,6 +126,7 @@ def list_extra_subject_attributes(
         attrs,
         _ATTRIBUTE_CONFIG_COLUMNS,
         title="Extra Subject Attributes",
+        wide_columns=_ATTRIBUTE_CONFIG_WIDE_COLUMNS,
     )
 
 
@@ -210,7 +224,13 @@ def search(  # noqa: WPS211
     criteria.page(page_no=1, page_size=page_size)
     client = _client_factory.make_cloudaz_client(cli_ctx)
     matches = list(client.component_type_search.search(criteria))
-    render(cli_ctx, matches, _CT_COLUMNS, title="Component Types")
+    render(
+        cli_ctx,
+        matches,
+        _CT_COLUMNS,
+        title="Component Types",
+        wide_columns=_CT_WIDE_COLUMNS,
+    )
 
 
 def _render_component_type_detail(model: BaseModel, console: Console) -> None:

--- a/src/nextlabs_sdk/_cli/_reporter_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_reporter_audit_logs_cmd.py
@@ -21,6 +21,14 @@ _COLUMNS = (
     ColumnDef("Created", "created_date"),
 )
 
+_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Last Updated", "last_updated"),
+    ColumnDef("Msg Code", "msg_code"),
+    ColumnDef("Created By", "created_by"),
+    ColumnDef("Last Updated By", "last_updated_by"),
+    ColumnDef("Hidden", "hidden"),
+)
+
 
 @reporter_audit_logs_app.command()
 @cli_error_handler
@@ -36,4 +44,10 @@ def search(
     client = _client_factory.make_cloudaz_client(cli_ctx)
     paginator = client.reporter_audit_logs.search(page_size=page_size)
     page = paginator.first_page()
-    render(cli_ctx, page.entries, _COLUMNS, title="Reporter Audit Logs")
+    render(
+        cli_ctx,
+        page.entries,
+        _COLUMNS,
+        title="Reporter Audit Logs",
+        wide_columns=_WIDE_COLUMNS,
+    )

--- a/src/nextlabs_sdk/_cli/_reports_cmd.py
+++ b/src/nextlabs_sdk/_cli/_reports_cmd.py
@@ -39,6 +39,14 @@ _REPORT_COLUMNS = (
     ColumnDef("Last Updated", "last_updated_date"),
 )
 
+_REPORT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("Description", "description"),
+    ColumnDef("Shared Mode", "shared_mode"),
+    ColumnDef("Window Mode", "window_mode"),
+    ColumnDef("Start Date", "start_date"),
+    ColumnDef("End Date", "end_date"),
+)
+
 _ENFORCEMENT_COLUMNS = (
     ColumnDef("Row ID", "row_id"),
     ColumnDef("Time", "time"),
@@ -47,6 +55,13 @@ _ENFORCEMENT_COLUMNS = (
     ColumnDef("Policy", "policy_name"),
     ColumnDef("Decision", "policy_decision"),
     ColumnDef("Action", "action"),
+)
+
+_ENFORCEMENT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    ColumnDef("From Resource Path", "from_resource_path"),
+    ColumnDef("To Resource", "to_resource_name"),
+    ColumnDef("Short Code", "action_short_code"),
+    ColumnDef("Log Level", "log_level"),
 )
 
 _REPORT_DETAIL_COLUMNS = (
@@ -105,7 +120,13 @@ def list_reports(  # noqa: WPS211
             page_size=page_size,
         )
     )
-    render(cli_ctx, reports, _REPORT_COLUMNS, title="Reports")
+    render(
+        cli_ctx,
+        reports,
+        _REPORT_COLUMNS,
+        title="Reports",
+        wide_columns=_REPORT_WIDE_COLUMNS,
+    )
 
 
 @reports_app.command()
@@ -196,7 +217,13 @@ def enforcements(
             page_size=page_size,
         )
     )
-    render(cli_ctx, entries, _ENFORCEMENT_COLUMNS, title="Enforcements")
+    render(
+        cli_ctx,
+        entries,
+        _ENFORCEMENT_COLUMNS,
+        title="Enforcements",
+        wide_columns=_ENFORCEMENT_WIDE_COLUMNS,
+    )
 
 
 @reports_app.command(name="export")
@@ -259,7 +286,13 @@ def generate_enforcements(
         page_size=page_size,
     )
     entries = list(paginator.first_page().entries)
-    render(cli_ctx, entries, _ENFORCEMENT_COLUMNS, title="Enforcements")
+    render(
+        cli_ctx,
+        entries,
+        _ENFORCEMENT_COLUMNS,
+        title="Enforcements",
+        wide_columns=_ENFORCEMENT_WIDE_COLUMNS,
+    )
 
 
 @reports_app.command(name="generate-export")

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -161,6 +161,62 @@ def test_activity_logs_get_by_row_id_table(stub: tuple[Any, Any]) -> None:
     assert "alice" in result.output
 
 
+def test_activity_logs_search_wide_includes_extra_columns(
+    stub: tuple[Any, Any],
+    query_file: Path,
+) -> None:
+    _, service = stub
+    entry = EnforcementEntry(
+        ROW_ID=99,
+        TIME="2024-01-01T00:00:00Z",
+        USER_NAME="alice",
+        FROM_RESOURCE_NAME="source.txt",
+        FROM_RESOURCE_PATH="/data/source.txt",
+        TO_RESOURCE_NAME="dest.txt",
+        POLICY_NAME="Allow",
+        POLICY_DECISION="ALLOW",
+        ACTION="read",
+        ACTION_SHORT_CODE="R",
+        LOG_LEVEL="INFO",
+    )
+
+    def fetch(page_no: int) -> PageResult[EnforcementEntry]:
+        return PageResult(
+            entries=[entry],
+            page_no=page_no,
+            page_size=1,
+            total_pages=1,
+            total_records=1,
+        )
+
+    when(service).search(...).thenReturn(SyncPaginator(fetch_page=fetch))
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "--output",
+            "wide",
+            "activity-logs",
+            "search",
+            "--query",
+            str(query_file),
+        ],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Resource" in output
+    assert "From Resource Path" in output
+    assert "To Resource" in output
+    assert "Short Code" in output
+    assert "Log Level" in output
+    assert "/data/source.txt" in output
+    assert "dest.txt" in output
+    assert "INFO" in output
+
+
 def test_activity_logs_export_writes_bytes(
     stub: tuple[Any, Any],
     tmp_path: Path,

--- a/tests/test_cli_audit_logs.py
+++ b/tests/test_cli_audit_logs.py
@@ -330,6 +330,37 @@ def test_search_accepts_iso_dates(stubbed_audit: Any) -> None:
     assert result.exit_code == 0, result.output
 
 
+def test_search_wide_includes_extra_columns(stubbed_audit: Any) -> None:
+    entry = AuditLogEntry.model_validate(
+        {
+            "id": 7,
+            "timestamp": 1700000000000,
+            "action": "UPDATE",
+            "actorId": 100,
+            "actor": "admin",
+            "entityType": "POLICY",
+            "entityId": 42,
+            "oldValue": "old-blob",
+            "newValue": "new-blob",
+        }
+    )
+    when(stubbed_audit).search(...).thenReturn(_make_paginator([entry]))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "audit-logs", "search", *_DATE_OPTS],
+        env={"COLUMNS": "240"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = strip_ansi(result.output).replace("\n", " ")
+    assert "Actor ID" in output
+    assert "Old Value" in output
+    assert "New Value" in output
+    assert "old-blob" in output
+    assert "new-blob" in output
+
+
 def test_search_rejects_unrecognized_date(stubbed_audit: Any) -> None:
     result = runner.invoke(
         app,

--- a/tests/test_cli_component_types.py
+++ b/tests/test_cli_component_types.py
@@ -259,6 +259,124 @@ def test_component_types_clone(stub_client):
     assert "42" in result.output
 
 
+def _make_component_type_rich(ct_id: int = 7) -> ComponentType:
+    return ComponentType.model_validate(
+        {
+            "id": ct_id,
+            "name": "File Server",
+            "shortName": "file_server",
+            "description": "A file server component type",
+            "type": "RESOURCE",
+            "status": "ACTIVE",
+            "tags": [],
+            "attributes": [],
+            "actions": [],
+            "obligations": [],
+            "version": 3,
+            "ownerDisplayName": "ops-team",
+            "createdDate": 1_700_000_000_000,
+            "lastUpdatedDate": 1_700_100_000_000,
+        },
+    )
+
+
+def test_component_types_get_wide_includes_extra_columns(stub_client):
+    _, mock_ct, _ = stub_client
+    when(mock_ct).get(7).thenReturn(_make_component_type_rich())
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "component-types", "get", "7"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Description" in output
+    assert "Owner" in output
+    assert "Created" in output
+    assert "Updated" in output
+    assert "Version" in output
+    assert "ops-team" in output
+    assert "1700000000000" in output
+
+
+def test_component_types_get_active_wide_includes_extra_columns(stub_client):
+    _, mock_ct, _ = stub_client
+    when(mock_ct).get_active(7).thenReturn(_make_component_type_rich())
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "component-types", "get-active", "7"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Description" in output
+    assert "Owner" in output
+    assert "ops-team" in output
+
+
+def test_component_types_search_wide_includes_extra_columns(stub_client):
+    _, _, mock_search = stub_client
+    when(mock_search).search(...).thenReturn(
+        _make_paginator([_make_component_type_rich()]),
+    )
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "component-types", "search"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Description" in output
+    assert "Owner" in output
+    assert "Version" in output
+
+
+def test_component_types_list_extra_subject_attributes_wide(stub_client):
+    from nextlabs_sdk._cloudaz._component_type_models import AttributeConfig
+
+    _, mock_ct, _ = stub_client
+    when(mock_ct).list_extra_subject_attributes("USER").thenReturn(
+        [
+            AttributeConfig.model_validate(
+                {
+                    "id": 1,
+                    "name": "Department",
+                    "shortName": "dept",
+                    "dataType": "STRING",
+                    "sortOrder": 0,
+                    "regExPattern": "^[A-Z]+$",
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "--output",
+            "wide",
+            "component-types",
+            "list-extra-subject-attributes",
+            "USER",
+        ],
+        env={"COLUMNS": "240"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Regex Pattern" in output
+    assert "Version" in output
+    assert "^[A-Z]+$" in output
+
+
 def test_component_types_list_extra_subject_attributes(stub_client):
     from nextlabs_sdk._cloudaz._component_type_models import AttributeConfig
 

--- a/tests/test_cli_reporter_audit_logs.py
+++ b/tests/test_cli_reporter_audit_logs.py
@@ -104,6 +104,28 @@ def test_reporter_audit_logs_search_page_size(stub: tuple[Any, Any]) -> None:
     assert result.exit_code == 0
 
 
+def test_reporter_audit_logs_search_wide_includes_extra_columns(
+    stub: tuple[Any, Any],
+) -> None:
+    _, service = stub
+    when(service).search(page_size=20).thenReturn(_paginator([_entry(42)]))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "reporter-audit-logs", "search"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Last Updated" in output
+    assert "Msg Code" in output
+    assert "Created By" in output
+    assert "Last Updated By" in output
+    assert "Hidden" in output
+    assert "ACTIVITY_CREATED" in output
+
+
 def test_reporter_audit_logs_search_error(stub: tuple[Any, Any]) -> None:
     _, service = stub
     when(service).search(page_size=20).thenRaise(NextLabsError("boom"))

--- a/tests/test_cli_reports.py
+++ b/tests/test_cli_reports.py
@@ -390,6 +390,75 @@ def test_reports_enforcements(
     assert check(result.output)
 
 
+# ── wide output ──
+
+
+def _make_enforcement_full() -> EnforcementEntry:
+    return EnforcementEntry.model_validate(
+        {
+            "ROW_ID": 101,
+            "TIME": "2024-06-01 12:00:00",
+            "USER_NAME": "admin@test.com",
+            "FROM_RESOURCE_NAME": "/shared/docs",
+            "FROM_RESOURCE_PATH": "/data/shared/docs",
+            "TO_RESOURCE_NAME": "/shared/archive",
+            "POLICY_NAME": "AllowRead",
+            "POLICY_DECISION": "Allow",
+            "ACTION": "READ",
+            "ACTION_SHORT_CODE": "R",
+            "LOG_LEVEL": "INFO",
+        },
+    )
+
+
+def test_reports_list_wide_includes_extra_columns(mock_reports: Any) -> None:
+    when(mock_reports).list(**_default_list_kw()).thenReturn(
+        _paginator([_make_report()]),
+    )
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "reports", "list"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "Description" in output
+    assert "Shared Mode" in output
+    assert "Window Mode" in output
+    assert "Start Date" in output
+    assert "End Date" in output
+    assert "A test report" in output
+    assert "PRIVATE" in output
+    assert "LAST_7_DAYS" in output
+
+
+def test_reports_enforcements_wide_includes_extra_columns(mock_reports: Any) -> None:
+    when(mock_reports).get_enforcements(
+        1,
+        sort_by="rowId",
+        sort_order="ascending",
+        page_size=20,
+    ).thenReturn(_paginator([_make_enforcement_full()]))
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "wide", "reports", "enforcements", "1"],
+        env={"COLUMNS": "320"},
+    )
+
+    assert result.exit_code == 0, result.output
+    output = result.output.replace("\n", " ")
+    assert "From Resource Path" in output
+    assert "To Resource" in output
+    assert "Short Code" in output
+    assert "Log Level" in output
+    assert "/data/shared/docs" in output
+    assert "/shared/archive" in output
+    assert "INFO" in output
+
+
 # ── export ──
 
 


### PR DESCRIPTION
## Summary

`--output wide` was a no-op for most cloudaz CLI commands: only `policies` and `components` passed `wide_columns=` to the shared `render()` helper, so every other table-rendering command silently printed the same columns as `--output table`.

## Changes

Added `wide_columns` tuples following the existing policies/components pattern (metadata + high-value triage fields, kubectl-style):

| Command | Wide adds |
|---|---|
| `audit-logs search` | Actor ID, Old Value, New Value |
| `activity-logs search` | Resource, From Resource Path, To Resource, Short Code, Log Level |
| `reports list` | Description, Shared Mode, Window Mode, Start Date, End Date |
| `reports enforcements` / `generate-enforcements` | From Resource Path, To Resource, Short Code, Log Level |
| `component-types get` / `get-active` / `search` | Description, Owner, Created, Updated, Version |
| `component-types list-extra-subject-attributes` | Regex Pattern, Version |
| `reporter-audit-logs search` | Last Updated, Msg Code, Created By, Last Updated By, Hidden |

Also clarified the global `--output` help text: `wide` now reads "extra columns where available" so users understand that commands whose default view already shows every field remain a silent pass-through (same UX convention as `kubectl -o wide`).

## Out of scope

- Realigning divergent default columns between `activity-logs enforcements` and `reports enforcements` (same model, different defaults) — intentionally untouched to avoid behavior change beyond the bug fix.

## Tests

TDD red→green cycle for each newly-wide command, mirroring the existing `test_cli_components.py` / `test_cli_policies.py` wide-output pattern. All 2124 tests pass; narrowed `checks.py --short` clean (black, flake8, mypy, pyright).