### PR TITLE
feat(cli): friendly error + toDate/header defaults for activity-logs

### DIFF
--- a/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
+++ b/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import typer
+
+from nextlabs_sdk._cli._output import print_error
 from nextlabs_sdk._cli._payload_loader import load_payload
-from nextlabs_sdk._cli._time_parser import parse_time
+from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
 from nextlabs_sdk._cloudaz._activity_log_query_models import ActivityLogQuery
 from nextlabs_sdk.exceptions import NextLabsError
 
@@ -33,6 +36,7 @@ def build_activity_log_query(  # noqa: WPS211
     header: list[str] | None = None,
     page: int | None = None,
     size: int | None = None,
+    default_header: list[str] | None = None,
 ) -> ActivityLogQuery:
     """Compose an ``ActivityLogQuery`` from an optional file and flags.
 
@@ -50,6 +54,10 @@ def build_activity_log_query(  # noqa: WPS211
         header: Overlay for the ``header`` list (full replacement).
         page: Overlay for ``page``.
         size: Overlay for ``size``.
+        default_header: Fallback ``header`` list applied only when
+            ``query_path`` is ``None`` and ``header`` is ``None``. Lets
+            the caller supply the CLI's render columns so picky servers
+            accept the payload and wide output never blanks.
 
     Returns:
         A validated ``ActivityLogQuery``.
@@ -58,8 +66,14 @@ def build_activity_log_query(  # noqa: WPS211
         NextLabsError: If the merged payload fails validation, or if a
             date string cannot be parsed.
         typer.Exit: If the file is missing, unreadable, or not JSON
-            (propagated from :func:`load_payload`).
+            (propagated from :func:`load_payload`), or if required
+            inline flags (``--field-name`` / ``--field-value``) are
+            missing in inline-build mode.
     """
