### PR TITLE
refactor(sdk): import clients from public facades + __all__ + export test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,8 @@ per-file-ignores =
 
   # Public facade: re-exports all public symbols for downstream consumers.
   src/nextlabs_sdk/_cloudaz/__init__.py: WPS203
+  # Top-level package: re-exports public API surface with __all__ metadata.
+  src/nextlabs_sdk/__init__.py: WPS410, WPS412
   # Public facade (external): same pattern, plus __all__ metadata.
   src/nextlabs_sdk/cloudaz/__init__.py: WPS201, WPS203, WPS410, WPS412
   src/nextlabs_sdk/pdp/__init__.py: WPS201, WPS410, WPS412

--- a/src/nextlabs_sdk/__init__.py
+++ b/src/nextlabs_sdk/__init__.py
@@ -1,5 +1,32 @@
 """nextlabs-sdk."""
 
+__all__: list[str] = [
+    # Clients
+    "AsyncCloudAzClient",
+    "AsyncPdpClient",
+    "CloudAzClient",
+    "PdpClient",
+    # Config
+    "HttpConfig",
+    "RetryConfig",
+    # Auth
+    "CachedToken",
+    "CloudAzAuth",
+    "FileTokenCache",
+    "NullTokenCache",
+    "PdpAuth",
+    "StaticTokenAuth",
+    "TokenCache",
+    # HTTP / Pagination
+    "AsyncPaginator",
+    "PageResult",
+    "SyncPaginator",
+    "create_async_http_client",
+    "create_http_client",
+    # Version
+    "__version__",
+]
+
 from nextlabs_sdk._auth._cloudaz_auth import CloudAzAuth as CloudAzAuth
 from nextlabs_sdk._auth._pdp_auth import PdpAuth as PdpAuth
 from nextlabs_sdk._auth._static_token_auth import StaticTokenAuth as StaticTokenAuth
@@ -15,10 +42,6 @@ from nextlabs_sdk._auth._token_cache import (
 from nextlabs_sdk._auth._token_cache import (
     TokenCache as TokenCache,
 )
-from nextlabs_sdk._cloudaz._async_client import (
-    AsyncCloudAzClient as AsyncCloudAzClient,
-)
-from nextlabs_sdk._cloudaz._client import CloudAzClient as CloudAzClient
 from nextlabs_sdk._config import HttpConfig as HttpConfig
 from nextlabs_sdk._config import RetryConfig as RetryConfig
 from nextlabs_sdk._http_transport import (
@@ -30,6 +53,8 @@ from nextlabs_sdk._http_transport import (
 from nextlabs_sdk._pagination import AsyncPaginator as AsyncPaginator
 from nextlabs_sdk._pagination import PageResult as PageResult
 from nextlabs_sdk._pagination import SyncPaginator as SyncPaginator
-from nextlabs_sdk._pdp._async_client import AsyncPdpClient as AsyncPdpClient
-from nextlabs_sdk._pdp._client import PdpClient as PdpClient
 from nextlabs_sdk._version import __version__ as __version__
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient as AsyncCloudAzClient
+from nextlabs_sdk.cloudaz import CloudAzClient as CloudAzClient
+from nextlabs_sdk.pdp import AsyncPdpClient as AsyncPdpClient
+from nextlabs_sdk.pdp import PdpClient as PdpClient

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -1,0 +1,16 @@
+"""Verify top-level ``nextlabs_sdk`` re-exports match ``__all__``."""
+
+import nextlabs_sdk
+
+
+class TestTopLevelExports:
+    """Every symbol listed in ``__all__`` must be importable from the package."""
+
+    def test_all_symbols_are_accessible(self) -> None:
+        for name in nextlabs_sdk.__all__:
+            attr = getattr(nextlabs_sdk, name, None)
+            assert attr is not None, f"{name!r} listed in __all__ but not importable"
+
+    def test_backward_compat_cloudaz_client_import(self) -> None:
+        assert hasattr(nextlabs_sdk, "CloudAzClient")
+        assert nextlabs_sdk.CloudAzClient is not None


### PR DESCRIPTION
Closes #147

## Changes

- **Client imports**: `CloudAzClient`/`AsyncCloudAzClient` now imported from `nextlabs_sdk.cloudaz` and `PdpClient`/`AsyncPdpClient` from `nextlabs_sdk.pdp` instead of private `_cloudaz._client`/`_pdp._client` modules.
- **`__all__`**: Defined on the top-level package with alphabetical ordering within logical groups (`# Clients`, `# Config`, `# Auth`, `# HTTP / Pagination`, `# Version`).
- **Export verification test**: `tests/test_top_level_exports.py` iterates `__all__` and asserts every symbol is accessible. Also verifies backward-compatible `CloudAzClient` import.
- **setup.cfg**: Added WPS410/WPS412 per-file-ignore for top-level `__init__.py`, matching the pattern already used by `cloudaz/__init__.py` and `pdp/__init__.py`.