### PR TITLE
fix(PRD): #170 cleanup — capstone findings

### DIFF
--- a/docs/vendor_gaps.md
+++ b/docs/vendor_gaps.md
@@ -9,13 +9,23 @@ published contract does not describe.
 ## Endpoint — policy revision history
 
 `GET /console/api/v1/policy/mgmt/history/{policyId}` is not present in the
-vendor OpenAPI spec. It returns the standard paginated envelope
-(`pageNo` / `pageSize` / `totalPages` / `totalNoOfRecords`) wrapping a list of
-revision-metadata objects. On this list view `policyDetail` is always `null`;
-only the per-revision metadata is populated.
+vendor OpenAPI spec. Although the response is wrapped in the standard paginated
+envelope (`pageNo` / `pageSize` / `totalPages` / `totalNoOfRecords`), the
+endpoint does **not** actually paginate: it ignores the `pageNo` / `pageSize`
+query params and returns every revision in a single response. The three count
+fields are all reported equal to the total record count — `pageSize`,
+`totalPages`, and `totalNoOfRecords` move together (verified live up to 180
+revisions returned in one shot). Treating them as real pagination cursors
+causes the same body to be refetched once per record.
 
-Consumed by `PolicyService.list_history` / `AsyncPolicyService.list_history`,
-which deserialize each entry into `PolicyHistoryEntry`.
+Because of this, `PolicyService.list_history` /
+`AsyncPolicyService.list_history` issue a single GET with no query params and
+return a plain `list[PolicyHistoryEntry]`. As a guard against the vendor ever
+introducing real pagination, the SDK raises `ApiError` if a response ever
+reports more `totalNoOfRecords` than it returned — at which point that returned
+count reveals the page size that genuine pagination support must be built
+around. On this list view `policyDetail` is always `null`; only the
+per-revision metadata is populated.
 
 ## Endpoint — policy revision detail
 

--- a/src/nextlabs_sdk/_cloudaz/_policies.py
+++ b/src/nextlabs_sdk/_cloudaz/_policies.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-
 import httpx
 
 from nextlabs_sdk._cloudaz._component_models import (
@@ -15,13 +13,37 @@ from nextlabs_sdk._cloudaz._policy_models import (
     PolicyHistoryEntry,
     PolicyRevision,
 )
-from nextlabs_sdk._cloudaz._response import build_page, parse_data
-from nextlabs_sdk._pagination import AsyncPaginator, PageResult, SyncPaginator
-from nextlabs_sdk.exceptions import raise_for_status
+from nextlabs_sdk._cloudaz._response import parse_data, parse_paginated
+from nextlabs_sdk.exceptions import ApiError, raise_for_status
 
 _DELETE_METHOD = "DELETE"
 _PLAIN_MODE = "PLAIN"
 _EXPORT_MODE_PARAM = "exportMode"
+
+
+def _history_entries(response: httpx.Response) -> list[PolicyHistoryEntry]:
+    """Parse a policy-history response into the full list of revision entries.
+
+    The CloudAz history endpoint does not paginate: it ignores page query
+    params and returns every revision in a single response, reporting
+    ``pageSize``, ``totalPages``, and ``totalNoOfRecords`` all equal to the
+    record count (see ``docs/vendor_gaps.md``). The SDK therefore fetches once
+    and returns the whole list.
+
+    The guard covers the day the vendor ever introduces real pagination: if the
+    envelope reports more total records than it returned, returning the short
+    list would silently truncate, so we raise instead. The returned count is
+    then the page size that pagination support must be built around.
+    """
+    raw_items, _total_pages, total_records, _page_size = parse_paginated(response)
+    entries = [PolicyHistoryEntry.model_validate(entry) for entry in raw_items]
+    if total_records > len(entries):
+        raise ApiError(
+            f"history endpoint returned {len(entries)} of {total_records} "
+            "records — it now paginates; SDK pagination support is required",
+            status_code=response.status_code,
+        )
+    return entries
 
 
 class PolicyService:  # noqa: WPS214
@@ -47,13 +69,11 @@ class PolicyService:  # noqa: WPS214
         )
         return PolicyRevision.model_validate(parse_data(response))
 
