### PR TITLE
feat(pdp): add __all__ to PDP facade + verification test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ per-file-ignores =
   src/nextlabs_sdk/_cloudaz/__init__.py: WPS203
   # Public facade (external): same pattern, plus __all__ metadata.
   src/nextlabs_sdk/cloudaz/__init__.py: WPS201, WPS203, WPS410, WPS412
+  src/nextlabs_sdk/pdp/__init__.py: WPS201, WPS410, WPS412
   # Add module-specific relaxations as needed. Examples:
   # src/nextlabs_sdk/orchestrator.py: WPS211, WPS234  # many args + deep imports
   # **/*_interface.py: WPS420, WPS463               # abstract methods

--- a/src/nextlabs_sdk/pdp/__init__.py
+++ b/src/nextlabs_sdk/pdp/__init__.py
@@ -3,6 +3,37 @@
 Re-exports the curated PDP API from the internal ``_pdp`` package.
 """
 
+__all__: list[str] = [
+    # Clients
+    "AsyncPdpClient",
+    "PdpClient",
+    # Enums/Types
+    "ContentType",
+    "Decision",
+    "ResourceDimension",
+    # Models
+    "Action",
+    "ActionPermission",
+    "Application",
+    "Environment",
+    "EvalRequest",
+    "EvalResponse",
+    "EvalResult",
+    "Obligation",
+    "ObligationAttribute",
+    "PermissionsRequest",
+    "PermissionsResponse",
+    "PolicyRef",
+    "Resource",
+    "Status",
+    "Subject",
+    # Payload
+    "LoadedPayload",
+    "PayloadFormat",
+    "load_eval_payload",
+    "load_permissions_payload",
+]
+
 from nextlabs_sdk._pdp._async_client import AsyncPdpClient as AsyncPdpClient
 from nextlabs_sdk._pdp._client import PdpClient as PdpClient
 from nextlabs_sdk._pdp._payload._format import LoadedPayload as LoadedPayload

--- a/tests/test_pdp_exports.py
+++ b/tests/test_pdp_exports.py
@@ -1,0 +1,24 @@
+"""Export-verification tests for the ``nextlabs_sdk.pdp`` facade."""
+
+import importlib
+
+import pytest
+
+from nextlabs_sdk.pdp import __all__ as pdp_all
+
+
+def _pdp_module() -> object:
+    return importlib.import_module("nextlabs_sdk.pdp")
+
+
+class TestPdpAllExports:
+    """``__all__`` lists every public symbol and each is importable."""
+
+    @pytest.mark.parametrize("symbol", pdp_all)
+    def test_all_symbol_importable(self, symbol: str) -> None:
+        mod = _pdp_module()
+        obj = getattr(mod, symbol, None)
+        assert obj is not None, (
+            f"__all__ lists '{symbol}' but it is not importable "
+            f"from nextlabs_sdk.pdp"
+        )


### PR DESCRIPTION
Closes #145

## Summary
- Added explicit `__all__` to `src/nextlabs_sdk/pdp/__init__.py` with alphabetical grouping and group comments (Clients, Enums/Types, Models, Payload)
- Created `tests/test_pdp_exports.py` with parametrized test verifying all 24 symbols in `__all__` are importable
- Extended `setup.cfg` per-file-ignores for PDP facade (WPS201, WPS410, WPS412), mirroring the existing CloudAz facade pattern

## Tests added (red → green)
- `tests/test_pdp_exports.py::TestPdpAllExports::test_all_symbol_importable` — parametrized over `__all__`, 24 cases

## Notable assumptions
- `setup.cfg` per-file-ignores extended with PDP facade entry mirroring CloudAz facade — structural necessity for any facade with `__all__` and many re-exports