### PR TITLE
feat(cloudaz): re-export missing models and services via public facade

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,8 @@ per-file-ignores =
 
   # Public facade: re-exports all public symbols for downstream consumers.
   src/nextlabs_sdk/_cloudaz/__init__.py: WPS203
+  # Public facade (external): same pattern, plus __all__ metadata.
+  src/nextlabs_sdk/cloudaz/__init__.py: WPS201, WPS203, WPS410, WPS412
   # Add module-specific relaxations as needed. Examples:
   # src/nextlabs_sdk/orchestrator.py: WPS211, WPS234  # many args + deep imports
   # **/*_interface.py: WPS420, WPS463               # abstract methods

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -33,7 +33,6 @@ from nextlabs_sdk._cli._expiry_format import format_expiry
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
 
-
 auth_app = typer.Typer(help="Authentication commands")
 
 _NO_ACCOUNTS_MESSAGE = "No cached accounts. Run `nextlabs auth login` to create one."

--- a/src/nextlabs_sdk/cloudaz/__init__.py
+++ b/src/nextlabs_sdk/cloudaz/__init__.py
@@ -3,6 +3,71 @@
 Re-exports the curated CloudAz API from the internal ``_cloudaz`` package.
 """
 
+__all__: list[str] = [
+    # Clients
+    "AsyncCloudAzClient",
+    "CloudAzClient",
+    # Models
+    "ActivityByEntity",
+    "ActivityLogAttribute",
+    "ActivityLogQuery",
+    "Alert",
+    "ApplicationUser",
+    "AttributeMapping",
+    "AttributeMappings",
+    "AuditLogEntry",
+    "AuditLogQuery",
+    "AuditLogUser",
+    "CachedPolicy",
+    "CachedUser",
+    "Component",
+    "ComponentLite",
+    "DeleteReportsRequest",
+    "EnforcementEntry",
+    "EnforcementTimeBucket",
+    "ExportAuditLogsRequest",
+    "FilterCriteria",
+    "FilterField",
+    "MonitorTagAlert",
+    "Policy",
+    "PolicyActivity",
+    "PolicyActivityReport",
+    "PolicyActivityReportDetail",
+    "PolicyActivityReportRequest",
+    "PolicyDayBucket",
+    "PolicyLite",
+    "PolicyModelAction",
+    "ReportCriteria",
+    "ReportFilterGeneral",
+    "ReportFilters",
+    "ReportOrderBy",
+    "ReportWidget",
+    "ReporterAuditLogEntry",
+    "ResourceActions",
+    "SaveInfo",
+    "SavedReportCriteria",
+    "SavedSearch",
+    "SearchCriteria",
+    "SystemConfig",
+    "UserGroup",
+    "WidgetData",
+    # Services
+    "AsyncComponentSearchService",
+    "AsyncComponentService",
+    "AsyncPolicySearchService",
+    "AsyncPolicyService",
+    "AsyncTagService",
+    "ComponentSearchService",
+    "ComponentService",
+    "PolicySearchService",
+    "PolicyService",
+    "TagService",
+    # Enums/Types
+    "Operator",
+    "Tag",
+    "TagType",
+]
+
 from nextlabs_sdk._cloudaz._async_client import (
     AsyncCloudAzClient as AsyncCloudAzClient,
 )
@@ -19,9 +84,35 @@ from nextlabs_sdk._cloudaz._audit_log_models import (
     ExportAuditLogsRequest as ExportAuditLogsRequest,
 )
 from nextlabs_sdk._cloudaz._client import CloudAzClient as CloudAzClient
+from nextlabs_sdk._cloudaz._component_models import Component as Component
+from nextlabs_sdk._cloudaz._component_models import ComponentLite as ComponentLite
+from nextlabs_sdk._cloudaz._component_search import (
+    AsyncComponentSearchService as AsyncComponentSearchService,
+)
+from nextlabs_sdk._cloudaz._component_search import (
+    ComponentSearchService as ComponentSearchService,
+)
+from nextlabs_sdk._cloudaz._components import (
+    AsyncComponentService as AsyncComponentService,
+)
+from nextlabs_sdk._cloudaz._components import ComponentService as ComponentService
 from nextlabs_sdk._cloudaz._models import Operator as Operator
 from nextlabs_sdk._cloudaz._models import Tag as Tag
 from nextlabs_sdk._cloudaz._models import TagType as TagType
+from nextlabs_sdk._cloudaz._policies import (
+    AsyncPolicyService as AsyncPolicyService,
+)
+from nextlabs_sdk._cloudaz._policies import PolicyService as PolicyService
+from nextlabs_sdk._cloudaz._policy_models import Policy as Policy
+from nextlabs_sdk._cloudaz._policy_models import PolicyLite as PolicyLite
+from nextlabs_sdk._cloudaz._policy_search import (
+    AsyncPolicySearchService as AsyncPolicySearchService,
+)
+from nextlabs_sdk._cloudaz._policy_search import (
+    PolicySearchService as PolicySearchService,
+)
+from nextlabs_sdk._cloudaz._tags import AsyncTagService as AsyncTagService
+from nextlabs_sdk._cloudaz._tags import TagService as TagService
 from nextlabs_sdk._cloudaz._report_models import (
     ApplicationUser as ApplicationUser,
 )

--- a/tests/_openapi/parity_allowlist.py
+++ b/tests/_openapi/parity_allowlist.py
@@ -23,7 +23,6 @@ entries stay stable across file moves.
 
 from __future__ import annotations
 
-
 # (model_name, field_alias) — SDK requires, spec does not.
 REQUIRED_ONLY_IN_SDK: frozenset[tuple[str, str]] = frozenset(
     (

--- a/tests/test_cloudaz_exports.py
+++ b/tests/test_cloudaz_exports.py
@@ -1,0 +1,61 @@
+"""Export-verification tests for the ``nextlabs_sdk.cloudaz`` facade."""
+
+import importlib
+
+import pytest
+
+from nextlabs_sdk.cloudaz import __all__ as cloudaz_all
+
+
+def _cloudaz_module() -> object:
+    return importlib.import_module("nextlabs_sdk.cloudaz")
+
+
+class TestCloudazModelImports:
+    """AC1: Core model classes are importable from the public facade."""
+
+    @pytest.mark.parametrize(
+        "symbol",
+        ["Policy", "PolicyLite", "Component", "ComponentLite"],
+    )
+    def test_model_importable(self, symbol: str) -> None:
+        mod = _cloudaz_module()
+        obj = getattr(mod, symbol, None)
+        assert obj is not None, f"{symbol} not found in nextlabs_sdk.cloudaz"
+
+
+class TestCloudazServiceImports:
+    """AC2: Service classes (sync, async, search) are importable."""
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "PolicyService",
+            "AsyncPolicyService",
+            "PolicySearchService",
+            "AsyncPolicySearchService",
+            "ComponentService",
+            "AsyncComponentService",
+            "ComponentSearchService",
+            "AsyncComponentSearchService",
+            "TagService",
+            "AsyncTagService",
+        ],
+    )
+    def test_service_importable(self, symbol: str) -> None:
+        mod = _cloudaz_module()
+        obj = getattr(mod, symbol, None)
+        assert obj is not None, f"{symbol} not found in nextlabs_sdk.cloudaz"
+
+
+class TestCloudazAllExports:
+    """AC4: ``__all__`` lists every public symbol and each is importable."""
+
+    @pytest.mark.parametrize("symbol", cloudaz_all)
+    def test_all_symbol_importable(self, symbol: str) -> None:
+        mod = _cloudaz_module()
+        obj = getattr(mod, symbol, None)
+        assert obj is not None, (
+            f"__all__ lists '{symbol}' but it is not importable "
+            f"from nextlabs_sdk.cloudaz"
+        )


### PR DESCRIPTION
Closes #144

## Summary
- Added 14 missing re-exports (Policy, PolicyLite, Component, ComponentLite, PolicyService, AsyncPolicyService, PolicySearchService, AsyncPolicySearchService, ComponentService, AsyncComponentService, ComponentSearchService, AsyncComponentSearchService, TagService, AsyncTagService) to the public `nextlabs_sdk.cloudaz` facade
- Defined `__all__` with alphabetical ordering within logical groups (Clients, Models, Services, Enums/Types) and group comments
- Added `tests/test_cloudaz_exports.py` with parametrized tests verifying all 58 symbols in `__all__` are importable, plus dedicated AC-specific tests for model and service imports

## Tests added (red → green)
- `TestCloudazModelImports::test_model_importable` — AC1: Policy, PolicyLite, Component, ComponentLite importable
- `TestCloudazServiceImports::test_service_importable` — AC2: all sync/async/search service classes importable
- `TestCloudazAllExports::test_all_symbol_importable` — AC4: every `__all__` entry resolves to a real symbol

## Notable assumptions
- Used `importlib.import_module` helper in tests to avoid WPS301 (dotted raw import) lint violation
- Black pre-commit reformatted two unrelated files (`_auth_cmd.py`, `parity_allowlist.py`) with trivial whitespace changes — included to keep commit clean