-    def list_history(
-        self,
-        policy_id: int,
-    ) -> SyncPaginator[PolicyHistoryEntry]:
-        return SyncPaginator(
-            fetch_page=functools.partial(self._fetch_history_page, policy_id),
+    def list_history(self, policy_id: int) -> list[PolicyHistoryEntry]:
+        response = self._client.get(
+            f"/console/api/v1/policy/mgmt/history/{policy_id}",
         )
+        return _history_entries(response)
 
     def create(self, payload: dict[str, object]) -> int:
         response = self._client.post(
@@ -217,17 +237,6 @@ class PolicyService:  # noqa: WPS214
         )
         raise_for_status(response)
 
-    def _fetch_history_page(
-        self,
-        policy_id: int,
-        page_no: int,
-    ) -> PageResult[PolicyHistoryEntry]:
-        response = self._client.get(
-            f"/console/api/v1/policy/mgmt/history/{policy_id}",
-            params={"pageNo": page_no},
-        )
-        return build_page(response, PolicyHistoryEntry, page_no)
-
 
 class AsyncPolicyService:  # noqa: WPS214
 
@@ -252,13 +261,11 @@ class AsyncPolicyService:  # noqa: WPS214
         )
         return PolicyRevision.model_validate(parse_data(resp))
 
-    def list_history(
-        self,
-        policy_id: int,
-    ) -> AsyncPaginator[PolicyHistoryEntry]:
-        return AsyncPaginator(
-            fetch_page=functools.partial(self._fetch_history_page, policy_id),
+    async def list_history(self, policy_id: int) -> list[PolicyHistoryEntry]:
+        resp = await self._client.get(
+            f"/console/api/v1/policy/mgmt/history/{policy_id}",
         )
+        return _history_entries(resp)
 
     async def create(self, payload: dict[str, object]) -> int:
         resp = await self._client.post(
@@ -421,14 +428,3 @@ class AsyncPolicyService:  # noqa: WPS214
             json=payload,
         )
         raise_for_status(resp)
-
-    async def _fetch_history_page(
-        self,
-        policy_id: int,
-        page_no: int,
-    ) -> PageResult[PolicyHistoryEntry]:
-        resp = await self._client.get(
-            f"/console/api/v1/policy/mgmt/history/{policy_id}",
-            params={"pageNo": page_no},
-        )
-        return build_page(resp, PolicyHistoryEntry, page_no)

--- a/src/nextlabs_sdk/_cloudaz/_policy_models.py
+++ b/src/nextlabs_sdk/_cloudaz/_policy_models.py
@@ -294,6 +294,17 @@ class PolicyLite(BaseModel):
 
 
 class PolicyHistoryEntry(BaseModel):
+    """A single entry in a policy's revision history (list view).
+
+    Returned by ``GET /console/api/v1/policy/mgmt/history/{policy_id}``. This
+    view carries revision metadata only; ``policyDetail`` is ``null`` here and
+    is deliberately not a field (see :class:`PolicyRevision` for the detail
+    view that embeds the full policy).
+
+    ``revision`` arrives from the API as a JSON string (e.g. ``"3"``) and is
+    normalized to ``int`` on load, so consumers always receive an integer.
+    """
+
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     id: int  # noqa: WPS125

--- a/tests/test_async_policy_service.py
+++ b/tests/test_async_policy_service.py
@@ -10,7 +10,7 @@ from mockito import mock, when
 from nextlabs_sdk.cloudaz import AsyncPolicyService, Policy, PolicyRevision
 from nextlabs_sdk._cloudaz._component_models import Dependency, DeploymentResult
 from nextlabs_sdk._cloudaz._policy_models import ExportOptions, ImportResult
-from nextlabs_sdk.exceptions import NotFoundError
+from nextlabs_sdk.exceptions import ApiError, NotFoundError
 
 BASE_URL = "https://cloudaz.example.com"
 MGMT = "/console/api/v1/policy/mgmt"
@@ -100,13 +100,6 @@ def _make_revision_data() -> dict[str, Any]:
 
 def _run(coro: Awaitable[T]) -> T:
     return asyncio.run(coro)  # type: ignore[arg-type]
-
-
-def _collect(paginator: Any) -> list[Any]:
-    async def gather() -> list[Any]:
-        return [item async for item in paginator]
-
-    return asyncio.run(gather())
 
 
 @pytest.fixture
@@ -462,12 +455,8 @@ def test_async_retrieve_all_policies_returns_filename(
     assert _run(service.retrieve_all_policies(**kwargs)) == filename
 
 
-def test_async_list_history_returns_paginator(client_and_service):
-    from nextlabs_sdk._pagination import AsyncPaginator
-    from nextlabs_sdk.cloudaz import PolicyHistoryEntry
-
-    client, service = client_and_service
-    data = {
+def _history_entry(**overrides: Any) -> dict[str, Any]:
+    base = {
         "id": 770,
         "revision": "3",
         "name": "ROOT_42/pentest_policy",
@@ -483,57 +472,59 @@ def test_async_list_history_returns_paginator(client_and_service):
         "submittedDate": 1761133292266,
         "actionType": "UN",
     }
-    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(
-        _make_envelope(data=[data]),
+    return {**base, **overrides}
+
+
+def test_async_list_history_returns_all_entries(client_and_service):
+    from nextlabs_sdk.cloudaz import PolicyHistoryEntry
+
+    client, service = client_and_service
+    entry1 = _history_entry()
+    entry2 = _history_entry(id=769, revision="2", actionType="DE")
+    entry3 = _history_entry(id=768, revision="1", actionType="DE")
+    # One-shot endpoint: three count fields all equal the record count
+    # (#169: 3 records, totalPages 3). A real paginator would yield 9; expect 3.
+    when(client).get(f"{MGMT}/history/42").thenReturn(
+        _make_envelope(
+            data=[entry1, entry2, entry3],
+            page_no=1,
+            page_size=3,
+            total_pages=3,
+            total_records=3,
+        ),
     )
 
-    paginator = service.list_history(42)
+    results = _run(service.list_history(42))
 
-    assert isinstance(paginator, AsyncPaginator)
-    results = _collect(paginator)
-    assert len(results) == 1
+    assert isinstance(results, list)
+    assert [entry.revision for entry in results] == [3, 2, 1]
     assert isinstance(results[0], PolicyHistoryEntry)
-    assert results[0].revision == 3
     assert results[0].action_type == "UN"
 
 
-def test_async_list_history_paginates_multiple_pages(client_and_service):
+def test_async_list_history_raises_when_records_exceed_returned(client_and_service):
     client, service = client_and_service
-    base = {
-        "id": 770,
-        "revision": "3",
-        "name": "p",
-        "description": None,
-        "activeFrom": 1,
-        "activeTo": 1,
-        "policyDetail": None,
-        "createdDate": 1,
-        "createdBy": "me",
-        "modifiedBy": "me",
-        "lastUpdatedDate": 1,
-        "submittedBy": "me",
-        "submittedDate": 1,
-        "actionType": "UN",
-    }
-    entry2 = {**base, "id": 769, "revision": "2", "actionType": "DE"}
-    page0 = _make_envelope(data=[base], page_no=0, total_pages=2, total_records=2)
-    page1 = _make_envelope(data=[entry2], page_no=1, total_pages=2, total_records=2)
-    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(page0)
-    when(client).get(f"{MGMT}/history/42", params={"pageNo": 1}).thenReturn(page1)
+    when(client).get(f"{MGMT}/history/42").thenReturn(
+        _make_envelope(
+            data=[_history_entry()],
+            page_size=1,
+            total_pages=180,
+            total_records=180,
+        ),
+    )
 
-    results = _collect(service.list_history(42))
-
-    assert [e.revision for e in results] == [3, 2]
+    with pytest.raises(ApiError):
+        _run(service.list_history(42))
 
 
 def test_async_list_history_raises_not_found(client_and_service):
     client, service = client_and_service
-    when(client).get(f"{MGMT}/history/999", params={"pageNo": 0}).thenReturn(
+    when(client).get(f"{MGMT}/history/999").thenReturn(
         httpx.Response(404, json={"message": "Not found"}, request=_make_request()),
     )
 
     with pytest.raises(NotFoundError):
-        _collect(service.list_history(999))
+        _run(service.list_history(999))
 
 
 def test_async_get_revision_returns_policy_revision(client_and_service):

--- a/tests/test_policy_service.py
+++ b/tests/test_policy_service.py
@@ -15,7 +15,7 @@ from nextlabs_sdk._cloudaz._policy_models import (
     ImportResult,
 )
 from nextlabs_sdk.cloudaz import Policy, PolicyRevision, PolicyService
-from nextlabs_sdk.exceptions import NotFoundError
+from nextlabs_sdk.exceptions import ApiError, NotFoundError
 
 BASE_URL = "https://cloudaz.example.com"
 MGMT = "/console/api/v1/policy/mgmt"
@@ -459,50 +459,61 @@ def test_get_raises_not_found(client_service: tuple[Any, PolicyService]):
         service.get(999)
 
 
-def test_list_history_returns_paginator(client_service: tuple[Any, PolicyService]):
-    from nextlabs_sdk._pagination import SyncPaginator
+def test_list_history_returns_all_entries(client_service: tuple[Any, PolicyService]):
     from nextlabs_sdk.cloudaz import PolicyHistoryEntry
 
     client, service = client_service
-    when(client).get(
-        f"{MGMT}/history/42",
-        params={"pageNo": 0},
-    ).thenReturn(_make_envelope(data=[_history_entry_data()]))
+    entry1 = _history_entry_data()
+    entry2 = {**_history_entry_data(), "id": 769, "revision": "2", "actionType": "DE"}
+    entry3 = {**_history_entry_data(), "id": 768, "revision": "1", "actionType": "DE"}
+    # The history endpoint returns every revision in one shot and reports its
+    # three count fields all equal to the record count (#169: 3 records,
+    # totalPages 3). A real paginator would refetch and yield 9; we expect 3.
+    when(client).get(f"{MGMT}/history/42").thenReturn(
+        _make_envelope(
+            data=[entry1, entry2, entry3],
+            page_no=1,
+            page_size=3,
+            total_pages=3,
+            total_records=3,
+        ),
+    )
 
-    paginator = service.list_history(42)
+    results = service.list_history(42)
 
-    assert isinstance(paginator, SyncPaginator)
-    results = list(paginator)
-    assert len(results) == 1
+    assert isinstance(results, list)
+    assert [entry.revision for entry in results] == [3, 2, 1]
     assert isinstance(results[0], PolicyHistoryEntry)
-    assert results[0].revision == 3
     assert results[0].action_type == "UN"
 
 
-def test_list_history_paginates_multiple_pages(
+def test_list_history_raises_when_records_exceed_returned(
     client_service: tuple[Any, PolicyService],
 ):
     client, service = client_service
-    entry1 = _history_entry_data()
-    entry2 = {**_history_entry_data(), "id": 769, "revision": "2", "actionType": "DE"}
-    page0 = _make_envelope(data=[entry1], page_no=0, total_pages=2, total_records=2)
-    page1 = _make_envelope(data=[entry2], page_no=1, total_pages=2, total_records=2)
-    when(client).get(f"{MGMT}/history/42", params={"pageNo": 0}).thenReturn(page0)
-    when(client).get(f"{MGMT}/history/42", params={"pageNo": 1}).thenReturn(page1)
+    # The day the vendor introduces real pagination, a page returns fewer
+    # entries than totalNoOfRecords — the SDK must refuse to silently truncate.
+    when(client).get(f"{MGMT}/history/42").thenReturn(
+        _make_envelope(
+            data=[_history_entry_data()],
+            page_size=1,
+            total_pages=180,
+            total_records=180,
+        ),
+    )
 
-    results = list(service.list_history(42))
-
-    assert [e.revision for e in results] == [3, 2]
+    with pytest.raises(ApiError):
+        service.list_history(42)
 
 
 def test_list_history_raises_not_found(client_service: tuple[Any, PolicyService]):
     client, service = client_service
-    when(client).get(f"{MGMT}/history/999", params={"pageNo": 0}).thenReturn(
+    when(client).get(f"{MGMT}/history/999").thenReturn(
         httpx.Response(404, json={"message": "Not found"}, request=_make_request()),
     )
 
     with pytest.raises(NotFoundError):
-        list(service.list_history(999))
+        service.list_history(999)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses the capstone findings from the local `<prd-review>` for PRD #170
(SDK policy history endpoints).

The history endpoint does not paginate: it ignores `pageNo`/`pageSize` and
returns every revision in one response, reporting `pageSize`, `totalPages`,
and `totalNoOfRecords` all equal to the record count (verified live up to 180
revisions in one shot). The shipped paginator trusted `totalPages` as its stop
condition and refetched the same body once per record, yielding N² duplicates
for any policy with two or more revisions. `list_history` now fetches once with
no query params and returns a plain `list[PolicyHistoryEntry]`, guarding against
the day the vendor introduces real pagination.

Finding IDs addressed:
  - F1 — `list_history` N² duplication on a non-paginating endpoint
  - F3 — `docs/vendor_gaps.md` mis-described the history pagination
  - R1 — replace the paginator with a one-shot list + forward-compat guard
  - F4 — document the `revision` string→int coercion on `PolicyHistoryEntry`

Finding IDs skipped (with reason):
  - none

Note: the curated decisions excerpt is omitted — `docs/*/` is gitignored in
this repo, so `docs/decisions/` cannot be tracked.

Closes #170 (capstone cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
