### PR TITLE
feat(cli): add policies history and view-revision commands (#191)

### DIFF
--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -26,10 +26,11 @@ policies_app = typer.Typer(help="Policy management commands")
 
 _ID_FIELD = "id"
 _ID_COLUMN = ColumnDef("ID", _ID_FIELD)
+_NAME_COLUMN = ColumnDef("Name", "name")
 
 _POLICY_COLUMNS = (
     _ID_COLUMN,
-    ColumnDef("Name", "name"),
+    _NAME_COLUMN,
     ColumnDef("Status", "status"),
     ColumnDef("Effect", "effect_type"),
     ColumnDef("Deployed", "deployed"),
@@ -46,7 +47,7 @@ _DEPENDENCY_COLUMNS = (
     _ID_COLUMN,
     ColumnDef("Type", "type"),
     ColumnDef("Group", "group"),
-    ColumnDef("Name", "name"),
+    _NAME_COLUMN,
     ColumnDef("Folder Path", "folder_path"),
 )
 
@@ -60,6 +61,30 @@ _IMPORT_RESULT_COLUMNS = (
     ColumnDef("Components", "total_components"),
     ColumnDef("Policy Models", "total_policy_models"),
     ColumnDef("Non-Blocking Error", "non_blocking_error"),
+)
+
+_HISTORY_COLUMNS = (
+    ColumnDef("Revision", "revision"),
+    ColumnDef("Action", "action_type"),
+    ColumnDef("Created By", "created_by"),
+    ColumnDef("Modified By", "modified_by"),
+    ColumnDef("Active From", "active_from"),
+    ColumnDef("Active To", "active_to"),
+)
+
+_HISTORY_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    _ID_COLUMN,
+    ColumnDef("Submitted By", "submitted_by"),
+    ColumnDef("Submitted Date", "submitted_date"),
+)
+
+_REVISION_COLUMNS = (
+    _ID_COLUMN,
+    ColumnDef("Revision", "revision"),
+    _NAME_COLUMN,
+    ColumnDef("Action", "action_type"),
+    ColumnDef("Created By", "created_by"),
+    ColumnDef("Modified By", "modified_by"),
 )
 
 
@@ -87,6 +112,39 @@ def get_active(  # noqa: WPS463
     client = _client_factory.make_cloudaz_client(cli_ctx)
     policy = client.policies.get_active(policy_id)
     render(cli_ctx, policy, _POLICY_COLUMNS, wide_columns=_POLICY_WIDE_COLUMNS)
+
+
+@policies_app.command()
+@cli_error_handler
+def history(
+    ctx: typer.Context,
+    policy_id: Annotated[int, typer.Argument(help="Policy ID")],
+) -> None:
+    """List the revision history of a policy."""
+    cli_ctx: CliContext = ctx.obj
+    client = _client_factory.make_cloudaz_client(cli_ctx)
+    entries = client.policies.list_history(policy_id)
+    render(
+        cli_ctx,
+        entries,
+        _HISTORY_COLUMNS,
+        title="Policy History",
+        wide_columns=_HISTORY_WIDE_COLUMNS,
+    )
+
+
+@policies_app.command(name="view-revision")
+@cli_error_handler
+def view_revision(
+    ctx: typer.Context,
+    revision_id: Annotated[int, typer.Argument(help="Revision ID")],
+    revision: Annotated[int, typer.Argument(help="Revision number")],
+) -> None:
+    """View a specific revision of a policy."""
+    cli_ctx: CliContext = ctx.obj
+    client = _client_factory.make_cloudaz_client(cli_ctx)
+    rev = client.policies.get_revision(revision_id, revision)
+    render(cli_ctx, rev, _REVISION_COLUMNS)
 
 
 @policies_app.command(name="create-sub")

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -138,7 +138,7 @@ def history(
 def view_revision(
     ctx: typer.Context,
     revision_id: Annotated[int, typer.Argument(help="Revision ID")],
-    revision: Annotated[int, typer.Argument(help="Revision number")],
+    revision: Annotated[int, typer.Argument(help="Revision number")] = 0,
 ) -> None:
     """View a specific revision of a policy."""
     cli_ctx: CliContext = ctx.obj

--- a/tests/test_cli_policies.py
+++ b/tests/test_cli_policies.py
@@ -13,7 +13,9 @@ from nextlabs_sdk._cli._app import app
 from nextlabs_sdk.cloudaz import (
     CloudAzClient,
     Policy,
+    PolicyHistoryEntry,
     PolicyLite,
+    PolicyRevision,
     PolicySearchService,
     PolicyService,
 )
@@ -663,3 +665,138 @@ def test_policies_validate_obligations(
 
     assert result.exit_code == 0, result.output
     assert "valid" in result.output
+
+
+# --- history helpers ---
+
+
+def _make_history_entry(
+    revision: int = 3,
+    action_type: str = "DEPLOY",
+) -> PolicyHistoryEntry:
+    return PolicyHistoryEntry(
+        id=10,
+        revision=revision,
+        action_type=action_type,
+        created_by="admin",
+        modified_by="editor",
+        active_from=1700000000,
+        active_to=1700003600,
+    )
+
+
+def _make_policy_revision() -> PolicyRevision:
+    return PolicyRevision(
+        id=10,
+        revision=3,
+        action_type="DEPLOY",
+        created_by="admin",
+        modified_by="editor",
+        active_from=1700000000,
+        active_to=1700003600,
+        policy_detail=_make_policy(),
+    )
+
+
+# --- history (table vs json) ---
+
+
+def test_policies_history_table(stub: tuple[Any, Any, Any]) -> None:
+    """Given a policy with revision history, when `history` is invoked in
+    table mode, then a titled table shows audit-relevant fields."""
+    _, mock_policies, _ = stub
+    entries = [_make_history_entry()]
+    when(mock_policies).list_history(10).thenReturn(entries)
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "history", "10"])
+
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "DEPLOY" in output
+    assert "admin" in output
+    assert "editor" in output
+
+
+def test_policies_history_json(stub: tuple[Any, Any, Any]) -> None:
+    """Given a policy with revision history, when `history --output json`
+    is invoked, then the raw list of history entries is emitted as JSON."""
+    _, mock_policies, _ = stub
+    entries = [_make_history_entry()]
+    when(mock_policies).list_history(10).thenReturn(entries)
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "history", "10"]
+    )
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, list)
+    assert parsed[0]["revision"] == 3
+    assert parsed[0]["action_type"] == "DEPLOY"
+
+
+# --- view-revision (table vs json) ---
+
+
+def test_policies_view_revision_table(stub: tuple[Any, Any, Any]) -> None:
+    """Given a valid revision, when `view-revision` is invoked in table
+    mode, then key identifying fields are rendered as a table."""
+    _, mock_policies, _ = stub
+    when(mock_policies).get_revision(10, 3).thenReturn(_make_policy_revision())
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "view-revision", "10", "3"])
+
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "DEPLOY" in output
+    assert "admin" in output
+
+
+def test_policies_view_revision_json(stub: tuple[Any, Any, Any]) -> None:
+    """Given a valid revision, when `view-revision --output json` is
+    invoked, then the full PolicyRevision including policyDetail is emitted."""
+    _, mock_policies, _ = stub
+    when(mock_policies).get_revision(10, 3).thenReturn(_make_policy_revision())
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "view-revision", "10", "3"]
+    )
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["revision"] == 3
+    assert "policy_detail" in parsed
+    assert parsed["policy_detail"]["name"] == "Allow IT Access"
+
+
+# --- error handling (history + view-revision) ---
+
+
+def test_policies_history_not_found(stub: tuple[Any, Any, Any]) -> None:
+    """Given a non-existent policy ID, when `history` is invoked, then
+    the error handler surfaces a non-zero exit code with no traceback."""
+    _, mock_policies, _ = stub
+    when(mock_policies).list_history(999).thenRaise(NotFoundError(message="HTTP 404"))
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "history", "999"])
+
+    assert result.exit_code == 1
+    assert "Not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_policies_view_revision_not_found(stub: tuple[Any, Any, Any]) -> None:
+    """Given a non-existent revision, when `view-revision` is invoked, then
+    the error handler surfaces a non-zero exit code with no traceback."""
+    _, mock_policies, _ = stub
+    when(mock_policies).get_revision(999, 1).thenRaise(
+        NotFoundError(message="HTTP 404")
+    )
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "view-revision", "999", "1"]
+    )
+
+    assert result.exit_code == 1
+    assert "Not found" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_cli_policies.py
+++ b/tests/test_cli_policies.py
@@ -769,6 +769,21 @@ def test_policies_view_revision_json(stub: tuple[Any, Any, Any]) -> None:
     assert parsed["policy_detail"]["name"] == "Allow IT Access"
 
 
+def test_policies_view_revision_defaults_revision_to_zero(
+    stub: tuple[Any, Any, Any],
+) -> None:
+    """Given only a revision_id, when `view-revision` is invoked without a
+    revision number, then revision defaults to 0."""
+    _, mock_policies, _ = stub
+    when(mock_policies).get_revision(10, 0).thenReturn(_make_policy_revision())
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "view-revision", "10"])
+
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "admin" in output
+
+
 # --- error handling (history + view-revision) ---
 
 


### PR DESCRIPTION
Closes #191

## Summary
- Added `policies history <policy_id>` and `policies view-revision <revision_id> <revision>` commands to the CLI, reusing `render`/`ColumnDef` and the existing `@cli_error_handler` decorator
- Six new tests cover table output, JSON output, and NotFoundError handling for both commands
- Extracted `_NAME_COLUMN` constant to resolve WPS226 string-literal overuse

## Tests added (red → green)
- `test_policies_history_table`
- `test_policies_history_json`
- `test_policies_view_revision_table`
- `test_policies_view_revision_json`
- `test_policies_history_not_found`
- `test_policies_view_revision_not_found`
