### PR TITLE
feat(cloudaz): re-export component, policy models and services

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ per-file-ignores =
   # inline noqa in this file, so WPS211 stays here too.
   src/nextlabs_sdk/_cli/_app.py: WPS211, WPS404
 
+  # Public facade: re-exports all public symbols for downstream consumers.
+  src/nextlabs_sdk/_cloudaz/__init__.py: WPS203
   # Add module-specific relaxations as needed. Examples:
   # src/nextlabs_sdk/orchestrator.py: WPS211, WPS234  # many args + deep imports
   # **/*_interface.py: WPS420, WPS463               # abstract methods

--- a/src/nextlabs_sdk/_cli/_error_handler.py
+++ b/src/nextlabs_sdk/_cli/_error_handler.py
@@ -6,8 +6,8 @@ from collections.abc import Callable
 from dataclasses import replace
 from typing import ParamSpec, TypeVar
 
-import click
 import typer
+from typer._click.core import Context as _ClickContext
 from rich.console import Console
 
 from nextlabs_sdk._cli._context import CliContext
@@ -57,12 +57,12 @@ def _format_error_message(exc: BaseException) -> str:
 def _extract_typer_context(
     args: tuple[object, ...],
     kwargs: dict[str, object] | None = None,
-) -> click.Context | None:
+) -> _ClickContext | None:
     for arg in args:
-        if isinstance(arg, click.Context):
+        if isinstance(arg, _ClickContext):
             return arg
     for ctx_value in (kwargs or {}).values():
-        if isinstance(ctx_value, click.Context):
+        if isinstance(ctx_value, _ClickContext):
             return ctx_value
     return None
 

--- a/src/nextlabs_sdk/_cloudaz/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/__init__.py
@@ -14,9 +14,35 @@ from nextlabs_sdk._cloudaz._audit_log_models import (
     ExportAuditLogsRequest as ExportAuditLogsRequest,
 )
 from nextlabs_sdk._cloudaz._client import CloudAzClient as CloudAzClient
+from nextlabs_sdk._cloudaz._component_models import Component as Component
+from nextlabs_sdk._cloudaz._component_models import ComponentLite as ComponentLite
+from nextlabs_sdk._cloudaz._component_search import (
+    AsyncComponentSearchService as AsyncComponentSearchService,
+)
+from nextlabs_sdk._cloudaz._component_search import (
+    ComponentSearchService as ComponentSearchService,
+)
+from nextlabs_sdk._cloudaz._components import (
+    AsyncComponentService as AsyncComponentService,
+)
+from nextlabs_sdk._cloudaz._components import ComponentService as ComponentService
 from nextlabs_sdk._cloudaz._models import Operator as Operator
 from nextlabs_sdk._cloudaz._models import Tag as Tag
 from nextlabs_sdk._cloudaz._models import TagType as TagType
+from nextlabs_sdk._cloudaz._policies import (
+    AsyncPolicyService as AsyncPolicyService,
+)
+from nextlabs_sdk._cloudaz._policies import PolicyService as PolicyService
+from nextlabs_sdk._cloudaz._policy_models import Policy as Policy
+from nextlabs_sdk._cloudaz._policy_models import PolicyLite as PolicyLite
+from nextlabs_sdk._cloudaz._policy_search import (
+    AsyncPolicySearchService as AsyncPolicySearchService,
+)
+from nextlabs_sdk._cloudaz._policy_search import (
+    PolicySearchService as PolicySearchService,
+)
+from nextlabs_sdk._cloudaz._tags import AsyncTagService as AsyncTagService
+from nextlabs_sdk._cloudaz._tags import TagService as TagService
 from nextlabs_sdk._cloudaz._report_models import (
     ApplicationUser as ApplicationUser,
 )

