### PR TITLE
feat(cloudaz): add policy revision history (list_history) (#172)

### DIFF
--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -40,6 +40,7 @@
 | --- | --- | --- |
 | **Policy** | A named rule, owned and versioned, that combines **Components** to permit or deny **Actions** on **Resources** for **Subjects**. | rule, policy doc |
 | **PolicyLite** | A trimmed listing projection of a **Policy** (search/index views), without full component bodies. | policy summary |
+| **Policy revision history** | The ordered list of past revisions of a **Policy**, each a `PolicyHistoryEntry` of revision metadata (no full policy body). Read via `list_history`. | audit trail, version log |
 | **Policy Model** | The schema/template a **Component** or **Policy Obligation** conforms to. | template |
 | **Component** | A reusable predicate over **Subjects**, **Resources**, or **Actions**, grouped into **ComponentGroups** inside a **Policy**. | element |
 | **ComponentGroup** | A boolean grouping (with an `operator`) of **Components** of a single **ComponentGroupType**. | group |

--- a/docs/vendor_gaps.md
+++ b/docs/vendor_gaps.md
@@ -1,0 +1,25 @@
+# Vendor gaps
+
+This file records CloudAz behaviours the SDK relies on that are absent from,
+or inconsistent with, the vendor OpenAPI spec
+(`https://developer.nextlabs.com/assets/external/cloudaz/api-docs.json`). Each
+entry exists because the SDK has to model a real server behaviour that the
+published contract does not describe.
+
+## Endpoint — policy revision history
+
+`GET /console/api/v1/policy/mgmt/history/{policyId}` is not present in the
+vendor OpenAPI spec. It returns the standard paginated envelope
+(`pageNo` / `pageSize` / `totalPages` / `totalNoOfRecords`) wrapping a list of
+revision-metadata objects. On this list view `policyDetail` is always `null`;
+only the per-revision metadata is populated.
+
+Consumed by `PolicyService.list_history` / `AsyncPolicyService.list_history`,
+which deserialize each entry into `PolicyHistoryEntry`.
+
+## Opaque `actionType` codes
+
+Revision entries carry an `actionType` string whose code meanings are
+undocumented by the vendor (observed values include `UN` and `DE`). The SDK
+exposes it as a plain `str`; it deliberately does not interpret the codes or
+map them to an enum, because the value space and semantics are unknown.

--- a/src/nextlabs_sdk/_cloudaz/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/__init__.py
@@ -32,6 +32,7 @@ __all__: list[str] = [
     "PolicyActivityReportDetail",
     "PolicyActivityReportRequest",
     "PolicyDayBucket",
+    "PolicyHistoryEntry",
     "PolicyLite",
     "PolicyModelAction",
     "ReportCriteria",
@@ -101,6 +102,9 @@ from nextlabs_sdk._cloudaz._policies import (
 )
 from nextlabs_sdk._cloudaz._policies import PolicyService as PolicyService
 from nextlabs_sdk._cloudaz._policy_models import Policy as Policy
+from nextlabs_sdk._cloudaz._policy_models import (
+    PolicyHistoryEntry as PolicyHistoryEntry,
+)
 from nextlabs_sdk._cloudaz._policy_models import PolicyLite as PolicyLite
 from nextlabs_sdk._cloudaz._policy_search import (
     AsyncPolicySearchService as AsyncPolicySearchService,

--- a/src/nextlabs_sdk/_cloudaz/_policies.py
+++ b/src/nextlabs_sdk/_cloudaz/_policies.py
@@ -15,7 +15,7 @@ from nextlabs_sdk._cloudaz._policy_models import (
     PolicyHistoryEntry,
 )
 from nextlabs_sdk._cloudaz._response import build_page, parse_data
-from nextlabs_sdk._pagination import PageResult, SyncPaginator
+from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
 
 _DELETE_METHOD = "DELETE"
@@ -239,6 +239,14 @@ class AsyncPolicyService:  # noqa: WPS214
         )
         return Policy.model_validate(parse_data(resp))
 
+    def list_history(
+        self,
+        policy_id: int,
+    ) -> AsyncPaginator[PolicyHistoryEntry]:
+        return AsyncPaginator(
+            fetch_page=functools.partial(self._fetch_history_page, policy_id),
+        )
+
     async def create(self, payload: dict[str, object]) -> int:
         resp = await self._client.post(
             "/console/api/v1/policy/mgmt/add",
@@ -400,3 +408,14 @@ class AsyncPolicyService:  # noqa: WPS214
             json=payload,
         )
         raise_for_status(resp)
+
+    async def _fetch_history_page(
+        self,
+        policy_id: int,
+        page_no: int,
+    ) -> PageResult[PolicyHistoryEntry]:
+        resp = await self._client.get(
+            f"/console/api/v1/policy/mgmt/history/{policy_id}",
+            params={"pageNo": page_no},
+        )
+        return build_page(resp, PolicyHistoryEntry, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_policies.py
+++ b/src/nextlabs_sdk/_cloudaz/_policies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+
 import httpx
 
 from nextlabs_sdk._cloudaz._component_models import (
@@ -10,8 +12,10 @@ from nextlabs_sdk._cloudaz._policy_models import (
     ExportOptions,
     ImportResult,
     Policy,
+    PolicyHistoryEntry,
 )
-from nextlabs_sdk._cloudaz._response import parse_data
+from nextlabs_sdk._cloudaz._response import build_page, parse_data
+from nextlabs_sdk._pagination import PageResult, SyncPaginator
 from nextlabs_sdk.exceptions import raise_for_status
 
 _DELETE_METHOD = "DELETE"
@@ -35,6 +39,14 @@ class PolicyService:  # noqa: WPS214
             f"/console/api/v1/policy/mgmt/active/{policy_id}",
         )
         return Policy.model_validate(parse_data(response))
+
+    def list_history(
+        self,
+        policy_id: int,
+    ) -> SyncPaginator[PolicyHistoryEntry]:
+        return SyncPaginator(
+            fetch_page=functools.partial(self._fetch_history_page, policy_id),
+        )
 
     def create(self, payload: dict[str, object]) -> int:
         response = self._client.post(
@@ -197,6 +209,17 @@ class PolicyService:  # noqa: WPS214
             json=payload,
         )
         raise_for_status(response)
+
+    def _fetch_history_page(
+        self,
+        policy_id: int,
+        page_no: int,
+    ) -> PageResult[PolicyHistoryEntry]:
+        response = self._client.get(
+            f"/console/api/v1/policy/mgmt/history/{policy_id}",
+            params={"pageNo": page_no},
+        )
+        return build_page(response, PolicyHistoryEntry, page_no)
 
 
 class AsyncPolicyService:  # noqa: WPS214

--- a/src/nextlabs_sdk/_cloudaz/_policy_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_policy_models.py
@@ -12,6 +12,11 @@ from nextlabs_sdk._cloudaz._component_models import (
 )
 from nextlabs_sdk._cloudaz._models import Tag
 
+_CREATED_DATE_ALIAS = "createdDate"
+_MODIFIED_BY_ALIAS = "modifiedBy"
+_LAST_UPDATED_DATE_ALIAS = "lastUpdatedDate"
+_ACTION_TYPE_ALIAS = "actionType"
+
 
 class PolicyComponentRef(BaseModel):
     model_config = ConfigDict(frozen=True, populate_by_name=True)
@@ -42,17 +47,17 @@ class PolicyComponentRef(BaseModel):
     parent_name: str | None = Field(default=None, alias="parentName")
     deployment_time: int = Field(default=0, alias="deploymentTime")
     deployed: bool = False
-    action_type: str | None = Field(default=None, alias="actionType")
+    action_type: str | None = Field(default=None, alias=_ACTION_TYPE_ALIAS)
     revision_count: int = Field(default=0, alias="revisionCount")
     owner_id: int = Field(default=0, alias="ownerId")
     owner_display_name: str | None = Field(
         default=None,
         alias="ownerDisplayName",
     )
-    created_date: int = Field(default=0, alias="createdDate")
+    created_date: int = Field(default=0, alias=_CREATED_DATE_ALIAS)
     modified_by_id: int = Field(default=0, alias="modifiedById")
-    modified_by: str | None = Field(default=None, alias="modifiedBy")
-    last_updated_date: int = Field(default=0, alias="lastUpdatedDate")
+    modified_by: str | None = Field(default=None, alias=_MODIFIED_BY_ALIAS)
+    last_updated_date: int = Field(default=0, alias=_LAST_UPDATED_DATE_ALIAS)
     skip_validate: bool = Field(default=False, alias="skipValidate")
     re_index_all_now: bool = Field(default=True, alias="reIndexAllNow")
     hidden: bool = False
@@ -182,14 +187,14 @@ class Policy(BaseModel):
     attributes: list[str] = Field(default_factory=list)
     deployment_time: int = Field(default=0, alias="deploymentTime")
     deployed: bool = False
-    action_type: str | None = Field(default=None, alias="actionType")
+    action_type: str | None = Field(default=None, alias=_ACTION_TYPE_ALIAS)
     revision_count: int = Field(default=0, alias="revisionCount")
     owner_id: int = Field(default=0, alias="ownerId")
     owner_display_name: str | None = Field(default=None, alias="ownerDisplayName")
-    created_date: int = Field(default=0, alias="createdDate")
+    created_date: int = Field(default=0, alias=_CREATED_DATE_ALIAS)
     modified_by_id: int = Field(default=0, alias="modifiedById")
-    modified_by: str | None = Field(default=None, alias="modifiedBy")
-    last_updated_date: int = Field(default=0, alias="lastUpdatedDate")
+    modified_by: str | None = Field(default=None, alias=_MODIFIED_BY_ALIAS)
+    last_updated_date: int = Field(default=0, alias=_LAST_UPDATED_DATE_ALIAS)
     skip_validate: bool = Field(default=False, alias="skipValidate")
     re_index_now: bool = Field(default=True, alias="reIndexNow")
     skip_adding_true_allow_attribute: bool = Field(
@@ -235,14 +240,14 @@ class PolicyLite(BaseModel):
     description: str | None = None
     status: str
     effect_type: str = Field(alias="effectType")
-    last_updated_date: int = Field(alias="lastUpdatedDate")
-    created_date: int = Field(alias="createdDate")
+    last_updated_date: int = Field(alias=_LAST_UPDATED_DATE_ALIAS)
+    created_date: int = Field(alias=_CREATED_DATE_ALIAS)
     has_parent: bool = Field(default=False, alias="hasParent")
     has_sub_policies: bool = Field(default=False, alias="hasSubPolicies")
     owner_id: int = Field(default=0, alias="ownerId")
     owner_display_name: str | None = Field(default=None, alias="ownerDisplayName")
     modified_by_id: int = Field(default=0, alias="modifiedById")
-    modified_by: str | None = Field(default=None, alias="modifiedBy")
+    modified_by: str | None = Field(default=None, alias=_MODIFIED_BY_ALIAS)
     tags: list[Tag] = Field(default_factory=list)
     no_of_tags: int = Field(default=0, alias="noOfTags")
     parent_policy: dict[str, Any] | None = Field(
@@ -261,7 +266,7 @@ class PolicyLite(BaseModel):
     manual_deploy: bool = Field(default=False, alias="manualDeploy")
     deployment_time: int = Field(default=0, alias="deploymentTime")
     deployed: bool = False
-    action_type: str | None = Field(default=None, alias="actionType")
+    action_type: str | None = Field(default=None, alias=_ACTION_TYPE_ALIAS)
     active_workflow_id: int | None = Field(
         default=None,
         alias="activeWorkflowId",
@@ -286,3 +291,21 @@ class PolicyLite(BaseModel):
     )
     hide_more_details: bool = Field(default=False, alias="hideMoreDetails")
     deployment_pending: bool = Field(default=False, alias="deploymentPending")
+
+
+class PolicyHistoryEntry(BaseModel):
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    id: int  # noqa: WPS125
+    revision: int
+    name: str | None = None
+    description: str | None = None
+    active_from: int | None = Field(default=None, alias="activeFrom")
+    active_to: int | None = Field(default=None, alias="activeTo")
+    created_date: int | None = Field(default=None, alias=_CREATED_DATE_ALIAS)
+    created_by: str | None = Field(default=None, alias="createdBy")
+    modified_by: str | None = Field(default=None, alias=_MODIFIED_BY_ALIAS)
+    last_updated_date: int | None = Field(default=None, alias=_LAST_UPDATED_DATE_ALIAS)
+    submitted_by: str | None = Field(default=None, alias="submittedBy")
+    submitted_date: int | None = Field(default=None, alias="submittedDate")
+    action_type: str | None = Field(default=None, alias=_ACTION_TYPE_ALIAS)

--- a/src/nextlabs_sdk/cloudaz/__init__.py
+++ b/src/nextlabs_sdk/cloudaz/__init__.py
@@ -35,6 +35,7 @@ __all__: list[str] = [
     "PolicyActivityReportDetail",
     "PolicyActivityReportRequest",
     "PolicyDayBucket",
+    "PolicyHistoryEntry",
     "PolicyLite",
     "PolicyModelAction",
     "ReportCriteria",
@@ -113,6 +114,7 @@ from nextlabs_sdk._cloudaz import (
     PolicyActivityReportRequest as PolicyActivityReportRequest,
 )
 from nextlabs_sdk._cloudaz import PolicyDayBucket as PolicyDayBucket
+from nextlabs_sdk._cloudaz import PolicyHistoryEntry as PolicyHistoryEntry
 from nextlabs_sdk._cloudaz import PolicyLite as PolicyLite
 from nextlabs_sdk._cloudaz import PolicyModelAction as PolicyModelAction
 from nextlabs_sdk._cloudaz import PolicySearchService as PolicySearchService

--- a/tests/test_async_policy_service.py
+++ b/tests/test_async_policy_service.py
@@ -25,17 +25,24 @@ def _make_request(path: str = "/api") -> httpx.Request:
     return httpx.Request("GET", f"{BASE_URL}{path}")
 
 
-def _make_envelope(data: object, status_code: int = 200) -> httpx.Response:
+def _make_envelope(
+    data: object,
+    status_code: int = 200,
+    page_no: int = 0,
+    page_size: int = 10,
+    total_pages: int = 1,
+    total_records: int = 1,
+) -> httpx.Response:
     return httpx.Response(
         status_code,
         json={
             "statusCode": "1003",
             "message": "Data found successfully",
             "data": data,
-            "pageNo": 0,
-            "pageSize": 10,
-            "totalPages": 1,
-            "totalNoOfRecords": 1,
+            "pageNo": page_no,
+            "pageSize": page_size,
+            "totalPages": total_pages,
+            "totalNoOfRecords": total_records,
             "additionalAttributes": None,
         },
         request=_make_request(),
@@ -74,6 +81,13 @@ def _make_policy_data() -> dict[str, Any]:
 
 def _run(coro: Awaitable[T]) -> T:
     return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def _collect(paginator: Any) -> list[Any]:
+    async def gather() -> list[Any]:
+        return [item async for item in paginator]
+
+    return asyncio.run(gather())
 
 
 @pytest.fixture
@@ -427,3 +441,77 @@ def test_async_retrieve_all_policies_returns_filename(
     ).thenReturn(_make_envelope(data=filename))
 
     assert _run(service.retrieve_all_policies(**kwargs)) == filename
+
+
+def test_async_list_history_returns_paginator(client_and_service):
+    from nextlabs_sdk._pagination import AsyncPaginator
+    from nextlabs_sdk.cloudaz import PolicyHistoryEntry
+
+    client, service = client_and_service
+    data = {
+        "id": 770,
+        "revision": "3",
+        "name": "ROOT_42/pentest_policy",
+        "description": None,
+        "activeFrom": 1761133292235,
+        "activeTo": 1761133292235,
+        "policyDetail": None,
+        "createdDate": 1761133292266,
+        "createdBy": "me",
+        "modifiedBy": "me",
+        "lastUpdatedDate": 1761133292250,
+        "submittedBy": "me",
+        "submittedDate": 1761133292266,
+        "actionType": "UN",
+    }
+    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(
+        _make_envelope(data=[data]),
+    )
+
+    paginator = service.list_history(42)
+
+    assert isinstance(paginator, AsyncPaginator)
+    results = _collect(paginator)
+    assert len(results) == 1
+    assert isinstance(results[0], PolicyHistoryEntry)
+    assert results[0].revision == 3
+    assert results[0].action_type == "UN"
+
+
+def test_async_list_history_paginates_multiple_pages(client_and_service):
+    client, service = client_and_service
+    base = {
+        "id": 770,
+        "revision": "3",
+        "name": "p",
+        "description": None,
+        "activeFrom": 1,
+        "activeTo": 1,
+        "policyDetail": None,
+        "createdDate": 1,
+        "createdBy": "me",
+        "modifiedBy": "me",
+        "lastUpdatedDate": 1,
+        "submittedBy": "me",
+        "submittedDate": 1,
+        "actionType": "UN",
+    }
+    entry2 = {**base, "id": 769, "revision": "2", "actionType": "DE"}
+    page0 = _make_envelope(data=[base], page_no=0, total_pages=2, total_records=2)
+    page1 = _make_envelope(data=[entry2], page_no=1, total_pages=2, total_records=2)
+    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(page0)
+    when(client).get(f"{MGMT}/history/42", params={"pageNo": 1}).thenReturn(page1)
+
+    results = _collect(service.list_history(42))
+
+    assert [e.revision for e in results] == [3, 2]
+
+
+def test_async_list_history_raises_not_found(client_and_service):
+    client, service = client_and_service
+    when(client).get(f"{MGMT}/history/999", params={"pageNo": 0}).thenReturn(
+        httpx.Response(404, json={"message": "Not found"}, request=_make_request()),
+    )
+
+    with pytest.raises(NotFoundError):
+        _collect(service.list_history(999))

--- a/tests/test_policy_models.py
+++ b/tests/test_policy_models.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from nextlabs_sdk.cloudaz import Policy, PolicyLite, TagType
+from nextlabs_sdk.cloudaz import Policy, PolicyHistoryEntry, PolicyLite, TagType
 from nextlabs_sdk._cloudaz._policy_models import (
     ComponentGroup,
     EnvironmentConfig,
@@ -502,3 +502,43 @@ def test_policy_lite_accepts_null_owner_and_modifier_metadata():
     lite = PolicyLite.model_validate(data)
     assert lite.owner_display_name is None
     assert lite.modified_by is None
+
+
+def _entry_data() -> dict[str, object]:
+    return {
+        "id": 770,
+        "revision": "3",
+        "name": "ROOT_42/pentest_policy",
+        "description": None,
+        "activeFrom": 1761133292235,
+        "activeTo": 1761133292235,
+        "policyDetail": None,
+        "createdDate": 1761133292266,
+        "createdBy": "me",
+        "modifiedBy": "me",
+        "lastUpdatedDate": 1761133292250,
+        "submittedBy": "me",
+        "submittedDate": 1761133292266,
+        "actionType": "UN",
+    }
+
+
+def test_policy_history_entry_parses_and_is_frozen():
+    # given / when
+    entry = PolicyHistoryEntry.model_validate(_entry_data())
+
+    # then — camelCase aliases populate, revision coerced to int
+    assert entry.id == 770
+    assert entry.revision == 3
+    assert entry.active_from == 1761133292235
+    assert entry.created_by == "me"
+    assert entry.action_type == "UN"
+    # actionType is a plain str, timestamps are int
+    assert isinstance(entry.action_type, str)
+    assert isinstance(entry.last_updated_date, int)
+    # no embedded policy on the list view
+    assert "policyDetail" not in PolicyHistoryEntry.model_fields
+    assert "policy_detail" not in PolicyHistoryEntry.model_fields
+    # frozen
+    with pytest.raises(ValidationError):
+        entry.name = "changed"  # type: ignore[misc]

--- a/tests/test_policy_service.py
+++ b/tests/test_policy_service.py
@@ -79,6 +79,25 @@ def _make_policy_data() -> dict[str, Any]:
     }
 
 
+def _history_entry_data() -> dict[str, Any]:
+    return {
+        "id": 770,
+        "revision": "3",
+        "name": "ROOT_42/pentest_policy",
+        "description": None,
+        "activeFrom": 1761133292235,
+        "activeTo": 1761133292235,
+        "policyDetail": None,
+        "createdDate": 1761133292266,
+        "createdBy": "me",
+        "modifiedBy": "me",
+        "lastUpdatedDate": 1761133292250,
+        "submittedBy": "me",
+        "submittedDate": 1761133292266,
+        "actionType": "UN",
+    }
+
+
 @pytest.fixture
 def client_service() -> tuple[Any, PolicyService]:
     client = mock(httpx.Client)
@@ -419,6 +438,52 @@ def test_get_raises_not_found(client_service: tuple[Any, PolicyService]):
 
     with pytest.raises(NotFoundError):
         service.get(999)
+
+
+def test_list_history_returns_paginator(client_service: tuple[Any, PolicyService]):
+    from nextlabs_sdk._pagination import SyncPaginator
+    from nextlabs_sdk.cloudaz import PolicyHistoryEntry
+
+    client, service = client_service
+    when(client).get(
+        f"{MGMT}/history/42",
+        params={"pageNo": 0},
+    ).thenReturn(_make_envelope(data=[_history_entry_data()]))
+
+    paginator = service.list_history(42)
+
+    assert isinstance(paginator, SyncPaginator)
+    results = list(paginator)
+    assert len(results) == 1
+    assert isinstance(results[0], PolicyHistoryEntry)
+    assert results[0].revision == 3
+    assert results[0].action_type == "UN"
+
+
+def test_list_history_paginates_multiple_pages(
+    client_service: tuple[Any, PolicyService],
+):
+    client, service = client_service
+    entry1 = _history_entry_data()
+    entry2 = {**_history_entry_data(), "id": 769, "revision": "2", "actionType": "DE"}
+    page0 = _make_envelope(data=[entry1], page_no=0, total_pages=2, total_records=2)
+    page1 = _make_envelope(data=[entry2], page_no=1, total_pages=2, total_records=2)
+    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(page0)
+    when(client).get(f"{MGMT}/history/42", params={"pageNo": 1}).thenReturn(page1)
+
+    results = list(service.list_history(42))
+
+    assert [e.revision for e in results] == [3, 2]
+
+
+def test_list_history_raises_not_found(client_service: tuple[Any, PolicyService]):
+    client, service = client_service
+    when(client).get(f"{MGMT}/history/999", params={"pageNo": 0}).thenReturn(
+        httpx.Response(404, json={"message": "Not found"}, request=_make_request()),
+    )
+
+    with pytest.raises(NotFoundError):
+        list(service.list_history(999))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds policy revision-history listing to the cloudaz policy service: `PolicyService.list_history(policy_id)` and its async twin return a paginator of the new frozen `PolicyHistoryEntry` model over `GET /console/api/v1/policy/mgmt/history/{policyId}`.

Closes #172

## What changed

- **`PolicyHistoryEntry`** (frozen, camelCase aliases) co-located in `_policy_models.py`; revision metadata only — `policyDetail` is intentionally not a field. `actionType` exposed as plain `str`; timestamps as `int`. Exported from `nextlabs_sdk._cloudaz` and the public `nextlabs_sdk.cloudaz`.
- **`PolicyService.list_history` / `AsyncPolicyService.list_history`** — return `SyncPaginator`/`AsyncPaginator[PolicyHistoryEntry]`, built via `build_page` exactly like `ComponentSearchService.search`. Pagination driven by the standard envelope; an unknown policy id surfaces `NotFoundError` lazily on first iteration with no `httpx` leak.
- **`docs/vendor_gaps.md`** (new) — records the undocumented history endpoint and the opaque `actionType` codes (`UN`, `DE`). `docs/ubiquitous_language.md` gains a "Policy revision history" glossary term.

## lint-escape actions

- `_policy_models.py`: adding `PolicyHistoryEntry` tipped four alias string literals (`createdDate`, `modifiedBy`, `lastUpdatedDate`, `actionType`) over flake8 **WPS226** ("string literal over-use > 3"), counted module-wide. Resolved at **lint-escape Tier 1** by extracting four module-level alias constants and referencing them at the existing call sites — Tier 2 (`# noqa`) is ineligible (>3 sites) and Tier 3 (`setup.cfg` exception) is forbidden by project rules.
- `PolicyHistoryEntry.id` carries `# noqa: WPS125` (builtin-shadow false positive), mirroring the established in-file pattern on every other `id` field (`PolicyComponentRef.id`, `Policy.id`). Authorized for this slice.

## Review-step notes (no-update-needed)

`README.md`, `docs/architecture.md`, and `CLAUDE.md` were inspected and need no change — none enumerates policy-service methods/public models, and no new pattern was introduced (mirrors existing pagination/model patterns).

## Tests

84 passing across `tests/test_policy_models.py`, `tests/test_policy_service.py`, `tests/test_async_policy_service.py` — single-page parse, multi-page paging, and unknown-id `NotFoundError` on both sync and async clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
