### PR TITLE
feat(cli): inline flags for activity-logs search/export

### DIFF
--- a/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
+++ b/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
@@ -1,0 +1,134 @@
+"""Build an ``ActivityLogQuery`` from an optional file and inline flags.
+
+Supports layered configuration: values from the ``--query`` JSON file
+are overlaid by any inline flags the user explicitly passed. When no
+file is given, defaults reused from the OpenAPI spec fill in optional
+fields so users only need to supply ``field_name`` / ``field_value``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nextlabs_sdk._cli._payload_loader import load_payload
+from nextlabs_sdk._cli._time_parser import parse_time
+from nextlabs_sdk._cloudaz._activity_log_query_models import ActivityLogQuery
+from nextlabs_sdk.exceptions import NextLabsError
+
+_DEFAULT_POLICY_DECISION = "AD"
+_DEFAULT_SORT_BY = "time"
+_DEFAULT_SORT_ORDER = "descending"
+
+
+def build_activity_log_query(  # noqa: WPS211
+    query_path: Path | None,
+    *,
+    policy_decision: str | None = None,
+    sort_by: str | None = None,
+    sort_order: str | None = None,
+    field_name: str | None = None,
+    field_value: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    header: list[str] | None = None,
+    page: int | None = None,
+    size: int | None = None,
+) -> ActivityLogQuery:
+    """Compose an ``ActivityLogQuery`` from an optional file and flags.
+
+    Args:
+        query_path: Optional path to a JSON payload matching
+            ``ActivityLogQuery``. When given, acts as the base config.
+        policy_decision: Overlay for ``policyDecision``.
+        sort_by: Overlay for ``sortBy``.
+        sort_order: Overlay for ``sortOrder``.
+        field_name: Overlay for ``fieldName``.
+        field_value: Overlay for ``fieldValue``.
+        from_date: Overlay for ``fromDate``; accepts formats handled by
+            :func:`parse_time` (epoch ms, ISO 8601, relative offset).
+        to_date: Overlay for ``toDate``; same formats as ``from_date``.
+        header: Overlay for the ``header`` list (full replacement).
+        page: Overlay for ``page``.
+        size: Overlay for ``size``.
+
+    Returns:
+        A validated ``ActivityLogQuery``.
+
+    Raises:
+        NextLabsError: If the merged payload fails validation, or if a
+            date string cannot be parsed.
+        typer.Exit: If the file is missing, unreadable, or not JSON
+            (propagated from :func:`load_payload`).
+    """
+    base: dict[str, object] = dict(load_payload(query_path)) if query_path else {}
+
+    overrides = _collect_overrides(
+        policy_decision=policy_decision,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        field_name=field_name,
+        field_value=field_value,
+        from_date=from_date,
+        to_date=to_date,
+        header=header,
+        page=page,
+        size=size,
+    )
+    base.update(overrides)
+
+    if query_path is None:
+        base.setdefault("policy_decision", _DEFAULT_POLICY_DECISION)
+        base.setdefault("sort_by", _DEFAULT_SORT_BY)
+        base.setdefault("sort_order", _DEFAULT_SORT_ORDER)
+
+    try:
+        return ActivityLogQuery.model_validate(base)
+    except ValueError as exc:
+        location = f" in {query_path}" if query_path else ""
+        raise NextLabsError(
+            f"Invalid activity log query{location}: {exc}",
+        ) from None
+
+
+def _collect_overrides(  # noqa: WPS211
+    *,
+    policy_decision: str | None,
+    sort_by: str | None,
+    sort_order: str | None,
+    field_name: str | None,
+    field_value: str | None,
+    from_date: str | None,
+    to_date: str | None,
+    header: list[str] | None,
+    page: int | None,
+    size: int | None,
+) -> dict[str, object]:
+    overrides: dict[str, object] = {}
+    if policy_decision is not None:
+        overrides["policy_decision"] = policy_decision
+    if sort_by is not None:
+        overrides["sort_by"] = sort_by
+    if sort_order is not None:
+        overrides["sort_order"] = sort_order
+    if field_name is not None:
+        overrides["field_name"] = field_name
+    if field_value is not None:
+        overrides["field_value"] = field_value
+    if from_date is not None:
+        overrides["from_date"] = _parse_date(from_date, "--from-date")
+    if to_date is not None:
+        overrides["to_date"] = _parse_date(to_date, "--to-date")
+    if header is not None:
+        overrides["header"] = header
+    if page is not None:
+        overrides["page"] = page
+    if size is not None:
+        overrides["size"] = size
+    return overrides
+
+
+def _parse_date(raw: str, flag: str) -> int:
+    try:
+        return parse_time(raw)
+    except ValueError as exc:
+        raise NextLabsError(f"Invalid {flag} value: {exc}") from None

--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -7,14 +7,12 @@ from typing import Annotated
 
 import typer
 
-from nextlabs_sdk import exceptions as sdk_exceptions
 from nextlabs_sdk._cli import _client_factory
+from nextlabs_sdk._cli._activity_log_query_builder import build_activity_log_query
 from nextlabs_sdk._cli._binary_output import write_bytes
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import ColumnDef, render
-from nextlabs_sdk._cli._payload_loader import load_payload
-from nextlabs_sdk._cloudaz._activity_log_query_models import ActivityLogQuery
 
 activity_logs_app = typer.Typer(help="Report activity log commands.")
 
@@ -44,31 +42,69 @@ _ATTRIBUTE_COLUMNS = (
 )
 
 
-def _load_query(query_path: Path) -> ActivityLogQuery:
-    raw = load_payload(query_path)
-    try:
-        return ActivityLogQuery.model_validate(raw)
-    except ValueError as exc:
-        raise sdk_exceptions.NextLabsError(
-            f"Invalid activity log query in {query_path}: {exc}",
-        ) from None
+_DATE_HELP = (
+    "Accepts epoch milliseconds (e.g. 1737014400000), ISO 8601 datetime "
+    "(e.g. 2024-01-15 or 2024-01-15T10:30:00+02:00, naive values treated "
+    "as UTC), or a relative offset from now (e.g. 30s, 5m, 2h, 3d, 1w)."
+)
 
 
 @activity_logs_app.command()
 @cli_error_handler
-def search(
+def search(  # noqa: WPS211
     ctx: typer.Context,
     query: Annotated[
-        Path,
+        Path | None,
         typer.Option("--query", help="Path to a JSON query file"),
-    ],
+    ] = None,
+    policy_decision: Annotated[
+        str | None,
+        typer.Option("--policy-decision", help="Policy decision filter"),
+    ] = None,
+    sort_by: Annotated[str | None, typer.Option("--sort-by", help="Sort field")] = None,
+    sort_order: Annotated[
+        str | None, typer.Option("--sort-order", help="Sort order")
+    ] = None,
+    field_name: Annotated[
+        str | None, typer.Option("--field-name", help="Filter field name")
+    ] = None,
+    field_value: Annotated[
+        str | None, typer.Option("--field-value", help="Filter field value")
+    ] = None,
+    from_date: Annotated[
+        str | None, typer.Option("--from-date", help=f"Start date. {_DATE_HELP}")
+    ] = None,
+    to_date: Annotated[
+        str | None, typer.Option("--to-date", help=f"End date. {_DATE_HELP}")
+    ] = None,
+    header: Annotated[
+        list[str] | None,
+        typer.Option("--header", help="Header name (repeatable)"),
+    ] = None,
     page_size: Annotated[
         int, typer.Option("--page-size", help="Entries per page")
     ] = 20,
 ) -> None:
-    """Search activity logs (first page of results)."""
+    """Search activity logs (first page of results).
+
+    Inline flags may be combined with ``--query PATH``. When both are
+    supplied, inline flag values override the corresponding keys in the
+    file. When ``--query`` is omitted, ``--field-name`` and
+    ``--field-value`` are required; other optional fields fall back to
+    spec-example defaults.
+    """
     cli_ctx: CliContext = ctx.obj
-    log_query = _load_query(query)
+    log_query = build_activity_log_query(
+        query,
+        policy_decision=policy_decision,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        field_name=field_name,
+        field_value=field_value,
+        from_date=from_date,
+        to_date=to_date,
+        header=header,
+    )
     client = _client_factory.make_cloudaz_client(cli_ctx)
     paginator = client.activity_logs.search(log_query, page_size=page_size)
     page = paginator.first_page()
@@ -96,24 +132,62 @@ def show_row(
 
 @activity_logs_app.command()
 @cli_error_handler
-def export(
+def export(  # noqa: WPS211
     ctx: typer.Context,
-    query: Annotated[
-        Path,
-        typer.Option("--query", help="Path to a JSON query file"),
-    ],
     output: Annotated[
         Path,
         typer.Option("--output", help="Destination file path"),
     ],
+    query: Annotated[
+        Path | None,
+        typer.Option("--query", help="Path to a JSON query file"),
+    ] = None,
+    policy_decision: Annotated[
+        str | None,
+        typer.Option("--policy-decision", help="Policy decision filter"),
+    ] = None,
+    sort_by: Annotated[str | None, typer.Option("--sort-by", help="Sort field")] = None,
+    sort_order: Annotated[
+        str | None, typer.Option("--sort-order", help="Sort order")
+    ] = None,
+    field_name: Annotated[
+        str | None, typer.Option("--field-name", help="Filter field name")
+    ] = None,
+    field_value: Annotated[
+        str | None, typer.Option("--field-value", help="Filter field value")
+    ] = None,
+    from_date: Annotated[
+        str | None, typer.Option("--from-date", help=f"Start date. {_DATE_HELP}")
+    ] = None,
+    to_date: Annotated[
+        str | None, typer.Option("--to-date", help=f"End date. {_DATE_HELP}")
+    ] = None,
+    header: Annotated[
+        list[str] | None,
+        typer.Option("--header", help="Header name (repeatable)"),
+    ] = None,
     overwrite: Annotated[
         bool,
         typer.Option("--overwrite/--no-overwrite", help="Replace existing file"),
     ] = False,
 ) -> None:
-    """Export matching activity logs as raw bytes to ``--output``."""
+    """Export matching activity logs as raw bytes to ``--output``.
+
+    Inline flags follow the same merge semantics as ``search``: they
+    override keys from ``--query PATH`` when both are supplied.
+    """
     cli_ctx: CliContext = ctx.obj
-    log_query = _load_query(query)
+    log_query = build_activity_log_query(
+        query,
+        policy_decision=policy_decision,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        field_name=field_name,
+        field_value=field_value,
+        from_date=from_date,
+        to_date=to_date,
+        header=header,
+    )
     client = _client_factory.make_cloudaz_client(cli_ctx)
     payload = client.activity_logs.export(log_query)
     write_bytes(output, payload, overwrite=overwrite)

--- a/tests/test_activity_log_query_builder.py
+++ b/tests/test_activity_log_query_builder.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nextlabs_sdk._cli._activity_log_query_builder import (
+    build_activity_log_query,
+)
+from nextlabs_sdk.exceptions import NextLabsError
+
+
+def _write(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_inline_only_uses_flag_values_and_defaults() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="user_name",
+        field_value="alice",
+    )
+
+    assert query.field_name == "user_name"
+    assert query.field_value == "alice"
+    assert query.policy_decision == "AD"
+    assert query.sort_by == "time"
+    assert query.sort_order == "descending"
+
+
+def test_inline_only_missing_required_fields_errors() -> None:
+    with pytest.raises(NextLabsError) as exc_info:
+        build_activity_log_query(None)
+
+    message = str(exc_info.value)
+    assert "field_name" in message or "fieldName" in message
+
+
+def test_file_only_preserves_existing_behaviour(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "ALLOW",
+            "sort_by": "TIME",
+            "sort_order": "ascending",
+            "field_name": "user_name",
+            "field_value": "bob",
+            "from_date": 1_700_000_000,
+        },
+    )
+
+    query = build_activity_log_query(path)
+
+    assert query.policy_decision == "ALLOW"
+    assert query.sort_order == "ascending"
+    assert query.field_value == "bob"
+    assert query.from_date == 1_700_000_000
+
+
+def test_flag_overrides_file_value(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "ALLOW",
+            "sort_by": "TIME",
+            "sort_order": "ascending",
+            "field_name": "user_name",
+            "field_value": "bob",
+        },
+    )
+
+    query = build_activity_log_query(path, field_value="carol")
+
+    assert query.field_value == "carol"
+    assert query.policy_decision == "ALLOW"
+    assert query.sort_order == "ascending"
+
+
+def test_flag_not_supplied_keeps_file_value(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "ALLOW",
+            "sort_by": "TIME",
+            "sort_order": "ascending",
+            "field_name": "user_name",
+            "field_value": "bob",
+        },
+    )
+
+    query = build_activity_log_query(path)
+
+    assert query.policy_decision == "ALLOW"
+    assert query.sort_by == "TIME"
+
+
+def test_header_list_overrides(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "AD",
+            "sort_by": "time",
+            "sort_order": "descending",
+            "field_name": "user_name",
+            "field_value": "bob",
+            "header": ["a", "b"],
+        },
+    )
+
+    query = build_activity_log_query(path, header=["x", "y", "z"])
+
+    assert query.header == ["x", "y", "z"]
+
+
+def test_from_date_parsed_epoch_ms() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        from_date="1737014400000",
+    )
+
+    assert query.from_date == 1_737_014_400_000
+
+
+def test_from_date_parsed_iso() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        from_date="2024-01-15T00:00:00+00:00",
+    )
+
+    assert query.from_date is not None
+    assert query.from_date == 1_705_276_800_000
+
+
+def test_from_date_parsed_relative(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nextlabs_sdk._cli import _time_parser
+
+    monkeypatch.setattr(_time_parser, "now_epoch_ms", lambda: 1_000_000)
+
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        from_date="1s",
+    )
+
+    assert query.from_date == 1_000_000 - 1_000
+
+
+def test_invalid_json_errors(tmp_path: Path) -> None:
+    import click
+
+    path = tmp_path / "bad.json"
+    path.write_text("{not json")
+
+    with pytest.raises(click.exceptions.Exit):
+        build_activity_log_query(path)
+
+
+def test_invalid_date_errors() -> None:
+    with pytest.raises(NextLabsError) as exc_info:
+        build_activity_log_query(
+            None,
+            field_name="u",
+            field_value="v",
+            from_date="not-a-date",
+        )
+
+    assert "from-date" in str(exc_info.value) or "from_date" in str(exc_info.value)

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -309,3 +309,187 @@ def test_activity_logs_search_invalid_query(
 
     assert result.exit_code == 1
     assert "Invalid activity log query" in result.output
+
+
+def test_activity_logs_search_inline_flags_only(
+    stub: tuple[Any, Any],
+) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "search",
+            "--field-name",
+            "user_name",
+            "--field-value",
+            "alice",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].field_name == "user_name"
+    assert captured["query"].field_value == "alice"
+    assert captured["query"].policy_decision == "AD"
+    assert captured["query"].sort_by == "time"
+    assert captured["query"].sort_order == "descending"
+
+
+def test_activity_logs_search_flag_overrides_file(
+    stub: tuple[Any, Any],
+    query_file: Path,
+) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "search",
+            "--query",
+            str(query_file),
+            "--field-value",
+            "carol",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].field_value == "carol"
+    assert captured["query"].field_name == "user_name"
+    assert captured["query"].from_date == 1_700_000_000
+
+
+def test_activity_logs_search_headers_repeatable(
+    stub: tuple[Any, Any],
+) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "search",
+            "--field-name",
+            "u",
+            "--field-value",
+            "v",
+            "--header",
+            "a",
+            "--header",
+            "b",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].header == ["a", "b"]
+
+
+def test_activity_logs_search_from_date_epoch_ms(
+    stub: tuple[Any, Any],
+) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "search",
+            "--field-name",
+            "u",
+            "--field-value",
+            "v",
+            "--from-date",
+            "1737014400000",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].from_date == 1_737_014_400_000
+
+
+def test_activity_logs_search_inline_missing_required_errors(
+    stub: tuple[Any, Any],
+) -> None:
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "activity-logs", "search"],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid activity log query" in result.output
+
+
+def test_activity_logs_export_inline_flags_only(
+    stub: tuple[Any, Any],
+    tmp_path: Path,
+) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(query: ActivityLogQuery) -> bytes:
+        captured["query"] = query
+        return b"csv"
+
+    when(service).export(...).thenAnswer(_fake)
+
+    out = tmp_path / "export.csv"
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "export",
+            "--output",
+            str(out),
+            "--field-name",
+            "u",
+            "--field-value",
+            "v",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out.read_bytes() == b"csv"
+    assert captured["query"].field_name == "u"
+    assert captured["query"].policy_decision == "AD"


### PR DESCRIPTION
Adds typed flags (`--policy-decision`, `--sort-by`, `--sort-order`, `--field-name`, `--field-value`, `--from-date`, `--to-date`, `--header`) to `nextlabs activity-logs search` and `export`, matching the sibling `audit-logs` UX.

## Behaviour
- `--query PATH` is now optional.
- When `--query` is given, inline flags override the corresponding keys in the JSON file (kubectl/helm-style layering).
- When `--query` is omitted, optional fields fall back to OpenAPI-spec example defaults (`policyDecision=AD`, `sortBy=time`, `sortOrder=descending`); `--field-name` / `--field-value` are required.
- Date flags accept epoch ms / ISO 8601 / relative offsets via the existing `parse_time` helper.
- `--header` is repeatable.

## Implementation
- New `_activity_log_query_builder.build_activity_log_query` owns the load + merge + validate pipeline so the Typer wrappers stay thin and directly unit-testable.
- `get-by-row-id` and `export-by-row-id` untouched (no query involved).

## Tests
- 11 unit tests on the builder (inline-only, file-only, override, header list, three date formats, invalid JSON, invalid date, missing required fields).
- 6 new CLI tests covering inline-only search, flag overrides file, repeatable `--header`, epoch-ms date flag, missing-required error, and export inline-only.