### PR TITLE
fix(cli): relax activity-logs inline defaults for live reporters

### DIFF
--- a/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
+++ b/src/nextlabs_sdk/_cli/_activity_log_query_builder.py
@@ -2,25 +2,27 @@
 
 Supports layered configuration: values from the ``--query`` JSON file
 are overlaid by any inline flags the user explicitly passed. When no
-file is given, defaults reused from the OpenAPI spec fill in optional
-fields so users only need to supply ``field_name`` / ``field_value``.
+file is given, defaults derived from a known-good live payload fill in
+optional fields so users can run ``search`` with no flags at all.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import typer
-
-from nextlabs_sdk._cli._output import print_error
 from nextlabs_sdk._cli._payload_loader import load_payload
 from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
 from nextlabs_sdk._cloudaz._activity_log_query_models import ActivityLogQuery
 from nextlabs_sdk.exceptions import NextLabsError
 
 _DEFAULT_POLICY_DECISION = "AD"
-_DEFAULT_SORT_BY = "time"
+_DEFAULT_SORT_BY = "ROW_ID"
 _DEFAULT_SORT_ORDER = "descending"
+_DEFAULT_FIELD_NAME = ""
+_DEFAULT_FIELD_VALUE = ""
+_DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000
+_FROM_DATE_KEY = "from_date"
+_TO_DATE_KEY = "to_date"
 
 
 def build_activity_log_query(  # noqa: WPS211
@@ -66,13 +68,9 @@ def build_activity_log_query(  # noqa: WPS211
         NextLabsError: If the merged payload fails validation, or if a
             date string cannot be parsed.
         typer.Exit: If the file is missing, unreadable, or not JSON
-            (propagated from :func:`load_payload`), or if required
-            inline flags (``--field-name`` / ``--field-value``) are
-            missing in inline-build mode.
+            (propagated from :func:`load_payload`).
     """
     inline_mode = query_path is None
-    if inline_mode:
-        _require_inline_flags(field_name=field_name, field_value=field_value)
 
     base: dict[str, object] = dict(load_payload(query_path)) if query_path else {}
 
@@ -108,10 +106,28 @@ def _apply_inline_defaults(
     base.setdefault("policy_decision", _DEFAULT_POLICY_DECISION)
     base.setdefault("sort_by", _DEFAULT_SORT_BY)
     base.setdefault("sort_order", _DEFAULT_SORT_ORDER)
-    if "from_date" in base and "to_date" not in base:
-        base["to_date"] = now_epoch_ms()
+    base.setdefault("field_name", _DEFAULT_FIELD_NAME)
+    base.setdefault("field_value", _DEFAULT_FIELD_VALUE)
+    _apply_date_window_defaults(base)
     if default_header is not None and "header" not in base:
         base["header"] = list(default_header)
+
+
+def _apply_date_window_defaults(base: dict[str, object]) -> None:
+    has_from = _FROM_DATE_KEY in base
+    has_to = _TO_DATE_KEY in base
+    if has_from and has_to:
+        return
+    now = now_epoch_ms()
+    if not has_from and not has_to:
+        base[_FROM_DATE_KEY] = now - _DEFAULT_WINDOW_MS
+        base[_TO_DATE_KEY] = now
+    elif has_from and not has_to:
+        base[_TO_DATE_KEY] = now
+    else:
+        to_date = base[_TO_DATE_KEY]
+        assert isinstance(to_date, int)
+        base[_FROM_DATE_KEY] = to_date - _DEFAULT_WINDOW_MS
 
 
 def _collect_overrides(  # noqa: WPS211
@@ -156,19 +172,3 @@ def _parse_date(raw: str, flag: str) -> int:
         return parse_time(raw)
     except ValueError as exc:
         raise NextLabsError(f"Invalid {flag} value: {exc}") from None
-
-
-def _require_inline_flags(*, field_name: str | None, field_value: str | None) -> None:
-    missing: list[str] = []
-    if field_name is None:
-        missing.append("--field-name")
-    if field_value is None:
-        missing.append("--field-value")
-    if not missing:
-        return
-    joined = ", ".join(missing)
-    print_error(
-        f"Missing required option: {joined} "
-        "(or provide --query PATH to supply them from a JSON file)",
-    )
-    raise typer.Exit(code=1)

--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -99,21 +99,22 @@ def search(  # noqa: WPS211
 
     Inline flags may be combined with ``--query PATH``. When both are
     supplied, inline flag values override the corresponding keys in the
-    file. When ``--query`` is omitted, ``--field-name`` and
-    ``--field-value`` are required; other optional fields fall back to
-    spec-example defaults.
+    file. All inline flags are optional: ``--field-name`` and
+    ``--field-value`` default to empty strings (unfiltered) and the
+    other fields fall back to a known-good live payload's values.
 
     Live reporter servers have been observed to return 500 when
     ``toDate`` or ``header`` are absent. In inline-build mode this
-    command therefore defaults ``toDate`` to now when ``--from-date`` is
-    supplied without ``--to-date``, and populates ``header`` with the
-    OpenAPI spec's example column set (``ROW_ID``, ``TIME``,
-    ``USER_NAME``, ``FROM_RESOURCE_NAME``, ``POLICY_NAME``,
-    ``POLICY_DECISION``, ``ACTION``) when ``--header`` is not given.
-    Non-example columns have been observed to be rejected by live
-    servers; pass ``--header`` explicitly to request additional columns
-    your deployment supports. Payloads loaded via ``--query PATH`` are
-    forwarded verbatim.
+    command therefore defaults the date window to the last 24 hours
+    (both ``fromDate`` and ``toDate`` are set; a lone ``--from-date``
+    defaults ``toDate`` to now, a lone ``--to-date`` defaults
+    ``fromDate`` to 24 hours earlier), and populates ``header`` with
+    ``ROW_ID``, ``TIME``, ``USER_NAME``, ``FROM_RESOURCE_NAME``,
+    ``POLICY_NAME``, ``POLICY_DECISION``, ``ACTION`` when ``--header``
+    is not given. Non-example columns have been observed to be rejected
+    by live servers; pass ``--header`` explicitly to request additional
+    columns your deployment supports. Payloads loaded via
+    ``--query PATH`` are forwarded verbatim.
     """
     cli_ctx: CliContext = ctx.obj
     log_query = build_activity_log_query(
@@ -197,10 +198,11 @@ def export(  # noqa: WPS211
     """Export matching activity logs as raw bytes to ``--output``.
 
     Inline flags follow the same merge semantics as ``search``: they
-    override keys from ``--query PATH`` when both are supplied. In
-    inline-build mode ``toDate`` and ``header`` are defaulted the same
-    way as ``search`` to satisfy live reporter servers that reject
-    payloads missing those fields.
+    override keys from ``--query PATH`` when both are supplied. All
+    inline flags are optional. In inline-build mode ``toDate``,
+    ``fromDate``, and ``header`` are defaulted the same way as
+    ``search`` to satisfy live reporter servers that reject payloads
+    missing those fields.
     """
     cli_ctx: CliContext = ctx.obj
     log_query = build_activity_log_query(

--- a/tests/test_activity_log_query_builder.py
+++ b/tests/test_activity_log_query_builder.py
@@ -26,15 +26,32 @@ def test_inline_only_uses_flag_values_and_defaults() -> None:
     assert query.field_name == "user_name"
     assert query.field_value == "alice"
     assert query.policy_decision == "AD"
-    assert query.sort_by == "time"
+    assert query.sort_by == "ROW_ID"
     assert query.sort_order == "descending"
 
 
-def test_inline_only_missing_required_fields_errors() -> None:
-    import click
+def test_inline_no_flags_uses_empty_field_defaults() -> None:
+    query = build_activity_log_query(None)
 
-    with pytest.raises(click.exceptions.Exit):
-        build_activity_log_query(None)
+    assert query.field_name == ""
+    assert query.field_value == ""
+    assert query.policy_decision == "AD"
+    assert query.sort_by == "ROW_ID"
+    assert query.sort_order == "descending"
+
+
+def test_inline_only_field_name_defaults_field_value_to_empty() -> None:
+    query = build_activity_log_query(None, field_name="sapsid")
+
+    assert query.field_name == "sapsid"
+    assert query.field_value == ""
+
+
+def test_inline_only_field_value_defaults_field_name_to_empty() -> None:
+    query = build_activity_log_query(None, field_value="R3M")
+
+    assert query.field_name == ""
+    assert query.field_value == "R3M"
 
 
 def test_file_only_preserves_existing_behaviour(tmp_path: Path) -> None:
@@ -173,34 +190,18 @@ def test_invalid_date_errors() -> None:
     assert "from-date" in str(exc_info.value) or "from_date" in str(exc_info.value)
 
 
-def test_inline_missing_flags_prints_friendly_error(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    import click
+def test_inline_missing_flags_no_longer_errors() -> None:
+    query = build_activity_log_query(None)
 
-    with pytest.raises(click.exceptions.Exit):
-        build_activity_log_query(None)
-
-    captured = capsys.readouterr()
-    combined = captured.out + captured.err
-    assert "Missing required option" in combined
-    assert "--field-name" in combined
-    assert "--field-value" in combined
-    assert "--query PATH" in combined
-    assert "validation error" not in combined.lower()
+    assert query.field_name == ""
+    assert query.field_value == ""
 
 
-def test_inline_missing_field_value_only(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    import click
+def test_inline_partial_flags_no_longer_errors() -> None:
+    query = build_activity_log_query(None, field_name="u")
 
-    with pytest.raises(click.exceptions.Exit):
-        build_activity_log_query(None, field_name="u")
-
-    combined = capsys.readouterr().out + capsys.readouterr().err
-    assert "--field-value" in combined
-    assert "--field-name" not in combined
+    assert query.field_name == "u"
+    assert query.field_value == ""
 
 
 def test_inline_from_date_defaults_to_date_to_now(
@@ -239,15 +240,76 @@ def test_inline_explicit_to_date_preserved(
     assert query.to_date == 1_737_100_800_000
 
 
-def test_inline_without_from_date_does_not_set_to_date() -> None:
+def test_inline_without_from_date_defaults_both(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 4_242_000)
+
     query = build_activity_log_query(
         None,
         field_name="u",
         field_value="v",
     )
 
-    assert query.from_date is None
-    assert query.to_date is None
+    assert query.to_date == 4_242_000
+    assert query.from_date == 4_242_000 - 24 * 60 * 60 * 1000
+
+
+def test_inline_without_dates_defaults_last_24h(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    now_ms = 1_737_014_400_000
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: now_ms)
+
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+    )
+
+    assert query.to_date == now_ms
+    assert query.from_date == now_ms - 24 * 60 * 60 * 1000
+
+
+def test_inline_only_to_date_defaults_from_date_24h_earlier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nextlabs_sdk._cli import _activity_log_query_builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "now_epoch_ms", lambda: 9_999_000)
+
+    query = build_activity_log_query(
+        None,
+        field_name="u",
+        field_value="v",
+        to_date="1737100800000",
+    )
+
+    assert query.to_date == 1_737_100_800_000
+    assert query.from_date == 1_737_100_800_000 - 24 * 60 * 60 * 1000
+
+
+def test_inline_query_path_forwarded_verbatim(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "q.json",
+        {
+            "policy_decision": "AD",
+            "sort_by": "time",
+            "sort_order": "descending",
+            "field_name": "u",
+            "field_value": "v",
+        },
+    )
+
+    query = build_activity_log_query(path)
+
+    assert query.sort_by == "time"
+    assert query.field_name == "u"
+    assert query.field_value == "v"
 
 
 def test_inline_default_header_applied_when_not_supplied() -> None:

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -342,7 +342,7 @@ def test_activity_logs_search_inline_flags_only(
     assert captured["query"].field_name == "user_name"
     assert captured["query"].field_value == "alice"
     assert captured["query"].policy_decision == "AD"
-    assert captured["query"].sort_by == "time"
+    assert captured["query"].sort_by == "ROW_ID"
     assert captured["query"].sort_order == "descending"
 
 
@@ -448,19 +448,29 @@ def test_activity_logs_search_from_date_epoch_ms(
     assert captured["query"].from_date == 1_737_014_400_000
 
 
-def test_activity_logs_search_inline_missing_required_errors(
+def test_activity_logs_search_inline_no_flags_succeeds(
     stub: tuple[Any, Any],
 ) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(
+        query: ActivityLogQuery, *, page_size: int
+    ) -> SyncPaginator[EnforcementEntry]:
+        captured["query"] = query
+        return _paginator()
+
+    when(service).search(...).thenAnswer(_fake)
+
     result = runner.invoke(
         app,
         [*_GLOBAL_OPTS, "activity-logs", "search"],
     )
 
-    assert result.exit_code == 1
-    assert "Missing required option" in result.output
-    assert "--field-name" in result.output
-    assert "--field-value" in result.output
-    assert "validation error" not in result.output.lower()
+    assert result.exit_code == 0, result.output
+    assert captured["query"].field_name == ""
+    assert captured["query"].field_value == ""
+    assert captured["query"].sort_by == "ROW_ID"
 
 
 def test_activity_logs_search_inline_defaults_to_date_and_header(
@@ -580,20 +590,29 @@ def test_activity_logs_search_file_mode_does_not_inject_defaults(
     assert captured["query"].header is None
 
 
-def test_activity_logs_export_inline_missing_required_errors(
+def test_activity_logs_export_inline_no_flags_succeeds(
     stub: tuple[Any, Any],
     tmp_path: Path,
 ) -> None:
+    _, service = stub
+    captured: dict[str, Any] = {}
+
+    def _fake(query: ActivityLogQuery) -> bytes:
+        captured["query"] = query
+        return b"csv"
+
+    when(service).export(...).thenAnswer(_fake)
+
     out = tmp_path / "export.csv"
     result = runner.invoke(
         app,
         [*_GLOBAL_OPTS, "activity-logs", "export", "--output", str(out)],
     )
 
-    assert result.exit_code == 1
-    assert "Missing required option" in result.output
-    assert "--field-name" in result.output
-    assert "--field-value" in result.output
+    assert result.exit_code == 0, result.output
+    assert captured["query"].field_name == ""
+    assert captured["query"].field_value == ""
+    assert captured["query"].sort_by == "ROW_ID"
 
 
 def test_activity_logs_export_inline_flags_only(


### PR DESCRIPTION
## Problem

`nextlabs activity-logs search --from-date 5m --field-name sapsid --field-value R3M` produces a 400 from live reporters:

```json
{"statusCode":"6000","message":"An internal server error occurred."}
```

A known-good payload from the same deployment uses `sortBy: "ROW_ID"` (not `"time"`), empty `fieldName` / `fieldValue`, and an explicit `fromDate`+`toDate` window.

## Changes

All localised to the inline-build path:

- `_activity_log_query_builder.py`
  - `sort_by` default: `time` → `ROW_ID` (uppercase header column key)
  - `field_name` / `field_value` default to empty string (unfiltered) instead of being required
  - Date window: defaults last 24 h when neither date is supplied; lone `--to-date` now back-fills `from_date = to_date − 24 h`; lone `--from-date` continues to default `to_date` to now (unchanged)
  - Removed `_require_inline_flags` — `nextlabs activity-logs search` now runs with zero flags
- Docstrings on `search` and `export` updated to match.
- Tests: existing inline-mode tests retargeted; added coverage for the new no-flag, lone-to-date, and `--query PATH` verbatim-forward cases.

File-mode (`--query PATH`) payloads are still forwarded verbatim.

## Checks

`python ./tools/checks.py --short` and `python ./tools/tests.py --short` both pass locally (2159 passed, coverage 95.92%).