### PR TITLE
feat(cloudaz): interpret no-data envelope by call shape (#159)

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_response.py
+++ b/src/nextlabs_sdk/_cloudaz/_response.py
@@ -8,9 +8,15 @@ from pydantic import BaseModel
 from nextlabs_sdk._envelope import envelope_from_mapping
 from nextlabs_sdk._json_response import decode_json, decode_json_object, require_key
 from nextlabs_sdk._pagination import PageResult
-from nextlabs_sdk.exceptions import ApiError, raise_for_status
+from nextlabs_sdk.exceptions import ApiError, NotFoundError, raise_for_status
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+# The CloudAz envelope signals "the query matched nothing" with this exact
+# statusCode plus a message naming the condition. Both signals are required:
+# either alone is treated as a generic error, not a no-data outcome.
+_NO_DATA_STATUS_CODE = "5000"
+_NO_DATA_MESSAGE_TOKEN = "no data found"
 
 
 def _request_context(response: httpx.Response) -> tuple[str | None, str | None]:
@@ -21,41 +27,83 @@ def _request_context(response: httpx.Response) -> tuple[str | None, str | None]:
     return request.method, str(request.url)
 
 
-def _check_envelope_status(body: dict[str, object], response: httpx.Response) -> None:
-    """Raise ApiError if the CloudAz envelope carries a non-success statusCode.
+def _is_no_data_envelope(raw_code: str | None, message: str | None) -> bool:
+    """Return True when the envelope signals the CloudAz no-data outcome.
 
-    The envelope convention is:
-        {"statusCode": "<code>", "message": "<text>", "data": <payload>}
-    where statusCode values starting with "1" indicate success and any
-    other value indicates an error (e.g. "5000" = "No data found").
-    If the envelope has no statusCode field at all, this returns silently
-    to preserve legacy behavior for endpoints that do not use the envelope.
+    The discriminator requires both ``statusCode == "5000"`` and a
+    message containing ``"no data found"`` as a case-insensitive
+    substring. Either signal alone is a generic error.
     """
-    raw_code, envelope_message = envelope_from_mapping(body)
-    if raw_code is None:
-        return
-    if raw_code.startswith("1"):
-        return
+    if raw_code != _NO_DATA_STATUS_CODE or message is None:
+        return False
+    return _NO_DATA_MESSAGE_TOKEN in message.lower()
 
-    message = envelope_message or f"CloudAz error (statusCode={raw_code})"
+
+def _no_data_not_found(
+    raw_code: str | None,
+    message: str | None,
+    response: httpx.Response,
+) -> NotFoundError:
+    """Build the NotFoundError for a single-fetch no-data envelope.
+
+    The raised error preserves the envelope status code and message.
+    """
     request_method, request_url = _request_context(response)
-
-    raise ApiError(
-        message,
+    return NotFoundError(
+        message or f"CloudAz no data found (statusCode={raw_code})",
         status_code=response.status_code,
         response_body=response.text,
         request_method=request_method,
         request_url=request_url,
         envelope_status_code=raw_code,
-        envelope_message=envelope_message,
+        envelope_message=message,
+    )
+
+
+def _raise_for_envelope_error(
+    raw_code: str | None,
+    message: str | None,
+    response: httpx.Response,
+) -> None:
+    """Raise ApiError when the CloudAz envelope carries a non-success code.
+
+    The envelope convention is:
+        {"statusCode": "<code>", "message": "<text>", "data": <payload>}
+    where statusCode values starting with "1" indicate success and any
+    other value indicates an error. Returns silently when there is no
+    statusCode (legacy non-envelope bodies) or when it indicates success.
+    The no-data outcome is handled by callers before reaching this guard.
+    """
+    if raw_code is None or raw_code.startswith("1"):
+        return
+
+    text = message or f"CloudAz error (statusCode={raw_code})"
+    request_method, request_url = _request_context(response)
+
+    raise ApiError(
+        text,
+        status_code=response.status_code,
+        response_body=response.text,
+        request_method=request_method,
+        request_url=request_url,
+        envelope_status_code=raw_code,
+        envelope_message=message,
     )
 
 
 def parse_data(response: httpx.Response) -> Any:
-    """Extract the 'data' field from a CloudAz API response envelope."""
+    """Extract the 'data' field from a CloudAz API response envelope.
+
+    A no-data envelope on a single-resource fetch raises
+    :class:`NotFoundError`, preserving the envelope status code and
+    message.
+    """
     raise_for_status(response)
     body = decode_json_object(response)
-    _check_envelope_status(body, response)
+    raw_code, message = envelope_from_mapping(body)
+    if _is_no_data_envelope(raw_code, message):
+        raise _no_data_not_found(raw_code, message, response)
+    _raise_for_envelope_error(raw_code, message, response)
     return require_key(body, "data")
 
 
@@ -65,10 +113,16 @@ def parse_paginated(response: httpx.Response) -> tuple[Any, int, int, int | None
     The fourth element is the server-reported ``pageSize`` (the effective page
     size the server used). It is ``None`` when the envelope omits the field, in
     which case callers should fall back to the length of the returned page.
+
+    A no-data envelope yields an empty page — ``([], 0, 0, 0)`` — so the
+    paginator terminates cleanly without raising.
     """
     raise_for_status(response)
     body = decode_json_object(response)
-    _check_envelope_status(body, response)
+    raw_code, message = envelope_from_mapping(body)
+    if _is_no_data_envelope(raw_code, message):
+        return [], 0, 0, 0
+    _raise_for_envelope_error(raw_code, message, response)
     total_pages = require_key(body, "totalPages")
     total_records = require_key(body, "totalNoOfRecords")
     if not isinstance(total_pages, int) or not isinstance(total_records, int):
@@ -93,10 +147,16 @@ def parse_reporter_paginated(response: httpx.Response) -> tuple[Any, int, int]:
     The newer ``/nextlabs-reporter/api/activity-logs/search`` endpoint returns
     a bare Spring ``Page<T>`` without an envelope — use :func:`parse_pageable`
     for that shape instead.
+
+    A no-data envelope yields an empty page — ``([], 0, 0)`` — so the
+    paginator terminates cleanly without raising.
     """
     raise_for_status(response)
     body = decode_json_object(response)
-    _check_envelope_status(body, response)
+    raw_code, message = envelope_from_mapping(body)
+    if _is_no_data_envelope(raw_code, message):
+        return [], 0, 0
+    _raise_for_envelope_error(raw_code, message, response)
     response_data = require_key(body, "data")
     if not isinstance(response_data, dict):
         raise ApiError(

--- a/tests/test_cloudaz_response.py
+++ b/tests/test_cloudaz_response.py
@@ -1,22 +1,35 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Callable
 
 import httpx
 import pytest
 
+from pydantic import BaseModel
+
 from nextlabs_sdk._cloudaz._response import (
+    build_page,
     parse_data,
     parse_pageable,
     parse_paginated,
     parse_raw,
     parse_reporter_paginated,
 )
+from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import ApiError, NotFoundError, ServerError
 
 
 def _make_request() -> httpx.Request:
     return httpx.Request("GET", "https://test/api")
+
+
+def _no_data_envelope(status_code: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json={"statusCode": "5000", "message": "No data found"},
+        request=_make_request(),
+    )
 
 
 def _make_envelope(
@@ -306,21 +319,37 @@ _ENVELOPE_PARSERS = (
 )
 
 
-@pytest.mark.parametrize("parser", _ENVELOPE_PARSERS)
-def test_envelope_error_surfaces_server_message(
-    parser: Callable[[httpx.Response], object],
+def test_single_fetch_no_data_surfaces_server_message_on_not_found():
+    response = httpx.Response(
+        200,
+        json={"statusCode": "5000", "message": "No data found"},
+        request=_make_request(),
+    )
+    with pytest.raises(NotFoundError) as exc_info:
+        parse_data(response)
+    assert exc_info.value.message == "No data found"
+    assert exc_info.value.envelope_status_code == "5000"
+    assert exc_info.value.envelope_message == "No data found"
+    assert exc_info.value.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "parser",
+    [
+        pytest.param(parse_paginated, id="parse_paginated"),
+        pytest.param(parse_reporter_paginated, id="parse_reporter_paginated"),
+    ],
+)
+def test_list_no_data_returns_empty_instead_of_raising(
+    parser: Callable[[httpx.Response], tuple[object, ...]],
 ):
     response = httpx.Response(
         200,
         json={"statusCode": "5000", "message": "No data found"},
         request=_make_request(),
     )
-    with pytest.raises(ApiError) as exc_info:
-        parser(response)
-    assert exc_info.value.message == "No data found"
-    assert exc_info.value.envelope_status_code == "5000"
-    assert exc_info.value.envelope_message == "No data found"
-    assert exc_info.value.status_code == 200
+    result = parser(response)
+    assert result[0] == []
 
 
 @pytest.mark.parametrize("parser", _ENVELOPE_PARSERS)
@@ -355,27 +384,26 @@ def test_envelope_error_with_empty_string_message_uses_fallback(
     assert exc_info.value.envelope_status_code == "5000"
 
 
-def test_envelope_error_wins_over_missing_pagination_keys():
+def test_no_data_empty_page_skips_missing_pagination_keys():
     response = httpx.Response(
         200,
         json={"statusCode": "5000", "message": "No data found"},
         request=_make_request(),
     )
-    with pytest.raises(ApiError) as exc_info:
-        parse_paginated(response)
-    assert exc_info.value.message == "No data found"
-    assert "totalPages" not in exc_info.value.message
+    data, total_pages, _, _ = parse_paginated(response)
+    assert data == []
+    assert total_pages == 0
 
 
-def test_envelope_error_wins_over_missing_data_key_on_reporter():
+def test_no_data_empty_page_skips_missing_data_key_on_reporter():
     response = httpx.Response(
         200,
         json={"statusCode": "5000", "message": "No data found"},
         request=_make_request(),
     )
-    with pytest.raises(ApiError) as exc_info:
-        parse_reporter_paginated(response)
-    assert exc_info.value.message == "No data found"
+    items, total_pages, _ = parse_reporter_paginated(response)
+    assert items == []
+    assert total_pages == 0
 
 
 def test_parse_data_without_statusCode_falls_through_to_missing_data():
@@ -506,3 +534,119 @@ def test_http_error_prefers_envelope_message_even_for_success_statuscode(
         parser(response)
     assert exc_info.value.message == "odd but surfaced"
     assert exc_info.value.envelope_status_code == "1003"
+
+
+class _Item(BaseModel):
+    id: int
+
+
+def test_paginated_no_data_returns_empty_without_raising():
+    data, total_pages, total_records, page_size = parse_paginated(_no_data_envelope())
+    assert data == []
+    assert total_pages == 0
+    assert total_records == 0
+    assert page_size == 0
+
+
+def test_build_page_no_data_yields_empty_terminating_page():
+    page = build_page(_no_data_envelope(), _Item, page_no=0)
+    assert page.entries == []
+    assert page.total_pages == 0
+    assert page.total_records == 0
+
+
+def test_reporter_paginated_no_data_returns_empty_without_raising():
+    items, total_pages, total_records = parse_reporter_paginated(_no_data_envelope())
+    assert items == []
+    assert total_pages == 0
+    assert total_records == 0
+
+
+def test_single_fetch_no_data_raises_not_found_with_envelope_fields():
+    with pytest.raises(NotFoundError) as exc_info:
+        parse_data(_no_data_envelope())
+    assert exc_info.value.envelope_status_code == "5000"
+    assert exc_info.value.envelope_message == "No data found"
+    assert exc_info.value.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        pytest.param("No Data Found", id="title-case"),
+        pytest.param("the server reports: no data found for query", id="substring"),
+    ],
+)
+def test_no_data_message_match_is_case_insensitive_substring(message: str):
+    response = httpx.Response(
+        200,
+        json={"statusCode": "5000", "message": message},
+        request=_make_request(),
+    )
+    with pytest.raises(NotFoundError):
+        parse_data(response)
+    data, _, _, _ = parse_paginated(response)
+    assert data == []
+
+
+def test_generic_5000_without_no_data_message_still_raises_api_error():
+    response = httpx.Response(
+        200,
+        json={"statusCode": "5000", "message": "Something else broke"},
+        request=_make_request(),
+    )
+    for parser in (parse_data, parse_paginated, parse_reporter_paginated):
+        with pytest.raises(ApiError) as exc_info:
+            parser(response)
+        assert not isinstance(exc_info.value, NotFoundError)
+        assert exc_info.value.envelope_status_code == "5000"
+
+
+def test_other_non_success_code_still_raises_api_error():
+    response = httpx.Response(
+        200,
+        json={"statusCode": "6000", "message": "No data found"},
+        request=_make_request(),
+    )
+    for parser in (parse_data, parse_paginated, parse_reporter_paginated):
+        with pytest.raises(ApiError) as exc_info:
+            parser(response)
+        assert not isinstance(exc_info.value, NotFoundError)
+        assert exc_info.value.envelope_status_code == "6000"
+
+
+def test_sync_and_async_pagination_handle_no_data_identically():
+    def fetch(page_no: int) -> PageResult[_Item]:
+        return build_page(_no_data_envelope(), _Item, page_no)
+
+    sync_items = list(SyncPaginator(fetch))
+
+    async def fetch_async(page_no: int) -> PageResult[_Item]:
+        return build_page(_no_data_envelope(), _Item, page_no)
+
+    async def collect() -> list[_Item]:
+        return [item async for item in AsyncPaginator(fetch_async)]
+
+    async_items = asyncio.run(collect())
+
+    assert sync_items == async_items == []
+
+
+def test_sync_and_async_single_fetch_raise_not_found_identically():
+    sync_exc: type[Exception] | None = None
+    try:
+        parse_data(_no_data_envelope())
+    except NotFoundError as err:
+        sync_exc = type(err)
+
+    async def fetch_async() -> object:
+        return parse_data(_no_data_envelope())
+
+    async_exc: type[Exception] | None = None
+    try:
+        asyncio.run(fetch_async())
+    except NotFoundError as err:
+        async_exc = type(err)
+
+    assert sync_exc is NotFoundError
+    assert async_exc is NotFoundError


### PR DESCRIPTION
Closes #159

## Summary
- CloudAz envelope handling now interprets the no-data condition (statusCode `"5000"` plus a message containing `"no data found"`, case-insensitive) by call shape: paginated/list parses (`parse_paginated`, `parse_reporter_paginated`, and the `build_page` path) return an empty page so iteration ends cleanly, while a single-resource fetch (`parse_data`) raises the existing `NotFoundError` carrying `envelope_status_code` and `envelope_message`.
- Detection is a single underscore-prefixed helper plus module-level named constants in the internal CloudAz response module; the previous catch-all envelope check was refactored to take the already-extracted `(statusCode, message)` so both the no-data branch and the generic error path share one extraction.
- Verified by 69 cases in `tests/test_cloudaz_response.py` (RED→GREEN) plus the full unit suite (2267 passed, 95.95% coverage). Generic `5000` (no no-data message) and other non-`1xxx` codes such as `6000` still raise `ApiError` unchanged; HTTP-level error paths are untouched.

## Tests added (red → green)
- `test_paginated_no_data_returns_empty_without_raising`
- `test_build_page_no_data_yields_empty_terminating_page`
- `test_reporter_paginated_no_data_returns_empty_without_raising`
- `test_single_fetch_no_data_raises_not_found_with_envelope_fields`
- `test_no_data_message_match_is_case_insensitive_substring`
- `test_generic_5000_without_no_data_message_still_raises_api_error`
- `test_other_non_success_code_still_raises_api_error`
- `test_sync_and_async_pagination_handle_no_data_identically`
- `test_sync_and_async_single_fetch_raise_not_found_identically`

## Notable assumptions
- `parse_reporter_paginated` is a paginated/list call shape, so its no-data envelope also yields an empty result (`[], 0, 0`) rather than raising.
- The empty page is represented as `total_pages=0`, `total_records=0`, `page_size=0`, which terminates both the sync and async paginators on the first fetch with no entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
