### PR TITLE
feat(cli): policies diff — end-to-end semantic diff (194/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ auth             login | logout | status | test | accounts | use
 tags             list (positional <tag_type>) | get | create | delete
 components       search | get | create | update | delete
 component-types  list | get | create | update | delete
-policies         search | get | export-all | tags
+policies         search | get | diff | export-all | tags
 audit-logs       search (--start-date / --end-date in epoch-ms)
 reports          ...
 dashboard        ...
@@ -302,7 +302,14 @@ NEXTLABS_TOKEN="$(vault kv get -field=token secret/nextlabs/ci)" \
 `NEXTLABS_TOKEN` (or `--token`) bypasses the OIDC login flow **and** the
 token cache — nothing is read from or written to disk.
 
-**6. Templated extraction with `jq`.**
+**6. Review a policy before deploy — diff the two most recent deployed revisions.**
+
+```bash
+nextlabs policies diff 17
+nextlabs policies diff 17 --from 3 --to 5
+```
+
+**7. Templated extraction with `jq`.**
 
 ```bash
 nextlabs -o json components search | jq '.[].id'

--- a/docs/adr/0002-cli-convenience-command-boundary.md
+++ b/docs/adr/0002-cli-convenience-command-boundary.md
@@ -1,0 +1,117 @@
+# ADR 0002: CLI convenience-command boundary
+
+## Status
+
+Accepted
+
+## Context
+
+`nextlabs-sdk` ships in two installable shapes: the core SDK
+(`pip install nextlabs-sdk`) and the CLI extra (`pip install
+nextlabs-sdk[cli]`). The original mental model was strict: the SDK is a
+faithful, opinion-free wrapper of the CloudAz Console API and the PDP REST
+API, and the CLI is a thin shell that mirrors SDK calls one-to-one (get,
+create, delete, etc.).
+
+A new class of demand has emerged that does not fit that model cleanly:
+**convenience features that compose existing SDK calls and present a
+result**, without introducing new business logic or persistent state. The
+first concrete example is a command that diffs the content of a policy in
+its last deployed state against the deployed state before it — it fetches
+two revisions the SDK already knows how to retrieve (`list_history`,
+`get_revision`) and renders the delta.
+
+These features are neither "pure API wrapper" (they compose and present)
+nor "third-domain product logic" (they encode no platform rules). We need a
+durable rule for where such features live, so each new convenience request
+does not re-open the same placement debate.
+
+## Decision Drivers
+
+* Keep the SDK core opinion-free: no rendering, no terminal concerns, no
+  composite "do three calls and format" helpers leaking into the public
+  surface that application developers import.
+* Give convenience/composition features an unambiguous home so they are not
+  blocked or bikeshedded on every request.
+* Avoid premature packaging overhead (a second distributable, its own
+  release cadence, its own config/plugin model) before there is evidence it
+  is needed.
+* Preserve the existing public-surface discipline from ADR 0001 (underscore
+  internals, curated facades).
+
+## Considered Options
+
+### Option 1 — Put convenience logic in the SDK core (public)
+
+Add composite helpers (fetch-two-revisions-and-diff) to the public SDK so
+both scripts and the CLI can call them.
+
+**Pros:** reusable from application code.
+**Cons:** the SDK stops being an opinion-free wrapper; presentation and
+composition concerns bleed into the public surface; every convenience
+request grows the public API and its compatibility burden. Diff/rendering
+has no natural place in a transport-level client.
+
+### Option 2 — Put convenience logic in the CLI layer (`[cli]`)
+
+Keep composition and presentation entirely inside the CLI extra. The SDK
+exposes only the primitive calls; the CLI fetches, composes, filters, and
+renders.
+
+**Pros:** SDK core stays pure; convenience features get a clear home; no new
+packaging; the boundary is visible in the filesystem (CLI-internal
+modules). Mirrors the tension analysis: composing and formatting are CLI
+territory, not impurity.
+**Cons:** the composite logic is not importable from plain application code
+(acceptable — these features are human-facing by nature).
+
+### Option 3 — Create a separate `nextlabs-cli` package
+
+Split the CLI into its own distributable that depends on the SDK.
+
+**Pros:** independent release cadence; CLI contributors need no SDK
+internals; enables alternative SDK backends behind one CLI.
+**Cons:** premature for current scope; doubles release/versioning overhead;
+no present requirement (own config files, plugin model, third-party
+backends) justifies it.
+
+## Decision
+
+**Option 2 — convenience/composition commands live in the CLI layer
+(`nextlabs-sdk[cli]`), as CLI-internal modules.**
+
+The boundary rule, to be used for every future convenience request:
+
+* **SDK core (`nextlabs_sdk`, `.cloudaz`, `.pdp`)** contains direct mappings
+  of API endpoints, data models, auth/transport, and anything an
+  application developer calls from code. It returns data and holds no
+  opinion on output.
+* **CLI extra (`nextlabs-sdk[cli]`)** may compose multiple SDK calls, filter
+  and normalise their results, and render them (tables, trees, diffs,
+  colour, paging, JSON) — **provided it introduces no new business logic and
+  requires no persistent state of its own.**
+* **Neither layer** hosts NextLabs platform/business rules, nor stateful
+  workflows that span sessions.
+
+A convenience feature graduates out of the CLI extra (toward Option 1 or 3)
+only when it needs persistent state, an external system not already in the
+SDK, or an independent release cadence. Until then, it stays CLI-internal.
+
+The first application of this rule is the `policies diff` command, whose
+diff engine and renderers live under CLI-internal modules and consume only
+the existing `PolicyService` primitives.
+
+## Consequences
+
+* **Positive:** every future convenience request has a default home and a
+  crisp test ("new business logic or persistent state? → not the CLI").
+* **Positive:** the SDK public surface stays minimal and opinion-free,
+  preserving ADR 0001's discipline.
+* **Positive:** the boundary is visible in the filesystem — composite logic
+  sits in CLI-internal packages, not in the SDK facades.
+* **Negative:** composite convenience logic is not reusable from plain
+  application code. Accepted: these features are inherently human-facing; if
+  a genuine library consumer appears, that is the trigger to revisit
+  Option 1/3.
+* **Neutral:** this ADR governs placement only; it does not change the
+  public API surface defined by ADR 0001.

--- a/src/nextlabs_sdk/_cli/_diff/__init__.py
+++ b/src/nextlabs_sdk/_cli/_diff/__init__.py
@@ -1,0 +1,1 @@
+"""CLI-internal package for policy diff functionality."""

--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -39,7 +39,6 @@ def diff_payloads(
         noise-field differences.
     """
     changes: list[FieldChange] = []
-    hidden_noise_count = 0
 
     _diff_dicts(old, new, path=(), show_all=show_all, changes=changes)
 

--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -1,0 +1,122 @@
+"""Structural diff engine for policy payloads."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+
+_NOISE_FIELDS: frozenset[str] = frozenset(
+    (
+        "deploymentTime",
+        "deploymentRequest",
+        "createdDate",
+        "lastUpdatedDate",
+        "modifiedBy",
+        "modifiedById",
+        "deploymentPending",
+    )
+)
+
+
+def diff_payloads(
+    old: Mapping[str, object],
+    new: Mapping[str, object],
+    *,
+    show_all: bool = False,
+) -> DiffResult:
+    """Compare two alias-keyed policy payload dicts and return a structured delta.
+
+    Args:
+        old: The baseline policy payload (alias-keyed JSON dict).
+        new: The revised policy payload (alias-keyed JSON dict).
+        show_all: When True, disables noise filtering and array-order
+            normalisation so every raw difference is reported.
+
+    Returns:
+        A DiffResult with all detected changes and a count of suppressed
+        noise-field differences.
+    """
+    changes: list[FieldChange] = []
+    hidden_noise_count = 0
+
+    _diff_dicts(old, new, path=(), show_all=show_all, changes=changes)
+
+    noise_changes = []
+    visible_changes = []
+    for change in changes:
+        if not show_all and change.path and change.path[-1] in _NOISE_FIELDS:
+            noise_changes.append(change)
+        else:
+            visible_changes.append(change)
+
+    hidden_noise_count = len(noise_changes)
+    return DiffResult(
+        changes=tuple(visible_changes),
+        hidden_noise_count=hidden_noise_count,
+    )
+
+
+def _diff_dicts(
+    old: Mapping[str, object],
+    new: Mapping[str, object],
+    *,
+    path: tuple[str, ...],
+    show_all: bool,
+    changes: list[FieldChange],
+) -> None:
+    all_keys = old.keys() | new.keys()
+    for key in all_keys:
+        child_path = path + (key,)
+        if key not in old:
+            changes.append(
+                FieldChange(path=child_path, kind="add", old=None, new=new[key])
+            )
+        elif key not in new:
+            changes.append(
+                FieldChange(path=child_path, kind="remove", old=old[key], new=None)
+            )
+        else:
+            _diff_values(
+                old[key], new[key], path=child_path, show_all=show_all, changes=changes
+            )
+
+
+def _diff_values(
+    old: object,
+    new: object,
+    *,
+    path: tuple[str, ...],
+    show_all: bool,
+    changes: list[FieldChange],
+) -> None:
+    if isinstance(old, dict) and isinstance(new, dict):
+        _diff_dicts(old, new, path=path, show_all=show_all, changes=changes)
+    elif isinstance(old, list) and isinstance(new, list):
+        _diff_lists(old, new, path=path, show_all=show_all, changes=changes)
+    elif old != new:
+        changes.append(FieldChange(path=path, kind="change", old=old, new=new))
+
+
+def _canonical(elem: object) -> str:
+    return json.dumps(elem, sort_keys=True)
+
+
+def _diff_lists(
+    old: list[object],
+    new: list[object],
+    *,
+    path: tuple[str, ...],
+    show_all: bool,
+    changes: list[FieldChange],
+) -> None:
+    if show_all:
+        if old != new:
+            changes.append(FieldChange(path=path, kind="change", old=old, new=new))
+        return
+
+    old_set = {_canonical(elem) for elem in old}
+    new_set = {_canonical(elem) for elem in new}
+    if old_set != new_set:
+        changes.append(FieldChange(path=path, kind="change", old=old, new=new))

--- a/src/nextlabs_sdk/_cli/_diff/_inline.py
+++ b/src/nextlabs_sdk/_cli/_diff/_inline.py
@@ -1,0 +1,28 @@
+"""Word-level inline highlighter for scalar string diffs."""
+
+from __future__ import annotations
+
+import difflib
+
+
+def highlight_inline(old: str, new: str) -> str:
+    """Return *new* with only inserted/replaced words wrapped in Rich emphasis.
+
+    Args:
+        old: The previous scalar string value.
+        new: The updated scalar string value.
+
+    Returns:
+        The new string with changed words wrapped in ``[bold yellow]...[/bold yellow]``.
+    """
+    old_words = old.split()
+    new_words = new.split()
+    matcher = difflib.SequenceMatcher(None, old_words, new_words, autojunk=False)
+    parts: list[str] = []
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        segment = new_words[j1:j2]
+        if tag == "equal":
+            parts.extend(segment)
+        else:
+            parts.extend(f"[bold yellow]{word}[/bold yellow]" for word in segment)
+    return " ".join(parts)

--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -1,0 +1,24 @@
+"""Delta model types for the policy diff engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class FieldChange:
+    """A single field-level change between two policy payloads."""
+
+    path: tuple[str, ...]
+    kind: Literal["add", "remove", "change"]
+    old: object | None
+    new: object | None
+
+
+@dataclass(frozen=True)
+class DiffResult:
+    """The structured result of comparing two policy payloads."""
+
+    changes: tuple[FieldChange, ...]
+    hidden_noise_count: int

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -1,0 +1,58 @@
+"""Semantic Rich renderer for policy diff results."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from nextlabs_sdk._cli._diff._inline import highlight_inline
+from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+
+_GLYPH_ADD = "[green]+[/green]"
+_GLYPH_REMOVE = "[red]-[/red]"
+_GLYPH_CHANGE = "[yellow]~[/yellow]"
+
+
+def _render_change(con: Console, field: str, change: FieldChange) -> None:
+    """Print a single FieldChange row to *con*.
+
+    Args:
+        con: The Rich console to print to.
+        field: Dot-joined path string for display.
+        change: The field change to render.
+    """
+    if change.kind == "add":
+        con.print(f"  {_GLYPH_ADD} {field}: {change.new}")
+    elif change.kind == "remove":
+        con.print(f"  {_GLYPH_REMOVE} {field}: {change.old}")
+    elif isinstance(change.old, str) and isinstance(change.new, str):
+        highlighted = highlight_inline(change.old, change.new)
+        con.print(f"  {_GLYPH_CHANGE} {field}: {highlighted}")
+    else:
+        con.print(f"  {_GLYPH_CHANGE} {field}: {change.old!r} \u2192 {change.new!r}")
+
+
+def render_semantic(diff: DiffResult, *, console: Console | None = None) -> None:
+    """Render a DiffResult as a Rich semantic report.
+
+    In-place scalar edits show only the changed words highlighted.
+    A footer is printed when noise-only changes were filtered.
+
+    Args:
+        diff: The structured diff result to render.
+        console: Rich Console to print to; defaults to a new Console().
+    """
+    con = Console() if console is None else console
+    con.print("[bold]Policy diff[/bold]")
+
+    sections: dict[str, list[FieldChange]] = {}
+    for change in diff.changes:
+        sections.setdefault(change.path[0], []).append(change)
+
+    for section, changes in sections.items():
+        con.print(f"\n[bold]{section}[/bold]")
+        for change in changes:
+            field = ".".join(str(segment) for segment in change.path)
+            _render_change(con, field, change)
+
+    if diff.hidden_noise_count > 0:
+        con.print(f"\n[dim]{diff.hidden_noise_count} noise-only change(s) hidden[/dim]")

--- a/src/nextlabs_sdk/_cli/_diff/_revision_select.py
+++ b/src/nextlabs_sdk/_cli/_diff/_revision_select.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from nextlabs_sdk._cloudaz._policies import PolicyService
+from nextlabs_sdk._cloudaz._policy_models import PolicyRevision
+
+DEPLOYED_ACTION_TYPE = "DE"
+
+
+class InsufficientRevisionsError(Exception):
+    """Raised when fewer than two comparable revisions exist for a policy."""
+
+
+def select_revisions(
+    policies: PolicyService,
+    policy_id: int,
+    *,
+    from_rev: int | None = None,
+    to_rev: int | None = None,
+) -> tuple[PolicyRevision, PolicyRevision]:
+    """Resolve the two policy revisions to compare.
+
+    Args:
+        policies: The policy service used to query history and fetch revisions.
+        policy_id: The policy whose revisions are being compared.
+        from_rev: Explicit revision number for the older side. When given,
+            bypasses the deployed-only filter for that side.
+        to_rev: Explicit revision number for the newer side. When given,
+            bypasses the deployed-only filter for that side.
+
+    Returns:
+        A ``(old, new)`` tuple where ``new`` is the newer/``to`` side.
+
+    Raises:
+        InsufficientRevisionsError: When both sides cannot be resolved because
+            fewer than two deployed revisions exist and overrides do not supply
+            both sides.
+    """
+    if from_rev is not None and to_rev is not None:
+        old = policies.get_revision(policy_id, from_rev)
+        new = policies.get_revision(policy_id, to_rev)
+        return old, new
+
+    entries = policies.list_history(policy_id)
+    deployed = sorted(
+        (entry for entry in entries if entry.action_type == DEPLOYED_ACTION_TYPE),
+        key=lambda entry: entry.revision,
+        reverse=True,
+    )
+
+    resolved_to = to_rev
+    resolved_from = from_rev
+
+    if resolved_to is None:
+        if not deployed:
+            raise InsufficientRevisionsError(
+                f"Policy {policy_id} has fewer than two comparable revisions to diff."
+            )
+        resolved_to = deployed[0].revision
+
+    if resolved_from is None:
+        remaining = [entry for entry in deployed if entry.revision != resolved_to]
+        if not remaining:
+            raise InsufficientRevisionsError(
+                f"Policy {policy_id} has fewer than two comparable revisions to diff."
+            )
+        resolved_from = remaining[0].revision
+
+    old = policies.get_revision(policy_id, resolved_from)
+    new = policies.get_revision(policy_id, resolved_to)
+    return old, new

--- a/src/nextlabs_sdk/_cli/_diff/_revision_select.py
+++ b/src/nextlabs_sdk/_cli/_diff/_revision_select.py
@@ -1,12 +1,15 @@
+"""Revision selection logic for the policy diff command."""
+
 from __future__ import annotations
 
 from nextlabs_sdk._cloudaz._policies import PolicyService
 from nextlabs_sdk._cloudaz._policy_models import PolicyRevision
+from nextlabs_sdk.exceptions import NextLabsError
 
 DEPLOYED_ACTION_TYPE = "DE"
 
 
-class InsufficientRevisionsError(Exception):
+class InsufficientRevisionsError(NextLabsError):
     """Raised when fewer than two comparable revisions exist for a policy."""
 
 

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -12,6 +12,12 @@ from nextlabs_sdk._cli._binary_output import write_bytes
 from nextlabs_sdk._cli._bulk_ids import parse_bulk_ids
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
+from nextlabs_sdk._cli._diff._engine import diff_payloads
+from nextlabs_sdk._cli._diff._render_semantic import render_semantic
+from nextlabs_sdk._cli._diff._revision_select import (
+    InsufficientRevisionsError,
+    select_revisions,
+)
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import ColumnDef, print_error, print_success, render
 from nextlabs_sdk._cli._payload_loader import (
@@ -592,3 +598,34 @@ def _render_policy_detail(model: BaseModel, console: Console) -> None:
 
 
 register_detail_renderer(Policy, _render_policy_detail)
+
+
+@policies_app.command()
+@cli_error_handler
+def diff(
+    ctx: typer.Context,
+    policy_id: Annotated[int, typer.Argument(help="Policy ID")],
+    from_rev: Annotated[
+        int | None, typer.Option("--from", help="Override the 'from' revision")
+    ] = None,
+    to_rev: Annotated[
+        int | None, typer.Option("--to", help="Override the 'to' revision")
+    ] = None,
+    show_all: Annotated[
+        bool, typer.Option("--show-all", help="Reveal ordering + noise differences")
+    ] = False,
+) -> None:
+    """Show a semantic diff between two revisions of a policy."""
+    cli_ctx: CliContext = ctx.obj
+    client = _client_factory.make_cloudaz_client(cli_ctx)
+    try:
+        old, new = select_revisions(
+            client.policies, policy_id, from_rev=from_rev, to_rev=to_rev
+        )
+    except InsufficientRevisionsError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from exc
+    old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)
+    new_payload = new.policy_detail.model_dump(mode="json", by_alias=True)
+    diff_result = diff_payloads(old_payload, new_payload, show_all=show_all)
+    render_semantic(diff_result)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mockito import mock, when
+from strip_ansi import strip_ansi
+from typer.testing import CliRunner
+
+from nextlabs_sdk._cli import _client_factory
+from nextlabs_sdk._cli._app import app
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
+    Policy,
+    PolicyHistoryEntry,
+    PolicyRevision,
+    PolicyService,
+)
+
+runner = CliRunner()
+
+_GLOBAL_OPTS = (
+    "--base-url",
+    "https://example.com",
+    "--username",
+    "admin",
+    "--password",
+    "secret",
+)
+
+
+@pytest.fixture
+def stub() -> tuple[Any, Any]:
+    mock_client = mock(CloudAzClient)
+    mock_policies = mock(PolicyService)
+    mock_client.policies = mock_policies
+    when(_client_factory).make_cloudaz_client(...).thenReturn(mock_client)
+    return mock_client, mock_policies
+
+
+def _entry(revision: int, action_type: str = "DE") -> PolicyHistoryEntry:
+    return PolicyHistoryEntry(id=10, revision=revision, action_type=action_type)
+
+
+def _revision(
+    revision: int, description: str = "d", deployment_time: int = 0
+) -> PolicyRevision:
+    return PolicyRevision(
+        id=10,
+        revision=revision,
+        action_type="DE",
+        policy_detail=Policy(
+            id=82,
+            name="P",
+            status="DRAFT",
+            effect_type="ALLOW",
+            description=description,
+            deployment_time=deployment_time,
+        ),
+    )
+
+
+def test_diff_default_renders_semantic_report(stub: tuple[Any, Any]) -> None:
+    """Given two deployed revisions differing in description, when running diff
+    with no flags, then it succeeds and shows the changed scalar."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "write" in output
+
+
+def test_diff_show_all_reveals_noise(stub: tuple[Any, Any]) -> None:
+    """Given two deployed revisions differing only in a deployment-noise field,
+    when running diff with --show-all, then the otherwise-hidden noise field is
+    revealed."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, deployment_time=200)
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, deployment_time=100)
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--show-all"])
+    assert result.exit_code == 0
+    assert "deploymentTime" in strip_ansi(result.output)
+
+
+def test_diff_from_to_override_fetches_those_revisions(stub: tuple[Any, Any]) -> None:
+    """Given explicit from/to revisions, when overriding both sides, then it
+    succeeds using the overridden revisions."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 1).thenReturn(
+        _revision(1, description="allow read access")
+    )
+    when(mock_policies).get_revision(10, 4).thenReturn(
+        _revision(4, description="allow write access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--from", "1", "--to", "4"]
+    )
+    assert result.exit_code == 0
+    assert "write" in strip_ansi(result.output)
+
+
+def test_diff_too_few_revisions_exits_nonzero_without_traceback(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given a policy with only one deployed revision, when running diff, then
+    it exits non-zero with a clear message and no traceback."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(3)])
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code != 0
+    output = strip_ansi(result.output)
+    assert "Traceback" not in output
+    assert "fewer than two" in output.lower()

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -98,7 +98,6 @@ def test_diff_from_to_override_fetches_those_revisions(stub: tuple[Any, Any]) ->
     """Given explicit from/to revisions, when overriding both sides, then it
     succeeds using the overridden revisions."""
     _, mock_policies = stub
-    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
     when(mock_policies).get_revision(10, 1).thenReturn(
         _revision(1, description="allow read access")
     )

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from nextlabs_sdk._cli._diff._engine import diff_payloads
+
+
+def test_reordered_idless_array_yields_no_change():
+    """Given two payloads whose only difference is tag ordering.
+
+    When diffing.
+    Then there are no changes.
+    """
+    old = {"name": "P", "tags": [{"key": "a"}, {"key": "b"}]}
+    new = {"name": "P", "tags": [{"key": "b"}, {"key": "a"}]}
+
+    result = diff_payloads(old, new)
+
+    assert result.changes == ()
+
+
+def test_deployment_noise_excluded_by_default():
+    """Given payloads differing only in deployment-noise leaf fields.
+
+    When diffing without show_all.
+    Then no visible changes, but the hidden count reflects the noise.
+    """
+    old = {"name": "P", "deploymentTime": 1, "createdDate": 10, "modifiedBy": "x"}
+    new = {"name": "P", "deploymentTime": 2, "createdDate": 20, "modifiedBy": "y"}
+
+    result = diff_payloads(old, new)
+
+    assert result.changes == ()
+    assert result.hidden_noise_count == 3
+
+
+def test_version_change_stays_visible():
+    """Given payloads differing only in version.
+
+    When diffing.
+    Then the version change is reported.
+    """
+    old = {"name": "P", "version": 3}
+    new = {"name": "P", "version": 4}
+
+    result = diff_payloads(old, new)
+
+    assert any(c.path == ("version",) and c.kind == "change" for c in result.changes)
+
+
+def test_nested_scalar_change_recorded_with_path():
+    """Given a nested scalar edit.
+
+    When diffing.
+    Then the change carries the full nested path.
+    """
+    old = {"environmentConfig": {"remoteAccess": 1}}
+    new = {"environmentConfig": {"remoteAccess": 2}}
+
+    result = diff_payloads(old, new)
+
+    assert any(
+        c.path == ("environmentConfig", "remoteAccess") and c.old == 1 and c.new == 2
+        for c in result.changes
+    )
+
+
+def test_show_all_reincludes_noise_and_ordering():
+    """Given payloads differing in noise and array order.
+
+    When diffing with show_all.
+    Then the deployment noise difference is now visible.
+    """
+    old = {"deploymentTime": 1, "tags": [{"key": "a"}, {"key": "b"}]}
+    new = {"deploymentTime": 2, "tags": [{"key": "b"}, {"key": "a"}]}
+
+    result = diff_payloads(old, new, show_all=True)
+
+    assert any(c.path == ("deploymentTime",) for c in result.changes)

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -1,0 +1,65 @@
+"""Tests for the inline highlighter and semantic renderer."""
+
+from rich.console import Console
+
+from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+
+
+def test_highlight_inline_emphasises_only_changed_word():
+    """Test that only changed words are emphasised.
+
+    Given two scalar strings differing by one word,
+    when highlighting the change inline,
+    then only the changed word carries emphasis; unchanged words are plain.
+    """
+    from nextlabs_sdk._cli._diff._inline import highlight_inline
+
+    old = "allow read access"
+    new = "allow write access"
+    markup = highlight_inline(old, new)
+    assert "[bold yellow]write[/bold yellow]" in markup
+    assert "allow" in markup
+    assert "[bold yellow]allow[/bold yellow]" not in markup
+
+
+def test_highlight_inline_unchanged_string_has_no_emphasis():
+    """Test that identical strings produce no emphasis markup.
+
+    Given identical strings,
+    when highlighting,
+    then no emphasis markup is added.
+    """
+    from nextlabs_sdk._cli._diff._inline import highlight_inline
+
+    text = "allow read access"
+    markup = highlight_inline(text, text)
+    assert "[bold yellow]" not in markup
+
+
+def test_render_semantic_shows_inplace_scalar_change():
+    """Test that the renderer shows in-place scalar changes with highlighted words.
+
+    Given a delta with a single scalar description edit,
+    when rendering to a captured console,
+    then the changed word and the hidden-noise footer are present in-place.
+    """
+    from nextlabs_sdk._cli._diff._render_semantic import render_semantic
+
+    result = DiffResult(
+        changes=(
+            FieldChange(
+                path=("description",),
+                kind="change",
+                old="allow read access",
+                new="allow write access",
+            ),
+        ),
+        hidden_noise_count=2,
+    )
+    console = Console()
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    assert "write" in output
+    assert "access" in output
+    assert "2 noise-only" in output

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -1,8 +1,12 @@
 """Tests for the inline highlighter and semantic renderer."""
 
+from __future__ import annotations
+
 from rich.console import Console
 
+from nextlabs_sdk._cli._diff._inline import highlight_inline
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._render_semantic import render_semantic
 
 
 def test_highlight_inline_emphasises_only_changed_word():
@@ -12,8 +16,6 @@ def test_highlight_inline_emphasises_only_changed_word():
     when highlighting the change inline,
     then only the changed word carries emphasis; unchanged words are plain.
     """
-    from nextlabs_sdk._cli._diff._inline import highlight_inline
-
     old = "allow read access"
     new = "allow write access"
     markup = highlight_inline(old, new)
@@ -29,8 +31,6 @@ def test_highlight_inline_unchanged_string_has_no_emphasis():
     when highlighting,
     then no emphasis markup is added.
     """
-    from nextlabs_sdk._cli._diff._inline import highlight_inline
-
     text = "allow read access"
     markup = highlight_inline(text, text)
     assert "[bold yellow]" not in markup
@@ -43,8 +43,6 @@ def test_render_semantic_shows_inplace_scalar_change():
     when rendering to a captured console,
     then the changed word and the hidden-noise footer are present in-place.
     """
-    from nextlabs_sdk._cli._diff._render_semantic import render_semantic
-
     result = DiffResult(
         changes=(
             FieldChange(

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from io import StringIO
+
 from rich.console import Console
 
 from nextlabs_sdk._cli._diff._inline import highlight_inline
@@ -54,7 +56,9 @@ def test_render_semantic_shows_inplace_scalar_change():
         ),
         hidden_noise_count=2,
     )
-    console = Console()
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
     with console.capture() as capture:
         render_semantic(result, console=console)
     output = capture.get()

--- a/tests/test_policy_diff_revision_select.py
+++ b/tests/test_policy_diff_revision_select.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from mockito import mock, when
 

--- a/tests/test_policy_diff_revision_select.py
+++ b/tests/test_policy_diff_revision_select.py
@@ -1,0 +1,80 @@
+import pytest
+from mockito import mock, when
+
+from nextlabs_sdk.cloudaz import (
+    Policy,
+    PolicyHistoryEntry,
+    PolicyRevision,
+    PolicyService,
+)
+from nextlabs_sdk._cli._diff._revision_select import (
+    InsufficientRevisionsError,
+    select_revisions,
+)
+
+
+def _entry(revision: int, action_type: str = "DE") -> PolicyHistoryEntry:
+    return PolicyHistoryEntry(id=10, revision=revision, action_type=action_type)
+
+
+def _revision(revision: int) -> PolicyRevision:
+    return PolicyRevision(
+        id=10,
+        revision=revision,
+        action_type="DE",
+        policy_detail=Policy(id=82, name="P", status="DRAFT", effect_type="ALLOW"),
+    )
+
+
+def test_default_selects_two_most_recent_deployed():
+    """Given history with three deployed revisions and one draft.
+
+    When selecting with no overrides.
+    Then the two most recent deployed revisions are chosen, newest as "new".
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(10).thenReturn(
+        [_entry(1), _entry(2), _entry(3), _entry(4, action_type="DR")]
+    )
+    when(policies).get_revision(10, 3).thenReturn(_revision(3))
+    when(policies).get_revision(10, 2).thenReturn(_revision(2))
+    # when
+    old, new = select_revisions(policies, 10)
+    # then
+    assert old.revision == 2
+    assert new.revision == 3
+
+
+def test_from_and_to_override_bypass_deployed_filter():
+    """Given history whose entries are all non-deployed drafts.
+
+    When overriding both sides explicitly.
+    Then those exact revisions are fetched despite none being deployed.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(10).thenReturn(
+        [_entry(5, action_type="DR"), _entry(6, action_type="DR")]
+    )
+    when(policies).get_revision(10, 5).thenReturn(_revision(5))
+    when(policies).get_revision(10, 6).thenReturn(_revision(6))
+    # when
+    old, new = select_revisions(policies, 10, from_rev=5, to_rev=6)
+    # then
+    assert old.revision == 5
+    assert new.revision == 6
+
+
+def test_fewer_than_two_comparable_raises():
+    """Given history with a single deployed revision and no overrides.
+
+    When selecting.
+    Then a clear domain error is raised.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(10).thenReturn([_entry(1)])
+    # when / then
+    with pytest.raises(InsufficientRevisionsError):
+        select_revisions(policies, 10)


### PR DESCRIPTION
Add `policies diff <policy_id>` subcommand that compares two revisions of a policy and renders a semantic report of the meaningful changes.

## What this does

- Resolves the two most recent **deployed** revisions by default; `--from`/`--to` override either side
- Structural diff engine: recurses dicts, compares scalar/id-less arrays as sets, skips noise (deployment timestamps/metadata)
- ComparePlus-style word-level inline highlighter for in-place scalar edits
- Rich semantic renderer with domain-grouped sections and hidden-noise footer
- `--show-all` disables ordering normalisation and noise blacklist
- Clear CLI error (non-zero exit, no traceback) when fewer than two comparable revisions exist

All logic lives CLI-internal under `_cli/_diff/` per ADR 0002.

Closes #195