--- a/tests/test_activity_log_query_builder.py
+++ b/tests/test_activity_log_query_builder.py
@@ -169,12 +169,12 @@ def test_from_date_parsed_relative(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invalid_json_errors(tmp_path: Path) -> None:
-    import click
+    import typer
 
     path = tmp_path / "bad.json"
     path.write_text("{not json")
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         build_activity_log_query(path)
 
 

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -620,7 +620,7 @@ def test_login_pdp_non_200_includes_body_snippet(
 # ─────────────────────── Recommended regression tests ──────────────────────
 
 
-from click.testing import Result as _CliResult
+from typer.testing import Result as _CliResult
 
 
 def _invoke_pdp_login(secret: str) -> _CliResult:

--- a/tests/test_cli_error_handler.py
+++ b/tests/test_cli_error_handler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import click
 import pytest
 import typer
 
@@ -45,7 +44,7 @@ def _make_cli_ctx(
 
 
 def _make_typer_context(cli_ctx: CliContext) -> typer.Context:
-    command = click.Command("test")
+    command = typer.core.TyperCommand(name="test", callback=lambda: None)
     ctx = typer.Context(command)
     ctx.obj = cli_ctx
     return ctx
@@ -100,7 +99,7 @@ def test_handler_catches_exception(
     def failing():
         raise exc
 
-    with pytest.raises(click.exceptions.Exit) as exc_info:
+    with pytest.raises(typer.Exit) as exc_info:
         failing()
 
     assert exc_info.value.exit_code == 1
@@ -116,7 +115,7 @@ def test_handler_lets_typer_exit_propagate():
 
         raise typer.Exit(code=2)
 
-    with pytest.raises(click.exceptions.Exit) as exc_info:
+    with pytest.raises(typer.Exit) as exc_info:
         failing()
 
     assert exc_info.value.exit_code == 2
@@ -177,7 +176,7 @@ def test_refresh_token_expired_reraises_when_not_tty(
     def command(_ctx: typer.Context) -> None:
         raise RefreshTokenExpiredError("refresh rejected")
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         command(ctx)
 
     captured = capsys.readouterr()
@@ -200,7 +199,7 @@ def test_refresh_token_expired_reraises_when_explicit_password(
     def command(_ctx: typer.Context) -> None:
         raise RefreshTokenExpiredError("refresh rejected")
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         command(ctx)
 
     captured = capsys.readouterr()
@@ -226,7 +225,7 @@ def test_refresh_token_expired_only_retries_once(
         calls.append(_ctx.obj.password)
         raise AuthenticationError("invalid credentials")
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         command(ctx)
 
     captured = capsys.readouterr()

--- a/tests/test_cli_error_handler_verbose.py
+++ b/tests/test_cli_error_handler_verbose.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import click
 import pytest
 import typer
 from strip_ansi import strip_ansi
@@ -24,7 +23,7 @@ def _ctx(verbose: int) -> typer.Context:
         timeout=30.0,
         verbose=verbose,
     )
-    ctx = typer.Context(click.Command("x"))
+    ctx = typer.Context(typer.core.TyperCommand(name="x", callback=lambda: None))
     ctx.obj = cli_ctx
     return ctx
 
@@ -44,7 +43,7 @@ def _run_failing(exc: Exception, verbose: int):
     def failing(ctx: typer.Context):
         raise exc
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         failing(_ctx(verbose=verbose))
 
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from click.exceptions import Exit as ClickExit
 import pytest
+import typer
 
 from nextlabs_sdk._cli._parsing import parse_json_payload, parse_key_value_attrs
 
@@ -24,7 +24,7 @@ def test_parse_json_payload_valid(raw, expected):
     ],
 )
 def test_parse_json_payload_rejects(raw):
-    with pytest.raises(ClickExit):
+    with pytest.raises(typer.Exit):
         parse_json_payload(raw)
 
 
@@ -41,5 +41,5 @@ def test_parse_key_value_attrs_valid(items, expected):
 
 
 def test_parse_key_value_attrs_invalid():
-    with pytest.raises(ClickExit):
+    with pytest.raises(typer.Exit):
         parse_key_value_attrs(["no-equals"])


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. feat(cloudaz): re-export public symbols

Add public re-exports to `nextlabs_sdk._cloudaz.__init__` for symbols that downstream consumers need without reaching into private submodules.

**Models:** `Component`, `ComponentLite`, `Policy`, `PolicyLite`
**Services (sync + async):** `ComponentService`, `ComponentSearchService`, `PolicyService`, `PolicySearchService`, `TagService`

Relaxed WPS203 for the `__init__.py` facade (public surface inherently exceeds 50-import limit).

### 2. fix(cli): adapt error handler and tests to typer 0.26 internals

Typer 0.26 bundles its own click fork as `typer._click`, breaking three assumptions:

1. **`_extract_typer_context`** checked `isinstance(arg, click.Context)` — but typer now passes `typer._click.core.Context` to callbacks. Fixed by checking against the actual base context class.
2. **Tests** used `pytest.raises(click.exceptions.Exit)` — but `typer.Exit` is now `typer._click.exceptions.Exit` (not `click.exceptions.Exit`). Fixed with `pytest.raises(typer.Exit)`.
3. **Tests** created contexts via `click.Command` which mypy rejects. Fixed using `typer.core.TyperCommand`.

**Result: 24 pre-existing test failures → 0 failures (2159 passed)**