### PR TITLE
fix(cli): narrow activity-logs default header to spec-example columns

### DIFF
--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -33,8 +33,14 @@ _ENFORCEMENT_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
     ColumnDef("Log Level", "log_level"),
 )
 
-_DEFAULT_HEADER_COLUMNS: tuple[str, ...] = tuple(
-    col.field.upper() for col in (*_ENFORCEMENT_COLUMNS, *_ENFORCEMENT_WIDE_COLUMNS)
+_DEFAULT_HEADER_COLUMNS: tuple[str, ...] = (
+    "ROW_ID",
+    "TIME",
+    "USER_NAME",
+    "FROM_RESOURCE_NAME",
+    "POLICY_NAME",
+    "POLICY_DECISION",
+    "ACTION",
 )
 
 _ATTRIBUTE_COLUMNS = (
@@ -101,8 +107,13 @@ def search(  # noqa: WPS211
     ``toDate`` or ``header`` are absent. In inline-build mode this
     command therefore defaults ``toDate`` to now when ``--from-date`` is
     supplied without ``--to-date``, and populates ``header`` with the
-    CLI's rendered column set when ``--header`` is not given. Payloads
-    loaded via ``--query PATH`` are forwarded verbatim.
+    OpenAPI spec's example column set (``ROW_ID``, ``TIME``,
+    ``USER_NAME``, ``FROM_RESOURCE_NAME``, ``POLICY_NAME``,
+    ``POLICY_DECISION``, ``ACTION``) when ``--header`` is not given.
+    Non-example columns have been observed to be rejected by live
+    servers; pass ``--header`` explicitly to request additional columns
+    your deployment supports. Payloads loaded via ``--query PATH`` are
+    forwarded verbatim.
     """
     cli_ctx: CliContext = ctx.obj
     log_query = build_activity_log_query(

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -499,9 +499,15 @@ def test_activity_logs_search_inline_defaults_to_date_and_header(
 
     assert result.exit_code == 0, result.output
     assert captured["query"].to_date == 9_999_000
-    assert "ROW_ID" in captured["query"].header
-    assert "FROM_RESOURCE_PATH" in captured["query"].header
-    assert "LOG_LEVEL" in captured["query"].header
+    assert captured["query"].header == [
+        "ROW_ID",
+        "TIME",
+        "USER_NAME",
+        "FROM_RESOURCE_NAME",
+        "POLICY_NAME",
+        "POLICY_DECISION",
+        "ACTION",
+    ]
 
 
 def test_activity_logs_export_inline_defaults_to_date_and_header(


### PR DESCRIPTION
Follow-up to #125.

### Problem

A live call (`nextlabs activity-logs search --from-date 5m --field-name sapsid --field-value R3M`) returned an error from the server. The posted body included the CLI's full wide-column union:

```
"header": ["ROW_ID", "TIME", "USER_NAME", "POLICY_NAME", "POLICY_DECISION", "ACTION", "FROM_RESOURCE_NAME", "FROM_RESOURCE_PATH", "TO_RESOURCE_NAME", "ACTION_SHORT_CODE", "LOG_LEVEL"]
```

The OpenAPI `ActivityLogQuery` schema (`tests/_openapi/fixtures/nextlabs-openapi.json`, schema `PolicyActivityLogQueryDTO`) declares a 7-item example for `header`: `ROW_ID, TIME, USER_NAME, FROM_RESOURCE_NAME, POLICY_NAME, POLICY_DECISION, ACTION`. The extra columns `FROM_RESOURCE_PATH`, `TO_RESOURCE_NAME`, `ACTION_SHORT_CODE`, `LOG_LEVEL` are not listed and are not accepted by the live server.

### Fix

Replace the derived `_ENFORCEMENT_COLUMNS + _ENFORCEMENT_WIDE_COLUMNS` default with a hard-coded constant matching the spec example. Users who need additional columns can still pass `--header` explicitly (the override path is unchanged). Docstring on `search` now calls this out.

### Verification

- `python ./tools/tests.py --short tests/test_cli_activity_logs.py tests/test_activity_log_query_builder.py` — 39 passed
- `python ./tools/checks.py --short …` — 4/4 passed