### PR TITLE
docs(cloudaz): record viewRevision endpoint in vendor_gaps

### DIFF
--- a/docs/vendor_gaps.md
+++ b/docs/vendor_gaps.md
@@ -17,6 +17,16 @@ only the per-revision metadata is populated.
 Consumed by `PolicyService.list_history` / `AsyncPolicyService.list_history`,
 which deserialize each entry into `PolicyHistoryEntry`.
 
+## Endpoint — policy revision detail
+
+`GET /console/api/v1/policy/mgmt/viewRevision/{revision_id}/{revision}` is not
+present in the vendor OpenAPI spec. It returns the full revision detail object,
+including the `policyDetail` payload, for a single revision identified by its
+`revision_id` and `revision` number.
+
+Consumed by `PolicyService.get_revision` / `AsyncPolicyService.get_revision`,
+which deserialize the response into `PolicyRevision`.
+
 ## Opaque `actionType` codes
 
 Revision entries carry an `actionType` string whose code meanings are


### PR DESCRIPTION
## Summary

- Adds a new section to `docs/vendor_gaps.md` documenting the undocumented `GET /console/api/v1/policy/mgmt/viewRevision/{revision_id}/{revision}` endpoint
- The file now records both undocumented history endpoints and the `actionType` code ambiguity, satisfying issue #174 AC1

## Acceptance criteria

- [x] (structural) `docs/vendor_gaps.md` records both undocumented endpoints (`policy/mgmt/history/<PolicyID>`, `policy/mgmt/viewRevision/<revision_id>/<revision>`) and the `actionType` code ambiguity (`UN`/`DE` observed, meaning undocumented)

## Test plan

- [ ] Docs-only change; no behaviour tests required (AC tagged `structural`)
- [ ] All 4 static checks pass (black, flake8, mypy, pyright)
- [ ] All 2296 unit tests pass at 95.99% coverage

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)