### PR TITLE
refactor(tests): migrate test imports to public facades (#148)

### DIFF
--- a/tests/_openapi/model_registry.py
+++ b/tests/_openapi/model_registry.py
@@ -32,14 +32,12 @@ class _Entry:
 def _entries() -> list[_Entry]:
     # Lazy imports — importing this module during collection must not
     # pull in every SDK submodule.
+    from nextlabs_sdk.cloudaz import Component, Policy, Tag
     from nextlabs_sdk._cloudaz._component_models import (
-        Component,
         Dependency,
         DeploymentResult,
     )
     from nextlabs_sdk._cloudaz._component_type_models import ComponentType
-    from nextlabs_sdk._cloudaz._models import Tag
-    from nextlabs_sdk._cloudaz._policy_models import Policy
 
     return [
         _Entry(

--- a/tests/test_activity_log_query_models.py
+++ b/tests/test_activity_log_query_models.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from nextlabs_sdk._cloudaz._activity_log_query_models import (
-    ActivityLogAttribute,
-    ActivityLogQuery,
-)
+from nextlabs_sdk.cloudaz import ActivityLogAttribute, ActivityLogQuery
 
 
 def _required() -> dict[str, object]:

--- a/tests/test_activity_log_query_service.py
+++ b/tests/test_activity_log_query_service.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import httpx
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._activity_log_query_models import (
+from nextlabs_sdk._cloudaz._activity_logs_service import ReportActivityLogService
+from nextlabs_sdk.cloudaz import (
     ActivityLogAttribute,
     ActivityLogQuery,
+    EnforcementEntry,
 )
-from nextlabs_sdk._cloudaz._activity_logs_service import ReportActivityLogService
-from nextlabs_sdk._cloudaz._report_models import EnforcementEntry
 from nextlabs_sdk._pagination import SyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_activity_log_query_service.py
+++ b/tests/test_async_activity_log_query_service.py
@@ -6,12 +6,12 @@ from typing import Any, Callable, Coroutine, TypeVar
 import httpx
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._activity_log_query_models import (
+from nextlabs_sdk.cloudaz import (
     ActivityLogAttribute,
     ActivityLogQuery,
+    EnforcementEntry,
 )
 from nextlabs_sdk._cloudaz._activity_logs_service import AsyncReportActivityLogService
-from nextlabs_sdk._cloudaz._report_models import EnforcementEntry
 from nextlabs_sdk._pagination import AsyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_audit_log_service.py
+++ b/tests/test_async_audit_log_service.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._audit_log_models import (
+from nextlabs_sdk.cloudaz import (
     AuditLogEntry,
     AuditLogQuery,
     AuditLogUser,

--- a/tests/test_async_cloudaz_client.py
+++ b/tests/test_async_cloudaz_client.py
@@ -8,16 +8,18 @@ import pytest
 from mockito import any as any_value, mock, verify, when
 
 from nextlabs_sdk import _http_transport as transport_mod
-from nextlabs_sdk._cloudaz._async_client import AsyncCloudAzClient
-from nextlabs_sdk._cloudaz._component_search import AsyncComponentSearchService
+from nextlabs_sdk.cloudaz import (
+    AsyncCloudAzClient,
+    AsyncComponentSearchService,
+    AsyncComponentService,
+    AsyncPolicySearchService,
+    AsyncPolicyService,
+    AsyncTagService,
+)
 from nextlabs_sdk._cloudaz._component_type_search import AsyncComponentTypeSearchService
 from nextlabs_sdk._cloudaz._component_types import AsyncComponentTypeService
-from nextlabs_sdk._cloudaz._components import AsyncComponentService
 from nextlabs_sdk._cloudaz._operators import AsyncOperatorService
-from nextlabs_sdk._cloudaz._policies import AsyncPolicyService
-from nextlabs_sdk._cloudaz._policy_search import AsyncPolicySearchService
 from nextlabs_sdk._cloudaz._reporter_audit_logs import AsyncReporterAuditLogService
-from nextlabs_sdk._cloudaz._tags import AsyncTagService
 from nextlabs_sdk._config import HttpConfig
 
 T = TypeVar("T")

--- a/tests/test_async_component_search_service.py
+++ b/tests/test_async_component_search_service.py
@@ -7,12 +7,13 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._component_models import (
+from nextlabs_sdk.cloudaz import (
+    AsyncComponentSearchService,
     ComponentLite,
-    ComponentNameEntry,
+    SavedSearch,
+    SearchCriteria,
 )
-from nextlabs_sdk._cloudaz._component_search import AsyncComponentSearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SearchCriteria
+from nextlabs_sdk._cloudaz._component_models import ComponentNameEntry
 from nextlabs_sdk._pagination import AsyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_component_service.py
+++ b/tests/test_async_component_service.py
@@ -7,12 +7,8 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._component_models import (
-    Component,
-    Dependency,
-    DeploymentResult,
-)
-from nextlabs_sdk._cloudaz._components import AsyncComponentService
+from nextlabs_sdk.cloudaz import AsyncComponentService, Component
+from nextlabs_sdk._cloudaz._component_models import Dependency, DeploymentResult
 
 BASE_URL = "https://cloudaz.example.com"
 

--- a/tests/test_async_component_type_search_service.py
+++ b/tests/test_async_component_type_search_service.py
@@ -8,7 +8,7 @@ from mockito import mock, when
 
 from nextlabs_sdk._cloudaz._component_type_models import ComponentType
 from nextlabs_sdk._cloudaz._component_type_search import AsyncComponentTypeSearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SearchCriteria
+from nextlabs_sdk.cloudaz import SavedSearch, SearchCriteria
 from nextlabs_sdk._pagination import AsyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_dashboard_service.py
+++ b/tests/test_async_dashboard_service.py
@@ -7,13 +7,13 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._dashboard import AsyncDashboardService
-from nextlabs_sdk._cloudaz._dashboard_models import (
+from nextlabs_sdk.cloudaz import (
     ActivityByEntity,
     Alert,
     MonitorTagAlert,
     PolicyActivity,
 )
+from nextlabs_sdk._cloudaz._dashboard import AsyncDashboardService
 
 BASE_URL = "https://cloudaz.example.com"
 _BASE_PATH = "/nextlabs-reporter/api/v1/dashboard"

--- a/tests/test_async_pdp_client.py
+++ b/tests/test_async_pdp_client.py
@@ -9,11 +9,12 @@ import pytest
 from mockito import any as any_value, mock, verify, when
 
 from nextlabs_sdk import _http_transport as transport_mod
-from nextlabs_sdk._pdp._async_client import AsyncPdpClient
-from nextlabs_sdk._pdp._enums import ContentType, Decision
-from nextlabs_sdk._pdp._request_models import (
+from nextlabs_sdk.pdp import (
     Action,
     Application,
+    AsyncPdpClient,
+    ContentType,
+    Decision,
     EvalRequest,
     PermissionsRequest,
     Resource,

--- a/tests/test_async_policy_search_service.py
+++ b/tests/test_async_policy_search_service.py
@@ -6,9 +6,12 @@ from typing import Any, Awaitable, TypeVar
 import httpx
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._policy_models import PolicyLite
-from nextlabs_sdk._cloudaz._policy_search import AsyncPolicySearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SearchCriteria
+from nextlabs_sdk.cloudaz import (
+    AsyncPolicySearchService,
+    PolicyLite,
+    SavedSearch,
+    SearchCriteria,
+)
 from nextlabs_sdk._pagination import AsyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_policy_service.py
+++ b/tests/test_async_policy_service.py
@@ -7,16 +7,9 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._component_models import (
-    Dependency,
-    DeploymentResult,
-)
-from nextlabs_sdk._cloudaz._policies import AsyncPolicyService
-from nextlabs_sdk._cloudaz._policy_models import (
-    ExportOptions,
-    ImportResult,
-    Policy,
-)
+from nextlabs_sdk.cloudaz import AsyncPolicyService, Policy
+from nextlabs_sdk._cloudaz._component_models import Dependency, DeploymentResult
+from nextlabs_sdk._cloudaz._policy_models import ExportOptions, ImportResult
 from nextlabs_sdk.exceptions import NotFoundError
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_async_report_service.py
+++ b/tests/test_async_report_service.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._report_models import (
+from nextlabs_sdk.cloudaz import (
     ApplicationUser,
     AttributeMappings,
     CachedPolicy,

--- a/tests/test_async_reporter_audit_log_service.py
+++ b/tests/test_async_reporter_audit_log_service.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 import httpx
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._reporter_audit_log_models import ReporterAuditLogEntry
+from nextlabs_sdk.cloudaz import ReporterAuditLogEntry
 from nextlabs_sdk._cloudaz._reporter_audit_logs import AsyncReporterAuditLogService
 from nextlabs_sdk._pagination import AsyncPaginator
 

--- a/tests/test_async_tag_service.py
+++ b/tests/test_async_tag_service.py
@@ -6,8 +6,7 @@ from typing import Any, Callable, Coroutine, TypeVar
 import httpx
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._models import Tag, TagType
-from nextlabs_sdk._cloudaz._tags import AsyncTagService
+from nextlabs_sdk.cloudaz import AsyncTagService, Tag, TagType
 from nextlabs_sdk._pagination import AsyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_audit_log_models.py
+++ b/tests/test_audit_log_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from nextlabs_sdk._cloudaz._audit_log_models import (
+from nextlabs_sdk.cloudaz import (
     AuditLogEntry,
     AuditLogQuery,
     AuditLogUser,

--- a/tests/test_audit_log_service.py
+++ b/tests/test_audit_log_service.py
@@ -6,13 +6,13 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._audit_log_models import (
+from nextlabs_sdk._cloudaz._audit_logs import EntityAuditLogService
+from nextlabs_sdk.cloudaz import (
     AuditLogEntry,
     AuditLogQuery,
     AuditLogUser,
     ExportAuditLogsRequest,
 )
-from nextlabs_sdk._cloudaz._audit_logs import EntityAuditLogService
 from nextlabs_sdk._pagination import SyncPaginator
 from nextlabs_sdk.exceptions import ServerError
 

--- a/tests/test_cli_active_account.py
+++ b/tests/test_cli_active_account.py
@@ -13,8 +13,8 @@ from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._cli._context import CliContext
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._operators import OperatorService
+from nextlabs_sdk.cloudaz import CloudAzClient
 
 runner = CliRunner()
 

--- a/tests/test_cli_activity_logs.py
+++ b/tests/test_cli_activity_logs.py
@@ -10,14 +10,14 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._activity_log_query_models import (
+from nextlabs_sdk._cloudaz._activity_logs_service import ReportActivityLogService
+from nextlabs_sdk._pagination import PageResult, SyncPaginator
+from nextlabs_sdk.cloudaz import (
     ActivityLogAttribute,
     ActivityLogQuery,
+    CloudAzClient,
+    EnforcementEntry,
 )
-from nextlabs_sdk._cloudaz._activity_logs_service import ReportActivityLogService
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._report_models import EnforcementEntry
-from nextlabs_sdk._pagination import PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import NextLabsError
 
 runner = CliRunner()

--- a/tests/test_cli_audit_logs.py
+++ b/tests/test_cli_audit_logs.py
@@ -10,10 +10,9 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._audit_log_models import AuditLogEntry
 from nextlabs_sdk._cloudaz._audit_logs import EntityAuditLogService
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._pagination import PageResult, SyncPaginator
+from nextlabs_sdk.cloudaz import AuditLogEntry, CloudAzClient
 
 runner = CliRunner()
 
@@ -161,7 +160,7 @@ def test_search_missing_required_dates():
 
 
 def test_audit_logs_export_with_ids(stubbed_audit: Any, tmp_path: Any) -> None:
-    from nextlabs_sdk._cloudaz._audit_log_models import ExportAuditLogsRequest
+    from nextlabs_sdk.cloudaz import ExportAuditLogsRequest
 
     when(stubbed_audit).export(
         ExportAuditLogsRequest(ids=[1, 2], query=None),
@@ -223,7 +222,7 @@ def test_audit_logs_export_requires_input(stubbed_audit: Any, tmp_path: Any) -> 
 
 
 def test_audit_logs_list_users(stubbed_audit: Any) -> None:
-    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogUser
+    from nextlabs_sdk.cloudaz import AuditLogUser
 
     when(stubbed_audit).list_users().thenReturn(
         [
@@ -254,7 +253,7 @@ def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> int:
 def test_search_accepts_relative_start_date(
     stubbed_audit: Any, frozen_clock: int
 ) -> None:
-    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+    from nextlabs_sdk.cloudaz import AuditLogQuery
 
     expected = AuditLogQuery(
         start_date=frozen_clock - 5 * 60 * 1000,
@@ -278,7 +277,7 @@ def test_search_accepts_relative_start_date(
 def test_search_applies_default_sort_and_page_size(
     stubbed_audit: Any, frozen_clock: int
 ) -> None:
-    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+    from nextlabs_sdk.cloudaz import AuditLogQuery
 
     expected = AuditLogQuery(
         start_date=frozen_clock - 5 * 60 * 1000,
@@ -300,7 +299,7 @@ def test_search_applies_default_sort_and_page_size(
 
 
 def test_search_accepts_iso_dates(stubbed_audit: Any) -> None:
-    from nextlabs_sdk._cloudaz._audit_log_models import AuditLogQuery
+    from nextlabs_sdk.cloudaz import AuditLogQuery
 
     # 2024-01-15T00:00:00Z = 1705276800000; 2024-01-16T00:00:00Z = 1705363200000
     expected = AuditLogQuery(

--- a/tests/test_cli_audit_logs_detail.py
+++ b/tests/test_cli_audit_logs_detail.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _audit_logs_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
-from nextlabs_sdk._cloudaz._audit_log_models import AuditLogEntry
+from nextlabs_sdk.cloudaz import AuditLogEntry
 
 
 def test_audit_log_entry_detail_renders_scalar_fields() -> None:

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -9,8 +9,8 @@ from typer.testing import CliRunner
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._cli._context import CliContext
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._operators import OperatorService
+from nextlabs_sdk.cloudaz import CloudAzClient
 from nextlabs_sdk.exceptions import AuthenticationError
 
 runner = CliRunner()

--- a/tests/test_cli_auth_pdp_login.py
+++ b/tests/test_cli_auth_pdp_login.py
@@ -20,8 +20,8 @@ from nextlabs_sdk._cli._app import app
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
 from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._operators import OperatorService
+from nextlabs_sdk.cloudaz import CloudAzClient
 
 runner = CliRunner()
 

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -16,8 +16,8 @@ from nextlabs_sdk._cli._cache_key import cache_key_for
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cli._pdp_auth_source import PdpAuthSource
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._pdp._client import PdpClient
+from nextlabs_sdk.cloudaz import CloudAzClient
+from nextlabs_sdk.pdp import PdpClient
 
 
 def _make_ctx(

--- a/tests/test_cli_component_types.py
+++ b/tests/test_cli_component_types.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
+from nextlabs_sdk.cloudaz import CloudAzClient
 from nextlabs_sdk._cloudaz._component_type_models import (
     ComponentType,
     ComponentTypeType,

--- a/tests/test_cli_component_types_detail.py
+++ b/tests/test_cli_component_types_detail.py
@@ -6,6 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _component_types_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
+from nextlabs_sdk.cloudaz import Tag, TagType
 from nextlabs_sdk._cloudaz._component_type_models import (
     ActionConfig,
     AttributeConfig,
@@ -15,7 +16,6 @@ from nextlabs_sdk._cloudaz._component_type_models import (
     ObligationConfig,
     ObligationRunAt,
 )
-from nextlabs_sdk._cloudaz._models import Tag, TagType
 
 
 def test_component_type_detail_renders_all_scalar_fields() -> None:

--- a/tests/test_cli_components.py
+++ b/tests/test_cli_components.py
@@ -10,16 +10,18 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._component_models import (
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
     Component,
-    ComponentGroupType,
     ComponentLite,
+    ComponentSearchService,
+    ComponentService,
+)
+from nextlabs_sdk._cloudaz._component_models import (
+    ComponentGroupType,
     ComponentStatus,
     DeploymentResult,
 )
-from nextlabs_sdk._cloudaz._component_search import ComponentSearchService
-from nextlabs_sdk._cloudaz._components import ComponentService
 from nextlabs_sdk._pagination import PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import NotFoundError
 

--- a/tests/test_cli_components_detail.py
+++ b/tests/test_cli_components_detail.py
@@ -6,15 +6,14 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _components_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
+from nextlabs_sdk.cloudaz import Component, Tag, TagType
 from nextlabs_sdk._cloudaz._component_models import (
     Authority,
-    Component,
     ComponentCondition,
     ComponentGroupType,
     ComponentStatus,
     PolicyModelRef,
 )
-from nextlabs_sdk._cloudaz._models import Tag, TagType
 
 
 def test_component_detail_renders_scalar_fields() -> None:

--- a/tests/test_cli_dashboard.py
+++ b/tests/test_cli_dashboard.py
@@ -10,11 +10,11 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._dashboard import DashboardService
-from nextlabs_sdk._cloudaz._dashboard_models import (
+from nextlabs_sdk.cloudaz import (
     ActivityByEntity,
     Alert,
+    CloudAzClient,
     PolicyActivity,
     PolicyDayBucket,
 )
@@ -220,7 +220,7 @@ def test_top_policies_custom_decision():
 
 
 def _make_tag_alert(tag: str = "red", count: int = 3) -> Any:
-    from nextlabs_sdk._cloudaz._dashboard_models import MonitorTagAlert
+    from nextlabs_sdk.cloudaz import MonitorTagAlert
 
     return MonitorTagAlert.model_validate(
         {"tagValue": tag, "monitorName": "Mon", "alertCount": count},

--- a/tests/test_cli_dashboard_detail.py
+++ b/tests/test_cli_dashboard_detail.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _dashboard_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
-from nextlabs_sdk._cloudaz._dashboard_models import PolicyActivity, PolicyDayBucket
+from nextlabs_sdk.cloudaz import PolicyActivity, PolicyDayBucket
 
 
 def _console() -> tuple[Console, io.StringIO]:

--- a/tests/test_cli_operators.py
+++ b/tests/test_cli_operators.py
@@ -9,8 +9,7 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._models import Operator
+from nextlabs_sdk.cloudaz import CloudAzClient, Operator
 from nextlabs_sdk._cloudaz._operators import OperatorService
 
 runner = CliRunner()

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -16,7 +16,7 @@ from nextlabs_sdk._cli._output import (
     render_table,
 )
 from nextlabs_sdk._cli._output_format import OutputFormat
-from nextlabs_sdk._cloudaz._models import Tag, TagType
+from nextlabs_sdk.cloudaz import Tag, TagType
 
 
 def _make_tag() -> Tag:

--- a/tests/test_cli_pdp.py
+++ b/tests/test_cli_pdp.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._pdp import (
+from nextlabs_sdk.pdp import (
     ActionPermission,
     Decision,
     EvalResponse,

--- a/tests/test_cli_pdp_detail.py
+++ b/tests/test_cli_pdp_detail.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _pdp_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
-from nextlabs_sdk._pdp import (
+from nextlabs_sdk.pdp import (
     ActionPermission,
     Decision,
     EvalResponse,

--- a/tests/test_cli_pdp_payload.py
+++ b/tests/test_cli_pdp_payload.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._pdp import (
+from nextlabs_sdk.pdp import (
     ContentType,
     Decision,
     EvalResponse,

--- a/tests/test_cli_policies.py
+++ b/tests/test_cli_policies.py
@@ -10,11 +10,15 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
+    Policy,
+    PolicyLite,
+    PolicySearchService,
+    PolicyService,
+)
 from nextlabs_sdk._cloudaz._component_models import DeploymentResult
-from nextlabs_sdk._cloudaz._policies import PolicyService
-from nextlabs_sdk._cloudaz._policy_models import ImportResult, Policy, PolicyLite
-from nextlabs_sdk._cloudaz._policy_search import PolicySearchService
+from nextlabs_sdk._cloudaz._policy_models import ImportResult
 from nextlabs_sdk._pagination import PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import NotFoundError
 

--- a/tests/test_cli_policies_detail.py
+++ b/tests/test_cli_policies_detail.py
@@ -6,12 +6,11 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _policies_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
+from nextlabs_sdk.cloudaz import Policy, Tag, TagType
 from nextlabs_sdk._cloudaz._component_models import Authority
-from nextlabs_sdk._cloudaz._models import Tag, TagType
 from nextlabs_sdk._cloudaz._policy_models import (
     ComponentGroup,
     EnvironmentConfig,
-    Policy,
     PolicyObligation,
 )
 

--- a/tests/test_cli_reporter_audit_logs.py
+++ b/tests/test_cli_reporter_audit_logs.py
@@ -9,10 +9,9 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._reporter_audit_log_models import ReporterAuditLogEntry
 from nextlabs_sdk._cloudaz._reporter_audit_logs import ReporterAuditLogService
 from nextlabs_sdk._pagination import PageResult, SyncPaginator
+from nextlabs_sdk.cloudaz import CloudAzClient, ReporterAuditLogEntry
 from nextlabs_sdk.exceptions import NextLabsError
 
 runner = CliRunner()

--- a/tests/test_cli_reports.py
+++ b/tests/test_cli_reports.py
@@ -9,8 +9,8 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._report_models import (
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
     EnforcementEntry,
     PolicyActivityReport,
     PolicyActivityReportDetail,
@@ -582,7 +582,7 @@ def test_reports_generate_export(mock_reports: Any, tmp_path: Any) -> None:
 
 
 def test_reports_list_cached_users(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import CachedUser
+    from nextlabs_sdk.cloudaz import CachedUser
 
     when(mock_reports).list_cached_users().thenReturn(
         [
@@ -599,7 +599,7 @@ def test_reports_list_cached_users(mock_reports: Any) -> None:
 
 
 def test_reports_list_cached_policies(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import CachedPolicy
+    from nextlabs_sdk.cloudaz import CachedPolicy
 
     when(mock_reports).list_cached_policies().thenReturn(
         [CachedPolicy.model_validate({"name": "P1", "fullName": "Root/P1"})],
@@ -612,7 +612,7 @@ def test_reports_list_cached_policies(mock_reports: Any) -> None:
 
 
 def test_reports_resource_actions(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import ResourceActions
+    from nextlabs_sdk.cloudaz import ResourceActions
 
     when(mock_reports).get_resource_actions().thenReturn(
         ResourceActions.model_validate(
@@ -633,10 +633,7 @@ def test_reports_resource_actions(mock_reports: Any) -> None:
 
 
 def test_reports_mappings(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import (
-        AttributeMapping,
-        AttributeMappings,
-    )
+    from nextlabs_sdk.cloudaz import AttributeMapping, AttributeMappings
 
     mapping = AttributeMapping.model_validate(
         {
@@ -659,7 +656,7 @@ def test_reports_mappings(mock_reports: Any) -> None:
 
 
 def test_reports_list_user_groups(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import UserGroup
+    from nextlabs_sdk.cloudaz import UserGroup
 
     when(mock_reports).list_user_groups().thenReturn(
         [UserGroup(id=5, title="Admins")],
@@ -672,7 +669,7 @@ def test_reports_list_user_groups(mock_reports: Any) -> None:
 
 
 def test_reports_list_application_users(mock_reports: Any) -> None:
-    from nextlabs_sdk._cloudaz._report_models import ApplicationUser
+    from nextlabs_sdk.cloudaz import ApplicationUser
 
     when(mock_reports).list_application_users().thenReturn(
         [

--- a/tests/test_cli_reports_detail.py
+++ b/tests/test_cli_reports_detail.py
@@ -6,10 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _reports_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
-from nextlabs_sdk._cloudaz._report_models import (
-    PolicyActivityReportDetail,
-    WidgetData,
-)
+from nextlabs_sdk.cloudaz import PolicyActivityReportDetail, WidgetData
 
 
 def _console() -> tuple[Console, io.StringIO]:

--- a/tests/test_cli_system_config.py
+++ b/tests/test_cli_system_config.py
@@ -9,9 +9,8 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._system_config import SystemConfigService
-from nextlabs_sdk._cloudaz._system_config_models import SystemConfig
+from nextlabs_sdk.cloudaz import CloudAzClient, SystemConfig
 
 runner = CliRunner()
 

--- a/tests/test_cli_tags.py
+++ b/tests/test_cli_tags.py
@@ -9,9 +9,7 @@ from typer.testing import CliRunner
 
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._app import app
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._models import Tag, TagType
-from nextlabs_sdk._cloudaz._tags import TagService
+from nextlabs_sdk.cloudaz import CloudAzClient, Tag, TagService, TagType
 from nextlabs_sdk._pagination import PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import NotFoundError
 

--- a/tests/test_cli_tags_detail.py
+++ b/tests/test_cli_tags_detail.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from nextlabs_sdk._cli import _tags_cmd
 from nextlabs_sdk._cli._detail_renderers import render_detail
-from nextlabs_sdk._cloudaz._models import Tag, TagType
+from nextlabs_sdk.cloudaz import Tag, TagType
 
 
 def test_tag_detail_renderer_registered_and_renders_fields() -> None:

--- a/tests/test_cloudaz_client.py
+++ b/tests/test_cloudaz_client.py
@@ -6,16 +6,18 @@ from mockito import any as any_value, mock, verify, when
 
 from nextlabs_sdk import _http_transport as transport_mod
 from nextlabs_sdk._config import HttpConfig
-from nextlabs_sdk._cloudaz._client import CloudAzClient
-from nextlabs_sdk._cloudaz._component_search import ComponentSearchService
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
+    ComponentSearchService,
+    ComponentService,
+    PolicySearchService,
+    PolicyService,
+    TagService,
+)
 from nextlabs_sdk._cloudaz._component_type_search import ComponentTypeSearchService
 from nextlabs_sdk._cloudaz._component_types import ComponentTypeService
-from nextlabs_sdk._cloudaz._components import ComponentService
 from nextlabs_sdk._cloudaz._operators import OperatorService
-from nextlabs_sdk._cloudaz._policies import PolicyService
-from nextlabs_sdk._cloudaz._policy_search import PolicySearchService
 from nextlabs_sdk._cloudaz._reporter_audit_logs import ReporterAuditLogService
-from nextlabs_sdk._cloudaz._tags import TagService
 
 BASE_URL = "https://cloudaz.example.com"
 

--- a/tests/test_cloudaz_client_activity_dashboard.py
+++ b/tests/test_cloudaz_client_activity_dashboard.py
@@ -5,12 +5,11 @@ import pytest
 from mockito import any as any_value, mock, when
 
 from nextlabs_sdk import _http_transport as transport_mod
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient
 from nextlabs_sdk._cloudaz._activity_logs_service import (
     AsyncReportActivityLogService,
     ReportActivityLogService,
 )
-from nextlabs_sdk._cloudaz._async_client import AsyncCloudAzClient
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._dashboard import AsyncDashboardService, DashboardService
 
 

--- a/tests/test_cloudaz_client_audit.py
+++ b/tests/test_cloudaz_client_audit.py
@@ -5,12 +5,11 @@ import pytest
 from mockito import any as any_value, mock, when
 
 from nextlabs_sdk import _http_transport as transport_mod
-from nextlabs_sdk._cloudaz._async_client import AsyncCloudAzClient
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient
 from nextlabs_sdk._cloudaz._audit_logs import (
     AsyncEntityAuditLogService,
     EntityAuditLogService,
 )
-from nextlabs_sdk._cloudaz._client import CloudAzClient
 from nextlabs_sdk._cloudaz._system_config import (
     AsyncSystemConfigService,
     SystemConfigService,

--- a/tests/test_cloudaz_client_reports.py
+++ b/tests/test_cloudaz_client_reports.py
@@ -7,8 +7,7 @@ import pytest
 from mockito import any as any_value, mock, when
 
 from nextlabs_sdk import _http_transport as transport_mod
-from nextlabs_sdk._cloudaz._async_client import AsyncCloudAzClient
-from nextlabs_sdk._cloudaz._client import CloudAzClient
+from nextlabs_sdk.cloudaz import AsyncCloudAzClient, CloudAzClient
 from nextlabs_sdk._cloudaz._reports import (
     AsyncPolicyActivityReportService,
     PolicyActivityReportService,

--- a/tests/test_cloudaz_models.py
+++ b/tests/test_cloudaz_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from nextlabs_sdk._cloudaz._models import Operator, Tag, TagType
+from nextlabs_sdk.cloudaz import Operator, Tag, TagType
 
 
 def test_operator_from_api_payload() -> None:

--- a/tests/test_component_models.py
+++ b/tests/test_component_models.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from nextlabs_sdk.cloudaz import Component, ComponentLite, TagType
 from nextlabs_sdk._cloudaz._component_models import (
     Authority,
-    Component,
     ComponentCondition,
     ComponentGroupType,
-    ComponentLite,
     ComponentNameData,
     ComponentNameEntry,
     ComponentStatus,
@@ -20,7 +19,6 @@ from nextlabs_sdk._cloudaz._component_models import (
     PredicateData,
     PushResult,
 )
-from nextlabs_sdk._cloudaz._models import TagType
 
 
 def _deployment_request_data() -> dict[str, object]:

--- a/tests/test_component_search_service.py
+++ b/tests/test_component_search_service.py
@@ -5,12 +5,16 @@ from mockito import mock, when
 import pytest
 
 from nextlabs_sdk._cloudaz._component_models import (
-    ComponentLite,
     ComponentNameEntry,
     ComponentStatus,
 )
-from nextlabs_sdk._cloudaz._component_search import ComponentSearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SavedSearchType, SearchCriteria
+from nextlabs_sdk._cloudaz._search import SavedSearchType
+from nextlabs_sdk.cloudaz import (
+    ComponentLite,
+    ComponentSearchService,
+    SavedSearch,
+    SearchCriteria,
+)
 from nextlabs_sdk._pagination import SyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_component_service.py
+++ b/tests/test_component_service.py
@@ -7,12 +7,11 @@ import pytest
 from mockito import mock, when
 
 from nextlabs_sdk._cloudaz._component_models import (
-    Component,
     ComponentGroupType,
     Dependency,
     DeploymentResult,
 )
-from nextlabs_sdk._cloudaz._components import ComponentService
+from nextlabs_sdk.cloudaz import Component, ComponentService
 from nextlabs_sdk.exceptions import NotFoundError
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_component_type_models.py
+++ b/tests/test_component_type_models.py
@@ -14,7 +14,7 @@ from nextlabs_sdk._cloudaz._component_type_models import (
     OperatorConfig,
     ParameterConfig,
 )
-from nextlabs_sdk._cloudaz._models import TagType
+from nextlabs_sdk.cloudaz import TagType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_component_type_search_service.py
+++ b/tests/test_component_type_search_service.py
@@ -8,7 +8,8 @@ from mockito import mock, when
 
 from nextlabs_sdk._cloudaz._component_type_models import ComponentType
 from nextlabs_sdk._cloudaz._component_type_search import ComponentTypeSearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SavedSearchType, SearchCriteria
+from nextlabs_sdk.cloudaz import SavedSearch, SearchCriteria
+from nextlabs_sdk._cloudaz._search import SavedSearchType
 from nextlabs_sdk._pagination import SyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_dashboard_models.py
+++ b/tests/test_dashboard_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from nextlabs_sdk._cloudaz._dashboard_models import (
+from nextlabs_sdk.cloudaz import (
     ActivityByEntity,
     Alert,
     MonitorTagAlert,

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -7,7 +7,7 @@ import pytest
 from mockito import mock, when
 
 from nextlabs_sdk._cloudaz._dashboard import DashboardService
-from nextlabs_sdk._cloudaz._dashboard_models import (
+from nextlabs_sdk.cloudaz import (
     ActivityByEntity,
     Alert,
     MonitorTagAlert,

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -5,21 +5,22 @@ from typing import Any, cast
 import httpx
 import pytest
 
-from nextlabs_sdk._pdp._enums import Decision, ResourceDimension
+from nextlabs_sdk.pdp import (
+    Action,
+    Application,
+    Decision,
+    Environment,
+    EvalRequest,
+    PermissionsRequest,
+    Resource,
+    ResourceDimension,
+    Subject,
+)
 from nextlabs_sdk._pdp._json_serializer import (
     deserialize_eval_response,
     deserialize_permissions_response,
     serialize_eval_request,
     serialize_permissions_request,
-)
-from nextlabs_sdk._pdp._request_models import (
-    Action,
-    Application,
-    Environment,
-    EvalRequest,
-    PermissionsRequest,
-    Resource,
-    Subject,
 )
 from nextlabs_sdk._pdp import _urns as urns
 from nextlabs_sdk.exceptions import PdpStatusError

--- a/tests/test_operator_service.py
+++ b/tests/test_operator_service.py
@@ -6,8 +6,8 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._models import Operator
 from nextlabs_sdk._cloudaz._operators import OperatorService
+from nextlabs_sdk.cloudaz import Operator
 
 BASE_URL = "https://cloudaz.example.com"
 _LIST_ALL = "/console/api/v1/config/dataType/list"

--- a/tests/test_pdp_client.py
+++ b/tests/test_pdp_client.py
@@ -9,12 +9,13 @@ from mockito import any as any_value, mock, verify, when
 
 from nextlabs_sdk import _http_transport as transport_mod
 from nextlabs_sdk._config import HttpConfig, RetryConfig
-from nextlabs_sdk._pdp._client import PdpClient
-from nextlabs_sdk._pdp._enums import ContentType, Decision
-from nextlabs_sdk._pdp._request_models import (
+from nextlabs_sdk.pdp import (
     Action,
     Application,
+    ContentType,
+    Decision,
     EvalRequest,
+    PdpClient,
     PermissionsRequest,
     Resource,
     Subject,

--- a/tests/test_pdp_enums.py
+++ b/tests/test_pdp_enums.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nextlabs_sdk._pdp._enums import ContentType, Decision, ResourceDimension
+from nextlabs_sdk.pdp import ContentType, Decision, ResourceDimension
 
 
 def test_content_type_json_value() -> None:

--- a/tests/test_pdp_request_models.py
+++ b/tests/test_pdp_request_models.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from nextlabs_sdk._pdp._enums import ResourceDimension
-from nextlabs_sdk._pdp._request_models import (
+from nextlabs_sdk.pdp import (
     Action,
     Application,
     Environment,
     EvalRequest,
     PermissionsRequest,
     Resource,
+    ResourceDimension,
     Subject,
 )
 

--- a/tests/test_pdp_response_models.py
+++ b/tests/test_pdp_response_models.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from nextlabs_sdk._pdp._enums import Decision
-from nextlabs_sdk._pdp._response_models import (
+from nextlabs_sdk.pdp import (
     ActionPermission,
+    Decision,
     EvalResponse,
     EvalResult,
     Obligation,

--- a/tests/test_policy_models.py
+++ b/tests/test_policy_models.py
@@ -5,15 +5,13 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from nextlabs_sdk._cloudaz._models import TagType
+from nextlabs_sdk.cloudaz import Policy, PolicyLite, TagType
 from nextlabs_sdk._cloudaz._policy_models import (
     ComponentGroup,
     EnvironmentConfig,
     ExportOptions,
     ImportResult,
-    Policy,
     PolicyComponentRef,
-    PolicyLite,
     PolicyObligation,
 )
 

--- a/tests/test_policy_search_service.py
+++ b/tests/test_policy_search_service.py
@@ -6,9 +6,13 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._policy_models import PolicyLite
-from nextlabs_sdk._cloudaz._policy_search import PolicySearchService
-from nextlabs_sdk._cloudaz._search import SavedSearch, SavedSearchType, SearchCriteria
+from nextlabs_sdk._cloudaz._search import SavedSearchType
+from nextlabs_sdk.cloudaz import (
+    PolicyLite,
+    PolicySearchService,
+    SavedSearch,
+    SearchCriteria,
+)
 from nextlabs_sdk._pagination import SyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_policy_service.py
+++ b/tests/test_policy_service.py
@@ -10,12 +10,11 @@ from nextlabs_sdk._cloudaz._component_models import (
     Dependency,
     DeploymentResult,
 )
-from nextlabs_sdk._cloudaz._policies import PolicyService
 from nextlabs_sdk._cloudaz._policy_models import (
     ExportOptions,
     ImportResult,
-    Policy,
 )
+from nextlabs_sdk.cloudaz import Policy, PolicyService
 from nextlabs_sdk.exceptions import NotFoundError
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_report_models.py
+++ b/tests/test_report_models.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from nextlabs_sdk._cloudaz._report_models import (
+from nextlabs_sdk.cloudaz import (
     ApplicationUser,
     AttributeMapping,
     AttributeMappings,
@@ -25,8 +25,8 @@ from nextlabs_sdk._cloudaz._report_models import (
     ReportFilters,
     ReportOrderBy,
     ReportWidget,
-    SaveInfo,
     ResourceActions,
+    SaveInfo,
     UserGroup,
     WidgetData,
 )

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -4,7 +4,8 @@ import httpx
 from mockito import mock, when
 import pytest
 
-from nextlabs_sdk._cloudaz._report_models import (
+from nextlabs_sdk._cloudaz._reports import PolicyActivityReportService
+from nextlabs_sdk.cloudaz import (
     ApplicationUser,
     AttributeMappings,
     CachedPolicy,
@@ -22,7 +23,6 @@ from nextlabs_sdk._cloudaz._report_models import (
     UserGroup,
     WidgetData,
 )
-from nextlabs_sdk._cloudaz._reports import PolicyActivityReportService
 from nextlabs_sdk._pagination import SyncPaginator
 from nextlabs_sdk.exceptions import ServerError
 

--- a/tests/test_reporter_audit_log_models.py
+++ b/tests/test_reporter_audit_log_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nextlabs_sdk._cloudaz._reporter_audit_log_models import ReporterAuditLogEntry
+from nextlabs_sdk.cloudaz import ReporterAuditLogEntry
 
 
 def test_reporter_audit_log_entry_parses_api_payload() -> None:

--- a/tests/test_reporter_audit_log_service.py
+++ b/tests/test_reporter_audit_log_service.py
@@ -4,8 +4,8 @@ import httpx
 import pytest
 from mockito import mock, when
 
-from nextlabs_sdk._cloudaz._reporter_audit_log_models import ReporterAuditLogEntry
 from nextlabs_sdk._cloudaz._reporter_audit_logs import ReporterAuditLogService
+from nextlabs_sdk.cloudaz import ReporterAuditLogEntry
 from nextlabs_sdk._pagination import SyncPaginator
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from nextlabs_sdk.cloudaz import SavedSearch, SearchCriteria
 from nextlabs_sdk._cloudaz._search import (
-    SavedSearch,
     SavedSearchType,
-    SearchCriteria,
     SearchField,
     SearchFieldType,
     SortField,

--- a/tests/test_system_config_models.py
+++ b/tests/test_system_config_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nextlabs_sdk._cloudaz._system_config_models import SystemConfig
+from nextlabs_sdk.cloudaz import SystemConfig
 
 
 def test_system_config_from_response_roundtrips_settings():

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -5,7 +5,7 @@ import pytest
 from mockito import mock, when
 
 from nextlabs_sdk._cloudaz._system_config import SystemConfigService
-from nextlabs_sdk._cloudaz._system_config_models import SystemConfig
+from nextlabs_sdk.cloudaz import SystemConfig
 from nextlabs_sdk.exceptions import ServerError
 
 BASE_URL = "https://cloudaz.example.com"

--- a/tests/test_tag_service.py
+++ b/tests/test_tag_service.py
@@ -4,8 +4,7 @@ import httpx
 from mockito import mock, when
 import pytest
 
-from nextlabs_sdk._cloudaz._models import Tag, TagType
-from nextlabs_sdk._cloudaz._tags import TagService
+from nextlabs_sdk.cloudaz import Tag, TagService, TagType
 from nextlabs_sdk._pagination import SyncPaginator
 from nextlabs_sdk.exceptions import NotFoundError
 

--- a/tests/test_xml_serializer.py
+++ b/tests/test_xml_serializer.py
@@ -5,10 +5,10 @@ from xml.etree import ElementTree as ET
 import httpx
 import pytest
 
-from nextlabs_sdk._pdp._enums import Decision
-from nextlabs_sdk._pdp._request_models import (
+from nextlabs_sdk.pdp import (
     Action,
     Application,
+    Decision,
     EvalRequest,
     PermissionsRequest,
     Resource,


### PR DESCRIPTION
Migrate test imports from private modules (`nextlabs_sdk._cloudaz`, `nextlabs_sdk._pdp`) to their public facade equivalents (`nextlabs_sdk.cloudaz`, `nextlabs_sdk.pdp`).

Only migrates imports of symbols that are re-exported by the public facades. Tests importing internal-only symbols (serializers, urns, non-facade services, component types, etc.) keep their private imports unchanged.

Closes #148

### Changes

- **74 test files** updated across 7 commits (model tests → search tests → sync service tests → async/client tests → CLI tests part 1 → CLI tests part 2 → PDP tests)
- Each commit is independently green (all 2257 tests pass)
- No behavior changes — purely structural import path migration

### Not modified (intentional)

- `tests/test_cloudaz_response.py` — `_response` module not in facade
- `tests/test_pdp_token_url.py` — `_token_url` module not in facade
- `tests/test_async_operator_service.py` — `AsyncOperatorService` not in facade
- `tests/test_component_type_service.py` / `test_async_component_type_service.py` — component type services not in facade
- `tests/architecture/test_issue_95_invariants.py` — intentionally tests private-to-facade type equivalence
