### PR TITLE
feat(cli): add --format option with unified diff for policies diff

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -33,6 +33,51 @@ _NOISE_FIELDS: frozenset[str] = frozenset(
 )
 
 
+def canonicalise(payload: Mapping[str, object], *, show_all: bool = False) -> object:
+    """Reduce a policy payload to a stable, comparison-ready form.
+
+    Arrays are sorted by their canonical content so element re-ordering is
+    erased, and deployment-noise fields are dropped. Dict keys are left for
+    the caller to sort at serialisation time. With show_all the noise filter
+    and array sort are disabled so every raw difference survives.
+
+    Args:
+        payload: The alias-keyed policy payload to canonicalise.
+        show_all: When True, keep noise fields and original array order.
+
+    Returns:
+        A JSON-serialisable structure with noise stripped and arrays sorted
+        (unless show_all is set).
+    """
+    return _canonicalise_value(payload, show_all=show_all)
+
+
+def _canonicalise_value(value: object, *, show_all: bool) -> object:  # noqa: WPS110
+    if isinstance(value, Mapping):
+        return _canonicalise_mapping(value, show_all=show_all)
+    if isinstance(value, list):
+        return _canonicalise_list(value, show_all=show_all)
+    return value
+
+
+def _canonicalise_mapping(
+    mapping: Mapping[str, object], *, show_all: bool
+) -> dict[str, object]:
+    kept: dict[str, object] = {}
+    for key, child in mapping.items():
+        if not show_all and key in _NOISE_FIELDS:
+            continue
+        kept[key] = _canonicalise_value(child, show_all=show_all)
+    return kept
+
+
+def _canonicalise_list(elements: list[object], *, show_all: bool) -> list[object]:
+    canonical = [_canonicalise_value(elem, show_all=show_all) for elem in elements]
+    if show_all:
+        return canonical
+    return sorted(canonical, key=_canonical)
+
+
 def diff_payloads(
     old: Mapping[str, object],
     new: Mapping[str, object],

--- a/src/nextlabs_sdk/_cli/_diff/_format.py
+++ b/src/nextlabs_sdk/_cli/_diff/_format.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class DiffFormat(str, Enum):
+    """Human renderer selected by ``policies diff --format``.
+
+    - SEMANTIC: the default sectioned, identity-aware report.
+    - UNIFIED:  a canonicalised git-style unified diff.
+    """
+
+    SEMANTIC = "semantic"
+    UNIFIED = "unified"

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -1,0 +1,65 @@
+"""Unified git-style renderer for policy diff results."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from difflib import unified_diff
+
+from rich.console import Console
+from rich.markup import escape
+
+from nextlabs_sdk._cli._diff._engine import canonicalise
+
+
+def render_unified(
+    old: Mapping[str, object],
+    new: Mapping[str, object],
+    *,
+    labels: tuple[str, str],
+    show_all: bool = False,
+    console: Console | None = None,
+) -> None:
+    """Render two revisions as a canonicalised git-style unified diff.
+
+    Both revisions are canonicalised first (keys sorted on serialisation,
+    arrays sorted by identity, noise stripped), so element re-ordering and
+    deployment noise produce no diff lines.
+
+    Args:
+        old: The baseline alias-keyed policy payload.
+        new: The revised alias-keyed policy payload.
+        labels: The ``(from, to)`` labels for the diff header.
+        show_all: When True, reveal ordering and noise differences.
+        console: Rich Console to print to; defaults to a new Console().
+    """
+    con = Console() if console is None else console
+    old_lines = _canonical_lines(old, show_all=show_all)
+    new_lines = _canonical_lines(new, show_all=show_all)
+    from_label, to_label = labels
+    for line in unified_diff(
+        old_lines,
+        new_lines,
+        fromfile=from_label,
+        tofile=to_label,
+        lineterm="",
+    ):
+        con.print(_colourise(line), highlight=False)
+
+
+def _canonical_lines(payload: Mapping[str, object], *, show_all: bool) -> list[str]:
+    canonical = canonicalise(payload, show_all=show_all)
+    return json.dumps(canonical, indent=2, sort_keys=True).splitlines()
+
+
+def _colourise(line: str) -> str:
+    text = escape(line)
+    if line.startswith(("---", "+++")):
+        return f"[bold]{text}[/bold]"
+    if line.startswith("@@"):
+        return f"[cyan]{text}[/cyan]"
+    if line.startswith("+"):
+        return f"[green]{text}[/green]"
+    if line.startswith("-"):
+        return f"[red]{text}[/red]"
+    return text

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -12,8 +12,12 @@ from nextlabs_sdk._cli._binary_output import write_bytes
 from nextlabs_sdk._cli._bulk_ids import parse_bulk_ids
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
-from nextlabs_sdk._cli._diff._engine import diff_payloads
-from nextlabs_sdk._cli._diff._render_semantic import render_semantic
+from nextlabs_sdk._cli._diff import (
+    _engine,
+    _format,
+    _render_semantic,
+    _render_unified,
+)
 from nextlabs_sdk._cli._diff._revision_select import (
     InsufficientRevisionsError,
     select_revisions,
@@ -602,7 +606,7 @@ register_detail_renderer(Policy, _render_policy_detail)
 
 @policies_app.command()
 @cli_error_handler
-def diff(
+def diff(  # noqa: WPS211
     ctx: typer.Context,
     policy_id: Annotated[int, typer.Argument(help="Policy ID")],
     from_rev: Annotated[
@@ -614,8 +618,12 @@ def diff(
     show_all: Annotated[
         bool, typer.Option("--show-all", help="Reveal ordering + noise differences")
     ] = False,
+    diff_format: Annotated[
+        _format.DiffFormat,
+        typer.Option("--format", help="Human renderer: semantic (default) or unified"),
+    ] = _format.DiffFormat.SEMANTIC,
 ) -> None:
-    """Show a semantic diff between two revisions of a policy."""
+    """Show a diff between two revisions of a policy."""
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     try:
@@ -627,5 +635,13 @@ def diff(
         raise typer.Exit(code=1) from exc
     old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)
     new_payload = new.policy_detail.model_dump(mode="json", by_alias=True)
-    diff_result = diff_payloads(old_payload, new_payload, show_all=show_all)
-    render_semantic(diff_result)
+    if diff_format is _format.DiffFormat.UNIFIED:
+        _render_unified.render_unified(
+            old_payload,
+            new_payload,
+            labels=(f"revision {old.revision}", f"revision {new.revision}"),
+            show_all=show_all,
+        )
+        return
+    diff_result = _engine.diff_payloads(old_payload, new_payload, show_all=show_all)
+    _render_semantic.render_semantic(diff_result)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -140,6 +140,48 @@ def test_diff_default_renders_semantic_report(stub: tuple[Any, Any]) -> None:
     assert "write" in output
 
 
+def test_diff_format_semantic_renders_semantic_report(stub: tuple[Any, Any]) -> None:
+    """Given two deployed revisions differing in description, when running diff
+    with --format semantic, then it renders the semantic report showing the
+    changed scalar."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "semantic"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Policy diff" in output
+    assert "write" in output
+
+
+def test_diff_format_unified_renders_git_style_diff(stub: tuple[Any, Any]) -> None:
+    """Given two deployed revisions differing in description, when running diff
+    with --format unified, then it renders a git-style unified diff with a hunk
+    header and the changed value on an added line."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "@@" in output
+    assert any(line.startswith("+") and "write" in line for line in output.splitlines())
+
+
 def test_diff_show_all_reveals_noise(stub: tuple[Any, Any]) -> None:
     """Given two deployed revisions differing only in a deployment-noise field,
     when running diff with --show-all, then the otherwise-hidden noise field is

--- a/tests/test_policy_diff_unified.py
+++ b/tests/test_policy_diff_unified.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+from strip_ansi import strip_ansi
+
+from nextlabs_sdk._cli._diff._render_unified import render_unified
+
+
+def _render(old: dict[str, Any], new: dict[str, Any], **kwargs: Any) -> str:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    render_unified(
+        old,
+        new,
+        labels=("revision 2", "revision 3"),
+        console=console,
+        **kwargs,
+    )
+    return strip_ansi(buffer.getvalue())
+
+
+def _body_change_lines(output: str) -> list[str]:
+    return [
+        line
+        for line in output.splitlines()
+        if (line.startswith("+") or line.startswith("-"))
+        and not line.startswith("+++")
+        and not line.startswith("---")
+    ]
+
+
+def test_reordered_array_produces_no_diff_lines() -> None:
+    """Given two payloads whose only difference is the order of an array's
+    elements, when rendering the unified diff, then no change lines are
+    emitted because both sides are canonicalised first."""
+    old = {"name": "P", "items": [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]}
+    new = {"name": "P", "items": [{"id": 2, "v": "b"}, {"id": 1, "v": "a"}]}
+    output = _render(old, new)
+    assert _body_change_lines(output) == []
+
+
+def test_noise_field_change_produces_no_diff_lines() -> None:
+    """Given two payloads differing only in a deployment-noise field, when
+    rendering the unified diff, then no change lines are emitted because the
+    noise blacklist is stripped during canonicalisation."""
+    old = {"name": "P", "deploymentTime": 100}
+    new = {"name": "P", "deploymentTime": 200}
+    output = _render(old, new)
+    assert _body_change_lines(output) == []
+
+
+def test_real_change_renders_git_style_unified_diff() -> None:
+    """Given two payloads with a genuinely changed scalar, when rendering the
+    unified diff, then it emits a git-style hunk with removed and added
+    lines carrying the old and new values."""
+    old = {"name": "P", "description": "allow read access"}
+    new = {"name": "P", "description": "allow write access"}
+    output = _render(old, new)
+    assert "@@" in output
+    changes = _body_change_lines(output)
+    assert any(line.startswith("-") and "read" in line for line in changes)
+    assert any(line.startswith("+") and "write" in line for line in changes)
+
+
+def test_show_all_reveals_noise_field_in_unified_diff() -> None:
+    """Given two payloads differing only in a noise field, when rendering the
+    unified diff with show_all, then the otherwise-stripped noise field
+    surfaces as a change line."""
+    old = {"name": "P", "deploymentTime": 100}
+    new = {"name": "P", "deploymentTime": 200}
+    output = _render(old, new, show_all=True)
+    assert "deploymentTime" in output
+    assert _body_change_lines(output) != []


### PR DESCRIPTION
Closes #198

## Summary
- Add a `--format semantic|unified` option to `policies diff` (default `semantic`) and a new git-style unified renderer that canonicalises both revisions (arrays sorted by canonical content, deployment-noise stripped) before diffing, so re-ordering and noise produce no diff lines. The unified path reuses the same delta/normalisation core as the semantic view via a shared `canonicalise` helper on the diff engine.
- Tested with new unit tests for the unified renderer (reorder/noise/real-change/show-all) and extended CLI tests covering `--format semantic` and `--format unified`; full suite green (2362 passed) with coverage at 95.92%.
- Trade-off: the inherited `--output json` structured-delta override (#194 D5) is deferred to its dedicated slice — no json-delta emitter exists yet, so json keeps the current semantic output rather than shipping a half-implemented override.

## Tests added (red → green)
- `tests/test_policy_diff_unified.py::test_reordered_array_produces_no_diff_lines`
- `tests/test_policy_diff_unified.py::test_noise_field_change_produces_no_diff_lines`
- `tests/test_policy_diff_unified.py::test_real_change_renders_git_style_unified_diff`
- `tests/test_policy_diff_unified.py::test_show_all_reveals_noise_field_in_unified_diff`
- `tests/test_cli_policy_diff.py::test_diff_format_semantic_renders_semantic_report`
- `tests/test_cli_policy_diff.py::test_diff_format_unified_renders_git_style_diff`

## Notable assumptions
- Unified diff header labels use `revision N` derived from the selected revisions.
- `--show-all` is threaded into the unified renderer so it disables noise stripping and array-order normalisation, mirroring the semantic renderer.
