### PR TITLE
fix(cloudaz): accept live API shapes for Component/Policy fields

### DIFF
--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -44,7 +44,7 @@
 | **Component** | A reusable predicate over **Subjects**, **Resources**, or **Actions**, grouped into **ComponentGroups** inside a **Policy**. | element |
 | **ComponentGroup** | A boolean grouping (with an `operator`) of **Components** of a single **ComponentGroupType**. | group |
 | **ComponentGroupType** | The role a **ComponentGroup** plays: `SUBJECT`, `RESOURCE`, or `ACTION`. | category, kind |
-| **ComponentCondition** | An `attribute operator value` predicate inside a **Component**. | rule, expression |
+| **ComponentCondition** | A predicate inside a **Component**. Often an `attribute operator value` triple, but may instead be member-object shaped (`operator` + `member` + `notFound`, with no top-level `attribute`/`value`). | rule, expression |
 | **PolicyObligation** | A named side-effect parameterized by a **Policy Model**, attached to allow/deny outcomes of a **Policy**. | obligation rule |
 | **Tag** | A typed label (`POLICY_MODEL`, `COMPONENT`, `POLICY`, `FOLDER`) attached to policy artifacts for organization. | label |
 | **Folder** | The hierarchical container in which **Policies** and **Components** live. | directory |

--- a/src/nextlabs_sdk/_cloudaz/_component_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_component_models.py
@@ -31,11 +31,13 @@ class PolicyModelRef(BaseModel):
 class ComponentCondition(BaseModel):
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    attribute: str
+    attribute: str | None = None
     operator: str
-    value: str  # noqa: WPS110
+    value: str | None = None  # noqa: WPS110
     rhs_type: str | None = Field(default=None, alias="rhsType")
     rhsvalue: str | None = None
+    member: dict[str, Any] | None = None
+    not_found: bool | None = Field(default=None, alias="notFound")
 
 
 class Authority(BaseModel):
@@ -68,7 +70,7 @@ class Component(BaseModel):
         default=None,
         alias="policyModel",
     )
-    actions: list[dict[str, Any]] = Field(default_factory=list)
+    actions: list[str | dict[str, Any]] = Field(default_factory=list)
     conditions: list[ComponentCondition] = Field(default_factory=list)
     member_conditions: list[ComponentCondition] = Field(
         default_factory=list,

--- a/src/nextlabs_sdk/_cloudaz/_policy_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_policy_models.py
@@ -27,7 +27,7 @@ class PolicyComponentRef(BaseModel):
         default=None,
         alias="policyModel",
     )
-    actions: list[dict[str, Any]] = Field(default_factory=list)
+    actions: list[str | dict[str, Any]] = Field(default_factory=list)
     conditions: list[ComponentCondition] = Field(default_factory=list)
     member_conditions: list[ComponentCondition] = Field(
         default_factory=list,
@@ -175,7 +175,7 @@ class Policy(BaseModel):
         alias="denyObligations",
     )
     sub_policy: bool = Field(default=False, alias="subPolicy")
-    sub_policy_refs: list[dict[str, Any]] = Field(
+    sub_policy_refs: list[str | dict[str, Any]] = Field(
         default_factory=list,
         alias="subPolicyRefs",
     )

--- a/tests/test_component_models.py
+++ b/tests/test_component_models.py
@@ -245,6 +245,34 @@ def test_component_condition_minimal():
     assert cond.rhsvalue is None
 
 
+def test_component_condition_accepts_member_object_shape():
+    cond = ComponentCondition.model_validate(
+        {"operator": "IN", "member": {"id": 7, "name": "Eng"}, "notFound": False},
+    )
+    assert cond.operator == "IN"
+    assert cond.attribute is None
+    assert cond.value is None
+    assert cond.member == {"id": 7, "name": "Eng"}
+    assert cond.not_found is False
+
+
+def test_component_accepts_member_object_member_conditions():
+    data = _make_full_component_data()
+    data["memberConditions"] = [
+        {"operator": "IN", "member": {"id": 7, "name": "Eng"}, "notFound": False},
+    ]
+    comp = Component.model_validate(data)
+    assert comp.member_conditions[0].member == {"id": 7, "name": "Eng"}
+    assert comp.member_conditions[0].not_found is False
+
+
+def test_component_accepts_string_actions():
+    data = _make_full_component_data()
+    data["actions"] = ["DELETE", "CONFIGURE"]
+    comp = Component.model_validate(data)
+    assert comp.actions == ["DELETE", "CONFIGURE"]
+
+
 def test_authority_from_api_payload():
     auth = Authority.model_validate({"authority": "VIEW_COMPONENT"})
     assert auth.authority == "VIEW_COMPONENT"

--- a/tests/test_policy_models.py
+++ b/tests/test_policy_models.py
@@ -452,3 +452,30 @@ def test_policy_lite_minimal():
     assert pl.parent_policy is None
     assert pl.component_ids is None
     assert pl.obligation_model_ids is None
+
+
+def test_policy_accepts_string_sub_policy_refs():
+    data = _make_full_policy_data()
+    data["subPolicyRefs"] = ["ABC Sub-Policy"]
+    policy = Policy.model_validate(data)
+    assert policy.sub_policy_refs == ["ABC Sub-Policy"]
+
+
+def test_policy_component_ref_accepts_string_actions():
+    ref = PolicyComponentRef.model_validate(
+        {"id": 42, "actions": ["DELETE", "CONFIGURE"]},
+    )
+    assert ref.actions == ["DELETE", "CONFIGURE"]
+
+
+def test_policy_component_ref_accepts_member_object_conditions():
+    ref = PolicyComponentRef.model_validate(
+        {
+            "id": 42,
+            "memberConditions": [
+                {"operator": "IN", "member": {"id": 7}, "notFound": False},
+            ],
+        },
+    )
+    assert ref.member_conditions[0].member == {"id": 7}
+    assert ref.member_conditions[0].not_found is False


### PR DESCRIPTION
Relax three over-constrained CloudAz model fields so live Component and Policy API responses deserialize into typed models instead of raising `pydantic.ValidationError`.

## What changed

- `ComponentCondition`: `attribute`/`value` are now optional, and the member-object shape (`member`, `notFound`) is exposed so member conditions deserialize losslessly.
- `Component.actions`, `PolicyComponentRef.actions`, `Policy.subPolicyRefs`: accept `list[str | dict[str, Any]]` — observed string shapes plus the prior dict contract (non-weakening union).

## Invariants held

- Public API surface (`nextlabs_sdk.cloudaz` exports) unchanged — no new public types.
- Sync/async parity preserved: the fix lives entirely in the shared models; no service edits.
- Edited models retain `model_config(frozen=True, populate_by_name=True)`; no schema migration.
- All existing CloudAz model/service tests stay green.

No `lint-escape` actions were taken. No review-step absences.

Closes #162