+    inline_mode = query_path is None
+    if inline_mode:
+        _require_inline_flags(field_name=field_name, field_value=field_value)
+
     base: dict[str, object] = dict(load_payload(query_path)) if query_path else {}
 
     overrides = _collect_overrides(
@@ -76,10 +90,8 @@ def build_activity_log_query(  # noqa: WPS211
     )
     base.update(overrides)
 
-    if query_path is None:
-        base.setdefault("policy_decision", _DEFAULT_POLICY_DECISION)
-        base.setdefault("sort_by", _DEFAULT_SORT_BY)
-        base.setdefault("sort_order", _DEFAULT_SORT_ORDER)
+    if inline_mode:
+        _apply_inline_defaults(base, default_header=default_header)
 
     try:
         return ActivityLogQuery.model_validate(base)
@@ -88,6 +100,18 @@ def build_activity_log_query(  # noqa: WPS211
         raise NextLabsError(
             f"Invalid activity log query{location}: {exc}",
         ) from None
+
+
+def _apply_inline_defaults(
+    base: dict[str, object], *, default_header: list[str] | None
+) -> None:
+    base.setdefault("policy_decision", _DEFAULT_POLICY_DECISION)
+    base.setdefault("sort_by", _DEFAULT_SORT_BY)
+    base.setdefault("sort_order", _DEFAULT_SORT_ORDER)
+    if "from_date" in base and "to_date" not in base:
+        base["to_date"] = now_epoch_ms()
+    if default_header is not None and "header" not in base:
+        base["header"] = list(default_header)
 
 
 def _collect_overrides(  # noqa: WPS211
@@ -132,3 +156,19 @@ def _parse_date(raw: str, flag: str) -> int:
         return parse_time(raw)
     except ValueError as exc:
         raise NextLabsError(f"Invalid {flag} value: {exc}") from None
+
+
+def _require_inline_flags(*, field_name: str | None, field_value: str | None) -> None:
+    missing: list[str] = []
+    if field_name is None:
+        missing.append("--field-name")
+    if field_value is None:
+        missing.append("--field-value")
+    if not missing:
+        return
+    joined = ", ".join(missing)
+    print_error(
+        f"Missing required option: {joined} "
+        "(or provide --query PATH to supply them from a JSON file)",
+    )
+    raise typer.Exit(code=1)

--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -33,6 +33,10 @@ _ENFORCEMENT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
     ColumnDef("Log Level", "log_level"),
 )
 
+_DEFAULT_HEADER_COLUMNS: tuple[str, ...] = tuple(
+    col.field.upper() for col in (*_ENFORCEMENT_COLUMNS, *_ENFORCEMENT_WIDE_COLUMNS)
+)
+
 _ATTRIBUTE_COLUMNS = (
     ColumnDef("Name", "name"),
     ColumnDef("Value", "value"),
@@ -92,6 +96,13 @@ def search(  # noqa: WPS211
     file. When ``--query`` is omitted, ``--field-name`` and
     ``--field-value`` are required; other optional fields fall back to
     spec-example defaults.
+
+    Live reporter servers have been observed to return 500 when
+    ``toDate`` or ``header`` are absent. In inline-build mode this
+    command therefore defaults ``toDate`` to now when ``--from-date`` is
+    supplied without ``--to-date``, and populates ``header`` with the
+    CLI's rendered column set when ``--header`` is not given. Payloads
+    loaded via ``--query PATH`` are forwarded verbatim.
     """
     cli_ctx: CliContext = ctx.obj
     log_query = build_activity_log_query(
@@ -104,6 +115,7 @@ def search(  # noqa: WPS211
         from_date=from_date,
         to_date=to_date,
         header=header,
+        default_header=list(_DEFAULT_HEADER_COLUMNS),
     )
     client = _client_factory.make_cloudaz_client(cli_ctx)
     paginator = client.activity_logs.search(log_query, page_size=page_size)
@@ -174,7 +186,10 @@ def export(  # noqa: WPS211
     """Export matching activity logs as raw bytes to ``--output``.
 
     Inline flags follow the same merge semantics as ``search``: they
-    override keys from ``--query PATH`` when both are supplied.
+    override keys from ``--query PATH`` when both are supplied. In
+    inline-build mode ``toDate`` and ``header`` are defaulted the same
+    way as ``search`` to satisfy live reporter servers that reject
+    payloads missing those fields.
     """
     cli_ctx: CliContext = ctx.obj
     log_query = build_activity_log_query(
@@ -187,6 +202,7 @@ def export(  # noqa: WPS211
         from_date=from_date,
         to_date=to_date,
         header=header,
+        default_header=list(_DEFAULT_HEADER_COLUMNS),
     )
     client = _client_factory.make_cloudaz_client(cli_ctx)
     payload = client.activity_logs.export(log_query)

--- a/tests/test_activity_log_query_builder.py
+++ b/tests/test_activity_log_query_builder.py
@@ -31,11 +31,10 @@ def test_inline_only_uses_flag_values_and_defaults() -> None:
 
 
 def test_inline_only_missing_required_fields_errors() -> None:
-    with pytest.raises(NextLabsError) as exc_info:
-        build_activity_log_query(None)
+    import click
 
-    message = str(exc_info.value)
-    assert "field_name" in message or "fieldName" in message
+    with pytest.raises(click.exceptions.Exit):
+        build_activity_log_query(None)
 
 
 def test_file_only_preserves_existing_behaviour(tmp_path: Path) -> None:
@@ -172,3 +171,144 @@ def test_invalid_date_errors() -> None:
         )
 
     assert "from-date" in str(exc_info.value) or "from_date" in str(exc_info.value)
+
+
+def test_inline_missing_flags_prints_friendly_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import click
+
+    with pytest.raises(click.exceptions.Exit):
+        build_activity_log_query(None)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Missing required option" in combined
+    assert "--field-name" in combined
+    assert "--field-value" in combined
+    assert "--query PATH" in combined
+    assert "validation error" not in combined.lower()
+
+
+def test_inline_missing_field_value_only(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import click
+
+    with pytest.raises(click.exceptions.Exit):
+        build_activity_log_query(None, field_name="u")
+
+    combined = capsys.readouterr().out + capsys.readouterr().err
+    assert "--field-value" in combined
+    assert "--field-name" not in combined
+
+
+def test_inline_from_date_defaults_to_date_to_now(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 4_242_000)
+
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        from_date="1737014400000",
+    )
+
+    assert query.from_date == 1_737_014_400_000
+    assert query.to_date == 4_242_000
+
+
+def test_inline_explicit_to_date_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 4_242_000)
+
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        from_date="1737014400000",
+        to_date="1737100800000",
+    )
+
+    assert query.to_date == 1_737_100_800_000
+
+
+def test_inline_without_from_date_does_not_set_to_date() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+    )
+
+    assert query.from_date is None
+    assert query.to_date is None
+
+
+def test_inline_default_header_applied_when_not_supplied() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        default_header=["ROW_ID", "TIME", "USER_NAME"],
+    )
+
+    assert query.header == ["ROW_ID", "TIME", "USER_NAME"]
+
+
+def test_inline_supplied_header_overrides_default() -> None:
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        header=["A", "B"],
+        default_header=["ROW_ID", "TIME", "USER_NAME"],
+    )
+
+    assert query.header == ["A", "B"]
+
+
+def test_file_mode_does_not_inject_to_date_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 4_242_000)
+
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "AD",
+            "sort_by": "time",
+            "sort_order": "descending",
+            "field_name": "u",
+            "field_value": "v",
+            "from_date": 1_700_000_000,
+        },
+    )
+
+    query = build_activity_log_query(path)
+
+    assert query.to_date is None
+
+
+def test_file_mode_does_not_inject_default_header(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "AD",
+            "sort_by": "time",
+            "sort_order": "descending",
+            "field_name": "u",
+            "field_value": "v",
+        },
+    )
+
+    query = build_activity_log_query(path, default_header=["ROW_ID"])
+
+    assert query.header is None

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -457,7 +457,137 @@ def test_activity_logs_search_inline_missing_required_errors(
     )
 
     assert result.exit_code == 1
-    assert "Invalid activity log query" in result.output
+    assert "Missing required option" in result.output
+    assert "--field-name" in result.output
+    assert "--field-value" in result.output
+    assert "validation error" not in result.output.lower()
+
+
+def test_activity_logs_search_inline_defaults_to_date_and_header(
+    stub: tuple[Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 9_999_000)
+
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "search",
+            "--field-name",
+            "u",
+            "--field-value",
+            "v",
+            "--from-date",
+            "1737014400000",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].to_date == 9_999_000
+    assert "ROW_ID" in captured["query"].header
+    assert "FROM_RESOURCE_PATH" in captured["query"].header
+    assert "LOG_LEVEL" in captured["query"].header
+
+
+def test_activity_logs_export_inline_defaults_to_date_and_header(
+    stub: tuple[Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 7_777_000)
+
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(query: ActivityLogQuery) -> bytes:
+        captured["query"] = query
+        return b"csv"
+
+    when(service).export(...).thenAnswer(_fake)
+
+    out = tmp_path / "export.csv"
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "activity-logs",
+            "export",
+            "--output",
+            str(out),
+            "--field-name",
+            "u",
+            "--field-value",
+            "v",
+            "--from-date",
+            "1737014400000",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].to_date == 7_777_000
+    assert "ROW_ID" in captured["query"].header
+
+
+def test_activity_logs_search_file_mode_does_not_inject_defaults(
+    stub: tuple[Any, Any],
+    query_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 9_999_000)
+
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "activity-logs", "search", "--query", str(query_file)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["query"].header is None
+
+
+def test_activity_logs_export_inline_missing_required_errors(
+    stub: tuple[Any, Any],
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "export.csv"
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "activity-logs", "export", "--output", str(out)],
+    )
+
+    assert result.exit_code == 1
+    assert "Missing required option" in result.output
+    assert "--field-name" in result.output
+    assert "--field-value" in result.output
 
 
 def test_activity_logs_export_inline_flags_only(


### PR DESCRIPTION
Completes the remaining delta from the `activity-logs search/export` inline-flags plan (PR #124 delivered the bulk of it).

### What this PR adds

1. **Friendly missing-flag error.** When `--query` is omitted and `--field-name`/`--field-value` are missing, the CLI now prints a one-line `Error: Missing required option: --field-name, --field-value (or provide --query PATH …)` and exits 1, instead of leaking Pydantic's multi-line validation dump. Mirrors the style of `_pdp_payload_helpers.require_flags`.

2. **`toDate` default = now.** In inline-build mode, if `--from-date` is supplied without `--to-date`, we set `toDate = now_epoch_ms()`. Copies the pattern already used by `audit-logs search`. Live reporter servers return 500 when `toDate` is absent.

3. **`header` default = CLI-rendered columns.** In inline-build mode, when no `--header` flag is supplied, we populate `header` with the uppercased field keys of `_ENFORCEMENT_COLUMNS` + `_ENFORCEMENT_WIDE_COLUMNS` (`ROW_ID`, `TIME`, `USER_NAME`, `POLICY_NAME`, `POLICY_DECISION`, `ACTION`, `FROM_RESOURCE_NAME`, `FROM_RESOURCE_PATH`, `TO_RESOURCE_NAME`, `ACTION_SHORT_CODE`, `LOG_LEVEL`). User-supplied `--header` values replace the default wholesale. Same 500-avoidance rationale.

4. **File-mode stays verbatim.** None of the above defaults are injected when `--query PATH` is given — file payloads are still forwarded as-is, matching the audit-logs contract.

5. **Docstrings on `search` / `export`** now document the server-quirk workaround, mirroring the existing note on `audit-logs export`.

### Tests

- Builder unit tests for: friendly-error exit, single-missing-flag naming, `toDate` default injection, explicit `to_date` preserved, default header applied / overridden, file-mode defaults not injected.
- CLI-level tests for: `search` inline friendly error, `search` inline defaults in the posted payload, `export` inline defaults, `export` inline friendly error, file-mode does not inject header default.

### Verification

- `python ./tools/checks.py --short` — 4/4 passed
- `python ./tools/tests.py --short` — 2154 passed, coverage 95.91%