### PR TITLE
feat(cli): compare allow and deny obligations in policy diff

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -8,8 +8,11 @@ from typing import Literal
 
 from nextlabs_sdk._cli._diff._identity import (
     COMPONENT_SLOT_FIELDS,
+    OBLIGATION_FIELDS,
     ComponentSummary,
+    ObligationSummary,
     flatten_slot,
+    pair_obligations,
 )
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
@@ -78,10 +81,9 @@ def _diff_dicts(
     all_keys = old.keys() | new.keys()
     for key in all_keys:
         child_path = path + (key,)
-        if not show_all and key in COMPONENT_SLOT_FIELDS:
-            _diff_component_slot(
-                old.get(key), new.get(key), path=child_path, changes=changes
-            )
+        if not show_all and _diff_special_field(
+            key, old, new, path=child_path, changes=changes
+        ):
             continue
         if key not in old:
             changes.append(
@@ -95,6 +97,30 @@ def _diff_dicts(
             _diff_values(
                 old[key], new[key], path=child_path, show_all=show_all, changes=changes
             )
+
+
+def _diff_special_field(
+    key: str,
+    old: Mapping[str, object],
+    new: Mapping[str, object],
+    *,
+    path: tuple[str, ...],
+    changes: list[FieldChange],
+) -> bool:
+    """Dispatch identity-aware diffing for component-slot and obligation keys.
+
+    Returns:
+        True when *key* was handled by a specialised differ, otherwise False.
+    """
+    old_value = old.get(key)
+    new_value = new.get(key)
+    if key in COMPONENT_SLOT_FIELDS:
+        _diff_component_slot(old_value, new_value, path=path, changes=changes)
+        return True
+    if key in OBLIGATION_FIELDS:
+        _diff_obligation_field(old_value, new_value, path=path, changes=changes)
+        return True
+    return False
 
 
 def _diff_component_slot(
@@ -128,6 +154,50 @@ def _classify_component(
     if new_summary is not None:
         return FieldChange(path=path, kind=_KIND_ADD, old=None, new=new_summary)
     return FieldChange(path=path, kind=_KIND_REMOVE, old=old_summary, new=None)
+
+
+def _diff_obligation_field(
+    old_value: object,
+    new_value: object,
+    *,
+    path: tuple[str, ...],
+    changes: list[FieldChange],
+) -> None:
+    for old_obl, new_obl in pair_obligations(old_value, new_value):
+        label = _obligation_label(new_obl if old_obl is None else old_obl)
+        if old_obl is not None and new_obl is not None:
+            _diff_dicts(
+                old_obl,
+                new_obl,
+                path=path + (label,),
+                show_all=False,
+                changes=changes,
+            )
+        elif new_obl is None:
+            changes.append(
+                FieldChange(
+                    path=path,
+                    kind=_KIND_REMOVE,
+                    old=ObligationSummary(name=label),
+                    new=None,
+                )
+            )
+        else:
+            changes.append(
+                FieldChange(
+                    path=path,
+                    kind=_KIND_ADD,
+                    old=None,
+                    new=ObligationSummary(name=label),
+                )
+            )
+
+
+def _obligation_label(obligation: Mapping[str, object] | None) -> str:
+    if obligation is None:
+        return "?"
+    name = obligation.get("name")
+    return name if isinstance(name, str) else "?"
 
 
 def _diff_values(

--- a/src/nextlabs_sdk/_cli/_diff/_identity.py
+++ b/src/nextlabs_sdk/_cli/_diff/_identity.py
@@ -13,6 +13,13 @@ from __future__ import annotations
 from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import TypeAlias
+
+_Element: TypeAlias = Mapping[str, object]
+_ObligationPair: TypeAlias = "tuple[_Element | None, _Element | None]"
+_ObligationGroups: TypeAlias = "dict[Hashable, list[_Element]]"
+
+_NAME_FIELD = "name"
 
 COMPONENT_SLOT_FIELDS: frozenset[str] = frozenset(
     (
@@ -23,6 +30,15 @@ COMPONENT_SLOT_FIELDS: frozenset[str] = frozenset(
         "actionComponents",
     )
 )
+
+OBLIGATION_FIELDS: frozenset[str] = frozenset(("allowObligations", "denyObligations"))
+
+
+@dataclass(frozen=True)
+class ObligationSummary:
+    """An obligation reduced to the name used to identify it for display."""
+
+    name: str | None
 
 
 @dataclass(frozen=True)
@@ -38,9 +54,9 @@ def _component_dto_key(element: Mapping[str, object]) -> Hashable | None:
     component_id = element.get("id")
     if component_id is not None:
         return ("id", component_id)
-    name = element.get("name")
+    name = element.get(_NAME_FIELD)
     if name is not None:
-        return ("name", name)
+        return (_NAME_FIELD, name)
     return None
 
 
@@ -101,6 +117,56 @@ def flatten_slot(slot_value: object) -> dict[Hashable, ComponentSummary]:
         for component in _as_mappings(group.get("components")):
             _collect_component(component, collected)
     return collected
+
+
+def _obligation_group_key(element: Mapping[str, object]) -> Hashable:
+    return (element.get(_NAME_FIELD), element.get("policyModelId"))
+
+
+def pair_obligations(old_value: object, new_value: object) -> list[_ObligationPair]:
+    """Pair old and new obligations for comparison.
+
+    Obligations carry a null ``id`` and a non-unique ``name``, so they are
+    grouped by ``(name, policyModelId)`` and, within each colliding group,
+    paired positionally. Surplus obligations on either side are paired
+    against ``None`` so they surface as additions or removals.
+
+    Args:
+        old_value: The alias-keyed baseline obligation list.
+        new_value: The alias-keyed revised obligation list.
+
+    Returns:
+        A list of ``(old, new)`` pairs; either side is ``None`` when the
+        colliding group has no positional counterpart.
+    """
+    old_groups = _group_obligations(old_value)
+    new_groups = _group_obligations(new_value)
+    pairs: list[_ObligationPair] = []
+    for key in _ordered_keys(old_groups, new_groups):
+        olds = old_groups.get(key, [])
+        news = new_groups.get(key, [])
+        for index in range(max(len(olds), len(news))):
+            old_obl = olds[index] if index < len(olds) else None
+            new_obl = news[index] if index < len(news) else None
+            pairs.append((old_obl, new_obl))
+    return pairs
+
+
+def _group_obligations(value: object) -> _ObligationGroups:  # noqa: WPS110
+    grouped: _ObligationGroups = {}
+    for element in _as_mappings(value):
+        grouped.setdefault(_obligation_group_key(element), []).append(element)
+    return grouped
+
+
+def _ordered_keys(
+    old_groups: _ObligationGroups, new_groups: _ObligationGroups
+) -> list[Hashable]:
+    ordered = list(old_groups)
+    for key in new_groups:
+        if key not in old_groups:
+            ordered.append(key)
+    return ordered
 
 
 def _as_mappings(value: object) -> list[Mapping[str, object]]:  # noqa: WPS110

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from nextlabs_sdk._cli._diff._identity import ComponentSummary
+from nextlabs_sdk._cli._diff._identity import ComponentSummary, ObligationSummary
 from nextlabs_sdk._cli._diff._inline import highlight_inline
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
@@ -61,6 +61,16 @@ def _render_scalar_change(con: Console, field: str, change: FieldChange) -> None
         con.print(f"  {_GLYPH_CHANGE} {field}: {change.old!r} \u2192 {change.new!r}")
 
 
+def _render_obligation_change(con: Console, field: str, change: FieldChange) -> None:
+    """Print an added or removed obligation identified by name."""
+    summary = change.new if isinstance(change.new, ObligationSummary) else change.old
+    label = summary.name if isinstance(summary, ObligationSummary) else "?"
+    if change.kind == "add":
+        con.print(f"  {_GLYPH_ADD} {field}: {label}")
+    else:
+        con.print(f"  {_GLYPH_REMOVE} {field}: {label}")
+
+
 def _render_change(con: Console, field: str, change: FieldChange) -> None:
     """Print a single FieldChange row to *con*.
 
@@ -69,7 +79,11 @@ def _render_change(con: Console, field: str, change: FieldChange) -> None:
         field: Dot-joined path string for display.
         change: The field change to render.
     """
-    if isinstance(change.old, ComponentSummary) or isinstance(
+    if isinstance(change.old, ObligationSummary) or isinstance(
+        change.new, ObligationSummary
+    ):
+        _render_obligation_change(con, field, change)
+    elif isinstance(change.old, ComponentSummary) or isinstance(
         change.new, ComponentSummary
     ):
         _render_component_change(con, field, change)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -186,3 +186,57 @@ def test_diff_too_few_revisions_exits_nonzero_without_traceback(
     output = strip_ansi(result.output)
     assert "Traceback" not in output
     assert "fewer than two" in output.lower()
+
+
+def _obligation(name: str, params: dict[str, str]) -> dict[str, Any]:
+    return {"id": None, "policyModelId": 0, "name": name, "params": params}
+
+
+def _revision_with_obligations(
+    revision: int, obligations: list[dict[str, Any]]
+) -> PolicyRevision:
+    policy = Policy.model_validate(
+        {
+            "id": 82,
+            "name": "P",
+            "status": "DRAFT",
+            "effectType": "ALLOW",
+            "allowObligations": obligations,
+        }
+    )
+    return PolicyRevision(
+        id=10, revision=revision, action_type="DE", policy_detail=policy
+    )
+
+
+def test_both_shared_name_obligations_report_changed_params(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions with two same-name obligations whose params each
+    change, when running diff, then both changed param values are shown so
+    neither obligation is silently dropped."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_obligations(
+            2,
+            [
+                _obligation("data_masking", {"col": "ssn"}),
+                _obligation("data_masking", {"col": "dob"}),
+            ],
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_obligations(
+            3,
+            [
+                _obligation("data_masking", {"col": "ssn_hash"}),
+                _obligation("data_masking", {"col": "dob_hash"}),
+            ],
+        )
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "ssn_hash" in output
+    assert "dob_hash" in output

--- a/tests/test_policy_diff_identity.py
+++ b/tests/test_policy_diff_identity.py
@@ -7,9 +7,12 @@ import pytest
 from nextlabs_sdk._cli._diff._engine import diff_payloads
 from nextlabs_sdk._cli._diff._identity import (
     COMPONENT_SLOT_FIELDS,
+    OBLIGATION_FIELDS,
     ComponentSummary,
+    ObligationSummary,
     flatten_slot,
     identity_key,
+    pair_obligations,
 )
 
 
@@ -178,3 +181,139 @@ def test_component_slots_field_set_covers_all_five():
             "actionComponents",
         )
     )
+
+
+def _obl(
+    name: str,
+    params: dict[str, str],
+    policy_model_id: int = 0,
+    obligation_id: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": obligation_id,
+        "policyModelId": policy_model_id,
+        "name": name,
+        "params": params,
+    }
+
+
+def _obligation_changes(result: Any, field: str) -> list[Any]:
+    return [
+        change for change in result.changes if change.path and change.path[0] == field
+    ]
+
+
+def test_obligation_fields_cover_allow_and_deny():
+    """Given the obligation field registry.
+
+    When inspecting it.
+    Then it contains exactly the allow and deny obligation aliases.
+    """
+    assert OBLIGATION_FIELDS == frozenset(("allowObligations", "denyObligations"))
+
+
+def test_obligations_sharing_a_name_are_paired_positionally():
+    """Given two obligations with the same (name, policyModelId).
+
+    When pairing the old and new obligation lists.
+    Then they are matched positionally within the colliding group.
+    """
+    old = [_obl("data_masking", {"col": "ssn"}), _obl("data_masking", {"col": "dob"})]
+    new = [_obl("data_masking", {"col": "ssn2"}), _obl("data_masking", {"col": "dob2"})]
+
+    pairs = pair_obligations(old, new)
+
+    assert len(pairs) == 2
+    old_cols: list[object] = []
+    new_cols: list[object] = []
+    for old_obl, new_obl in pairs:
+        assert old_obl is not None and new_obl is not None
+        old_params = old_obl["params"]
+        new_params = new_obl["params"]
+        assert isinstance(old_params, dict) and isinstance(new_params, dict)
+        old_cols.append(old_params["col"])
+        new_cols.append(new_params["col"])
+    assert old_cols == ["ssn", "dob"]
+    assert new_cols == ["ssn2", "dob2"]
+
+
+def test_both_shared_name_obligations_have_their_param_changes_reported():
+    """Given two same-name obligations each with a changed param.
+
+    When diffing the two payloads.
+    Then both param changes are reported and none is dropped.
+    """
+    old = {
+        "allowObligations": [
+            _obl("data_masking", {"col": "ssn"}),
+            _obl("data_masking", {"col": "dob"}),
+        ]
+    }
+    new = {
+        "allowObligations": [
+            _obl("data_masking", {"col": "ssn_hash"}),
+            _obl("data_masking", {"col": "dob_hash"}),
+        ]
+    }
+
+    changes = _obligation_changes(diff_payloads(old, new), "allowObligations")
+    kinds = [change.kind for change in changes]
+
+    assert kinds == ["change", "change"]
+    assert sorted(change.new for change in changes) == ["dob_hash", "ssn_hash"]
+
+
+def test_changed_obligation_param_is_reported_as_a_scalar_string_change():
+    """Given an obligation whose param value changes.
+
+    When diffing the two payloads.
+    Then a scalar string change is produced for the changed param.
+    """
+    old = {"allowObligations": [_obl("redact", {"fields": "name email"})]}
+    new = {"allowObligations": [_obl("redact", {"fields": "name phone"})]}
+
+    changes = _obligation_changes(diff_payloads(old, new), "allowObligations")
+
+    assert [change.kind for change in changes] == ["change"]
+    assert changes[0].old == "name email"
+    assert changes[0].new == "name phone"
+    assert changes[0].path[-1] == "fields"
+
+
+def test_added_and_removed_obligations_are_reported():
+    """Given one obligation replaced by a differently-named obligation.
+
+    When diffing the two payloads.
+    Then one add and one remove are produced, each carrying the name.
+    """
+    old = {"denyObligations": [_obl("log", {"level": "info"})]}
+    new = {"denyObligations": [_obl("alert", {"channel": "ops"})]}
+
+    changes = _obligation_changes(diff_payloads(old, new), "denyObligations")
+    kinds = sorted(change.kind for change in changes)
+
+    assert kinds == ["add", "remove"]
+    added = next(change for change in changes if change.kind == "add")
+    removed = next(change for change in changes if change.kind == "remove")
+    assert added.new == ObligationSummary(name="alert")
+    assert removed.old == ObligationSummary(name="log")
+
+
+def test_extra_obligation_in_colliding_group_is_reported_as_added():
+    """Given a colliding-name group that gains an extra obligation.
+
+    When diffing the two payloads.
+    Then the unpaired obligation is reported as added, not a change.
+    """
+    old = {"allowObligations": [_obl("data_masking", {"col": "a"})]}
+    new = {
+        "allowObligations": [
+            _obl("data_masking", {"col": "a"}),
+            _obl("data_masking", {"col": "b"}),
+        ]
+    }
+
+    changes = _obligation_changes(diff_payloads(old, new), "allowObligations")
+
+    assert [change.kind for change in changes] == ["add"]
+    assert changes[0].new == ObligationSummary(name="data_masking")


### PR DESCRIPTION
Closes #197

## Summary
- Add identity-aware obligation comparison for `allowObligations` and `denyObligations`: obligations are grouped by `(name, policyModelId)` and paired positionally within each colliding group, so every obligation is compared and none is silently dropped (including multiple `data_masking` obligations).
- Matched pairs diff their `params`; a changed param value renders in-place with the existing inline word-level highlighter, and unpaired obligations render as added/removed via a new `ObligationSummary`.
- Tested with new unit tests on the diff engine/identity pairing plus a CLI test asserting both same-name obligations report their changed params; full `policies diff` suite (44 tests) and `checks.py` (black/flake8/mypy/pyright) pass.

## Tests added (red → green)
- `test_obligation_fields_cover_allow_and_deny`
- `test_obligations_sharing_a_name_are_paired_positionally`
- `test_both_shared_name_obligations_have_their_param_changes_reported`
- `test_changed_obligation_param_is_reported_as_a_scalar_string_change`
- `test_added_and_removed_obligations_are_reported`
- `test_extra_obligation_in_colliding_group_is_reported_as_added`
- `test_both_shared_name_obligations_report_changed_params`

## Notable assumptions
- Added/removed obligations are displayed by `name` only (no params dump); matched-pair param edits flow through the existing scalar/inline render path, with the obligation `name` used as the display path segment.
