### PR TITLE
feat(cli): match policy component slots by schema-type identity (194/2)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -4,8 +4,18 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from typing import Literal
 
+from nextlabs_sdk._cli._diff._identity import (
+    COMPONENT_SLOT_FIELDS,
+    ComponentSummary,
+    flatten_slot,
+)
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+
+_KIND_ADD: Literal["add"] = "add"
+_KIND_REMOVE: Literal["remove"] = "remove"
+_KIND_CHANGE: Literal["change"] = "change"
 
 _NOISE_FIELDS: frozenset[str] = frozenset(
     (
@@ -68,18 +78,56 @@ def _diff_dicts(
     all_keys = old.keys() | new.keys()
     for key in all_keys:
         child_path = path + (key,)
+        if not show_all and key in COMPONENT_SLOT_FIELDS:
+            _diff_component_slot(
+                old.get(key), new.get(key), path=child_path, changes=changes
+            )
+            continue
         if key not in old:
             changes.append(
-                FieldChange(path=child_path, kind="add", old=None, new=new[key])
+                FieldChange(path=child_path, kind=_KIND_ADD, old=None, new=new[key])
             )
         elif key not in new:
             changes.append(
-                FieldChange(path=child_path, kind="remove", old=old[key], new=None)
+                FieldChange(path=child_path, kind=_KIND_REMOVE, old=old[key], new=None)
             )
         else:
             _diff_values(
                 old[key], new[key], path=child_path, show_all=show_all, changes=changes
             )
+
+
+def _diff_component_slot(
+    old_value: object,
+    new_value: object,
+    *,
+    path: tuple[str, ...],
+    changes: list[FieldChange],
+) -> None:
+    old_components = flatten_slot(old_value)
+    new_components = flatten_slot(new_value)
+    for key in old_components.keys() | new_components.keys():
+        change = _classify_component(
+            path, old_components.get(key), new_components.get(key)
+        )
+        if change is not None:
+            changes.append(change)
+
+
+def _classify_component(
+    path: tuple[str, ...],
+    old_summary: ComponentSummary | None,
+    new_summary: ComponentSummary | None,
+) -> FieldChange | None:
+    if old_summary is not None and new_summary is not None:
+        if old_summary == new_summary:
+            return None
+        return FieldChange(
+            path=path, kind=_KIND_CHANGE, old=old_summary, new=new_summary
+        )
+    if new_summary is not None:
+        return FieldChange(path=path, kind=_KIND_ADD, old=None, new=new_summary)
+    return FieldChange(path=path, kind=_KIND_REMOVE, old=old_summary, new=None)
 
 
 def _diff_values(
@@ -95,7 +143,7 @@ def _diff_values(
     elif isinstance(old, list) and isinstance(new, list):
         _diff_lists(old, new, path=path, show_all=show_all, changes=changes)
     elif old != new:
-        changes.append(FieldChange(path=path, kind="change", old=old, new=new))
+        changes.append(FieldChange(path=path, kind=_KIND_CHANGE, old=old, new=new))
 
 
 def _canonical(elem: object) -> str:
@@ -112,10 +160,10 @@ def _diff_lists(
 ) -> None:
     if show_all:
         if old != new:
-            changes.append(FieldChange(path=path, kind="change", old=old, new=new))
+            changes.append(FieldChange(path=path, kind=_KIND_CHANGE, old=old, new=new))
         return
 
     old_set = {_canonical(elem) for elem in old}
     new_set = {_canonical(elem) for elem in new}
     if old_set != new_set:
-        changes.append(FieldChange(path=path, kind="change", old=old, new=new))
+        changes.append(FieldChange(path=path, kind=_KIND_CHANGE, old=old, new=new))

--- a/src/nextlabs_sdk/_cli/_diff/_identity.py
+++ b/src/nextlabs_sdk/_cli/_diff/_identity.py
@@ -1,0 +1,117 @@
+"""Type-driven identity registry for matching policy structure arrays.
+
+Identity is keyed by *schema type* rather than by field name, so every
+field that shares a shape is matched through one code path. The five
+policy component slots (``subjectComponents``, ``toSubjectComponents``,
+``fromResourceComponents``, ``toResourceComponents``, ``actionComponents``)
+all carry ``ComponentDTORes`` elements and are therefore flattened and
+matched identically.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+COMPONENT_SLOT_FIELDS: frozenset[str] = frozenset(
+    (
+        "subjectComponents",
+        "toSubjectComponents",
+        "fromResourceComponents",
+        "toResourceComponents",
+        "actionComponents",
+    )
+)
+
+
+@dataclass(frozen=True)
+class ComponentSummary:
+    """A referenced component reduced to its identity and version."""
+
+    component_id: int | None
+    name: str | None
+    version: int | None
+
+
+def _component_dto_key(element: Mapping[str, object]) -> Hashable | None:
+    component_id = element.get("id")
+    if component_id is not None:
+        return ("id", component_id)
+    name = element.get("name")
+    if name is not None:
+        return ("name", name)
+    return None
+
+
+_KEY_RESOLVERS = MappingProxyType(
+    {
+        "ComponentDTORes": _component_dto_key,
+    }
+)
+
+
+def identity_key(schema_type: str, element: Mapping[str, object]) -> Hashable | None:
+    """Resolve the stable identity key of *element* for *schema_type*.
+
+    Args:
+        schema_type: The schema type whose identity rule should be applied.
+        element: The alias-keyed element dict to key.
+
+    Returns:
+        A hashable identity key, or None when no key can be derived or the
+        schema type has no registered resolver.
+    """
+    resolver = _KEY_RESOLVERS.get(schema_type)
+    if resolver is None:
+        return None
+    return resolver(element)
+
+
+def _collect_component(
+    component: Mapping[str, object],
+    collected: dict[Hashable, ComponentSummary],
+) -> None:
+    key = identity_key("ComponentDTORes", component)
+    if key is not None and key not in collected:
+        collected[key] = ComponentSummary(
+            component_id=_as_int(component.get("id")),
+            name=_as_str(component.get("name")),
+            version=_as_int(component.get("version")),
+        )
+    for sub in _as_mappings(component.get("subComponents")):
+        _collect_component(sub, collected)
+
+
+def flatten_slot(slot_value: object) -> dict[Hashable, ComponentSummary]:
+    """Flatten a component slot to the set of referenced components by identity.
+
+    Each slot holds component groups; every group's components, and every
+    component reachable through nested ``subComponents``, is collected and
+    keyed by its stable identity (id, falling back to name).
+
+    Args:
+        slot_value: The alias-keyed slot value (a list of component groups).
+
+    Returns:
+        A mapping from identity key to the referenced component's summary.
+    """
+    collected: dict[Hashable, ComponentSummary] = {}
+    for group in _as_mappings(slot_value):
+        for component in _as_mappings(group.get("components")):
+            _collect_component(component, collected)
+    return collected
+
+
+def _as_mappings(value: object) -> list[Mapping[str, object]]:  # noqa: WPS110
+    if not isinstance(value, list):
+        return []
+    return [element for element in value if isinstance(element, Mapping)]
+
+
+def _as_int(value: object) -> int | None:  # noqa: WPS110
+    return value if isinstance(value, int) else None
+
+
+def _as_str(value: object) -> str | None:  # noqa: WPS110
+    return value if isinstance(value, str) else None

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -4,12 +4,61 @@ from __future__ import annotations
 
 from rich.console import Console
 
+from nextlabs_sdk._cli._diff._identity import ComponentSummary
 from nextlabs_sdk._cli._diff._inline import highlight_inline
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
 _GLYPH_ADD = "[green]+[/green]"
 _GLYPH_REMOVE = "[red]-[/red]"
 _GLYPH_CHANGE = "[yellow]~[/yellow]"
+
+
+def _format_component(summary: ComponentSummary | None) -> str:
+    """Render a component summary as ``name (id=N)`` for display."""
+    if summary is None:
+        return "?"
+    label = summary.name or "?"
+    if summary.component_id is None:
+        return label
+    return f"{label} (id={summary.component_id})"
+
+
+def _version_of(summary: ComponentSummary | None) -> int | None:
+    if summary is None:
+        return None
+    return summary.version
+
+
+def _format_version_bump(
+    previous: ComponentSummary | None, summary: ComponentSummary | None
+) -> str:
+    return f"v{_version_of(previous)} \u2192 v{_version_of(summary)}"
+
+
+def _render_component_change(con: Console, field: str, change: FieldChange) -> None:
+    """Print a component-slot change identified by name and id."""
+    summary = change.new if isinstance(change.new, ComponentSummary) else None
+    previous = change.old if isinstance(change.old, ComponentSummary) else None
+    if change.kind == "add":
+        con.print(f"  {_GLYPH_ADD} {field}: {_format_component(summary)}")
+    elif change.kind == "remove":
+        con.print(f"  {_GLYPH_REMOVE} {field}: {_format_component(previous)}")
+    else:
+        bump = _format_version_bump(previous, summary)
+        con.print(f"  {_GLYPH_CHANGE} {field}: {_format_component(summary)} {bump}")
+
+
+def _render_scalar_change(con: Console, field: str, change: FieldChange) -> None:
+    """Print a non-component FieldChange row to *con*."""
+    if change.kind == "add":
+        con.print(f"  {_GLYPH_ADD} {field}: {change.new}")
+    elif change.kind == "remove":
+        con.print(f"  {_GLYPH_REMOVE} {field}: {change.old}")
+    elif isinstance(change.old, str) and isinstance(change.new, str):
+        highlighted = highlight_inline(change.old, change.new)
+        con.print(f"  {_GLYPH_CHANGE} {field}: {highlighted}")
+    else:
+        con.print(f"  {_GLYPH_CHANGE} {field}: {change.old!r} \u2192 {change.new!r}")
 
 
 def _render_change(con: Console, field: str, change: FieldChange) -> None:
@@ -20,15 +69,12 @@ def _render_change(con: Console, field: str, change: FieldChange) -> None:
         field: Dot-joined path string for display.
         change: The field change to render.
     """
-    if change.kind == "add":
-        con.print(f"  {_GLYPH_ADD} {field}: {change.new}")
-    elif change.kind == "remove":
-        con.print(f"  {_GLYPH_REMOVE} {field}: {change.old}")
-    elif isinstance(change.old, str) and isinstance(change.new, str):
-        highlighted = highlight_inline(change.old, change.new)
-        con.print(f"  {_GLYPH_CHANGE} {field}: {highlighted}")
+    if isinstance(change.old, ComponentSummary) or isinstance(
+        change.new, ComponentSummary
+    ):
+        _render_component_change(con, field, change)
     else:
-        con.print(f"  {_GLYPH_CHANGE} {field}: {change.old!r} \u2192 {change.new!r}")
+        _render_scalar_change(con, field, change)
 
 
 def render_semantic(diff: DiffResult, *, console: Console | None = None) -> None:

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -60,6 +60,69 @@ def _revision(
     )
 
 
+def _component(component_id: int, name: str, version: int = 1) -> dict[str, Any]:
+    return {"id": component_id, "name": name, "version": version, "subComponents": []}
+
+
+def _revision_with_subjects(
+    revision: int, components: list[dict[str, Any]]
+) -> PolicyRevision:
+    policy = Policy.model_validate(
+        {
+            "id": 82,
+            "name": "P",
+            "status": "DRAFT",
+            "effectType": "ALLOW",
+            "subjectComponents": [{"operator": "AND", "components": components}],
+        }
+    )
+    return PolicyRevision(
+        id=10, revision=revision, action_type="DE", policy_detail=policy
+    )
+
+
+def test_edited_component_renders_single_modified_entry(stub: tuple[Any, Any]) -> None:
+    """Given two revisions where a subject component's version is bumped, when
+    running diff, then it shows a single modified entry by name and id, not a
+    remove-plus-add."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subjects(2, [_component(5, "Engineers", version=1)])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subjects(3, [_component(5, "Engineers", version=2)])
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Engineers (id=5)" in output
+    assert "v1" in output and "v2" in output
+    assert "- subjectComponents" not in output
+    assert "+ subjectComponents" not in output
+
+
+def test_added_and_removed_components_render_by_name_and_id(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions where a subject component is replaced, when running
+    diff, then both the added and removed components are shown by name and
+    id."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subjects(2, [_component(5, "Engineers")])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subjects(3, [_component(6, "Operations")])
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Engineers (id=5)" in output
+    assert "Operations (id=6)" in output
+
+
 def test_diff_default_renders_semantic_report(stub: tuple[Any, Any]) -> None:
     """Given two deployed revisions differing in description, when running diff
     with no flags, then it succeeds and shows the changed scalar."""

--- a/tests/test_policy_diff_identity.py
+++ b/tests/test_policy_diff_identity.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nextlabs_sdk._cli._diff._engine import diff_payloads
+from nextlabs_sdk._cli._diff._identity import (
+    COMPONENT_SLOT_FIELDS,
+    ComponentSummary,
+    flatten_slot,
+    identity_key,
+)
+
+
+def _comp(
+    component_id: int | None,
+    name: str,
+    version: int = 1,
+    subs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": component_id,
+        "name": name,
+        "version": version,
+        "subComponents": subs or [],
+    }
+
+
+def _slot(*components: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{"operator": "AND", "components": list(components)}]
+
+
+def _slot_changes(result: Any, field: str) -> list[Any]:
+    return [
+        change for change in result.changes if change.path and change.path[0] == field
+    ]
+
+
+def test_identity_key_uses_id_when_present():
+    """Given a component dict carrying an id.
+
+    When resolving its identity key for the ComponentDTORes schema type.
+    Then the key is derived from the id.
+    """
+    key = identity_key("ComponentDTORes", {"id": 5, "name": "Engineers"})
+
+    assert key == identity_key("ComponentDTORes", {"id": 5, "name": "Renamed"})
+
+
+def test_identity_key_falls_back_to_name_when_id_absent():
+    """Given a component dict with no id but a name.
+
+    When resolving its identity key.
+    Then the key is derived from the name.
+    """
+    key = identity_key("ComponentDTORes", {"id": None, "name": "Engineers"})
+
+    assert key is not None
+    assert key == identity_key("ComponentDTORes", {"name": "Engineers"})
+    assert key != identity_key("ComponentDTORes", {"name": "Other"})
+
+
+def test_flatten_slot_recurses_subcomponents_by_id():
+    """Given a slot whose component nests another component via subComponents.
+
+    When flattening the slot.
+    Then both the parent and the nested component are collected by id.
+    """
+    slot = _slot(_comp(5, "Group", subs=[_comp(9, "Leaf", version=2)]))
+
+    flat = flatten_slot(slot)
+
+    assert flat[identity_key("ComponentDTORes", _comp(5, "Group"))] == ComponentSummary(
+        component_id=5, name="Group", version=1
+    )
+    assert flat[identity_key("ComponentDTORes", _comp(9, "Leaf"))] == ComponentSummary(
+        component_id=9, name="Leaf", version=2
+    )
+
+
+def test_edited_component_shows_single_change_not_remove_add():
+    """Given a slot whose only component has its version bumped.
+
+    When diffing the two payloads.
+    Then a single change entry is produced and no add/remove pair.
+    """
+    old = {"subjectComponents": _slot(_comp(5, "Engineers", version=1))}
+    new = {"subjectComponents": _slot(_comp(5, "Engineers", version=2))}
+
+    changes = _slot_changes(diff_payloads(old, new), "subjectComponents")
+
+    assert [change.kind for change in changes] == ["change"]
+    assert changes[0].old == ComponentSummary(
+        component_id=5, name="Engineers", version=1
+    )
+    assert changes[0].new == ComponentSummary(
+        component_id=5, name="Engineers", version=2
+    )
+
+
+def test_added_and_removed_components_reported_by_id_and_name():
+    """Given a slot where one component is replaced by another.
+
+    When diffing the two payloads.
+    Then one add and one remove are produced, each carrying id and name.
+    """
+    old = {"subjectComponents": _slot(_comp(5, "Engineers"))}
+    new = {"subjectComponents": _slot(_comp(6, "Operations"))}
+
+    changes = _slot_changes(diff_payloads(old, new), "subjectComponents")
+    kinds = sorted(change.kind for change in changes)
+
+    assert kinds == ["add", "remove"]
+    added = next(change for change in changes if change.kind == "add")
+    removed = next(change for change in changes if change.kind == "remove")
+    assert added.new == ComponentSummary(component_id=6, name="Operations", version=1)
+    assert removed.old == ComponentSummary(component_id=5, name="Engineers", version=1)
+
+
+def test_nested_subcomponent_matched_by_id_at_depth():
+    """Given an edit to a component nested via subComponents.
+
+    When diffing the two payloads.
+    Then the nested component yields a single change matched by its id.
+    """
+    old = {"subjectComponents": _slot(_comp(5, "Group", subs=[_comp(9, "Leaf", 1)]))}
+    new = {"subjectComponents": _slot(_comp(5, "Group", subs=[_comp(9, "Leaf", 2)]))}
+
+    changes = _slot_changes(diff_payloads(old, new), "subjectComponents")
+
+    assert [change.kind for change in changes] == ["change"]
+    assert changes[0].old == ComponentSummary(component_id=9, name="Leaf", version=1)
+    assert changes[0].new == ComponentSummary(component_id=9, name="Leaf", version=2)
+
+
+def test_reordered_components_yield_no_change():
+    """Given two slots holding the same components in different order.
+
+    When diffing the two payloads.
+    Then no changes are reported.
+    """
+    old = {"subjectComponents": _slot(_comp(5, "A"), _comp(6, "B"))}
+    new = {"subjectComponents": _slot(_comp(6, "B"), _comp(5, "A"))}
+
+    changes = _slot_changes(diff_payloads(old, new), "subjectComponents")
+
+    assert changes == []
+
+
+@pytest.mark.parametrize("field", sorted(COMPONENT_SLOT_FIELDS))
+def test_all_five_component_slots_share_one_code_path(field: str):
+    """Given an edited component in any of the five component slots.
+
+    When diffing the two payloads.
+    Then each slot yields the same single-change identity behaviour.
+    """
+    old = {field: _slot(_comp(5, "Engineers", version=1))}
+    new = {field: _slot(_comp(5, "Engineers", version=2))}
+
+    changes = _slot_changes(diff_payloads(old, new), field)
+
+    assert [change.kind for change in changes] == ["change"]
+
+
+def test_component_slots_field_set_covers_all_five():
+    """Given the component slot field registry.
+
+    When inspecting it.
+    Then it contains exactly the five policy component slot aliases.
+    """
+    assert COMPONENT_SLOT_FIELDS == frozenset(
+        (
+            "subjectComponents",
+            "toSubjectComponents",
+            "fromResourceComponents",
+            "toResourceComponents",
+            "actionComponents",
+        )
+    )


### PR DESCRIPTION
Closes #196

## Summary
- Add a schema-type identity registry (`_diff/_identity.py`) and use it to match the five policy component slots by stable identity (id, falling back to name), recursing through `subComponents` at any depth, replacing the slice-194/1 set-comparison fallback for these slots.
- Tested with new engine/registry unit tests and extended CLI rendering tests; full suite green (2348 passed, 95.92% coverage).
- Trade-off: a component "edit" is recognised via its version bump, which the PRD designates as the visible content-change signal.

## Tests added (red → green)
- `tests/test_policy_diff_identity.py::test_edited_component_shows_single_change_not_remove_add`
- `tests/test_policy_diff_identity.py::test_added_and_removed_components_reported_by_id_and_name`
- `tests/test_policy_diff_identity.py::test_nested_subcomponent_matched_by_id_at_depth`
- `tests/test_policy_diff_identity.py::test_all_five_component_slots_share_one_code_path`
- `tests/test_cli_policy_diff.py::test_edited_component_renders_single_modified_entry`
- `tests/test_cli_policy_diff.py::test_added_and_removed_components_render_by_name_and_id`

## Notable assumptions
- Identity-based flattening (`flatten_slot`, `ComponentSummary`) lives in the `_identity` registry module; the engine consumes it to stay thin.
- Each slot value is a list of component groups (`{operator, components}`); flattening unwraps the group and recurses `subComponents`.
- A component edit is detected via its version bump, per the PRD (component `version` stays visible and signals a real content change).
