### PR TITLE
feat(cli): json delta output and --exit-code for policies diff (#199)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -22,3 +22,23 @@ class DiffResult:
 
     changes: tuple[FieldChange, ...]
     hidden_noise_count: int
+
+
+def diff_result_to_dict(delta: DiffResult) -> dict[str, object]:
+    """Render a :class:`DiffResult` as a JSON-serialisable mapping.
+
+    Each change enumerates its ``path`` (as a list of segments), ``kind``,
+    ``old`` value and ``new`` value.
+    """
+    return {
+        "changes": [
+            {
+                "path": list(change.path),
+                "kind": change.kind,
+                "old": change.old,
+                "new": change.new,
+            }
+            for change in delta.changes
+        ],
+        "hidden_noise_count": delta.hidden_noise_count,
+    }

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -15,6 +16,7 @@ from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._diff import (
     _engine,
     _format,
+    _models,
     _render_semantic,
     _render_unified,
 )
@@ -24,6 +26,7 @@ from nextlabs_sdk._cli._diff._revision_select import (
 )
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._output import ColumnDef, print_error, print_success, render
+from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cli._payload_loader import (
     load_payload,
     reject_data_flag,
@@ -622,6 +625,13 @@ def diff(  # noqa: WPS211
         _format.DiffFormat,
         typer.Option("--format", help="Human renderer: semantic (default) or unified"),
     ] = _format.DiffFormat.SEMANTIC,
+    exit_code: Annotated[
+        bool,
+        typer.Option(
+            "--exit-code",
+            help="Exit non-zero when post-filter differences exist (default 0)",
+        ),
+    ] = False,
 ) -> None:
     """Show a diff between two revisions of a policy."""
     cli_ctx: CliContext = ctx.obj
@@ -635,13 +645,17 @@ def diff(  # noqa: WPS211
         raise typer.Exit(code=1) from exc
     old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)
     new_payload = new.policy_detail.model_dump(mode="json", by_alias=True)
-    if diff_format is _format.DiffFormat.UNIFIED:
+    diff_result = _engine.diff_payloads(old_payload, new_payload, show_all=show_all)
+    if cli_ctx.output_format is OutputFormat.JSON:
+        print(json.dumps(_models.diff_result_to_dict(diff_result), indent=2))
+    elif diff_format is _format.DiffFormat.UNIFIED:
         _render_unified.render_unified(
             old_payload,
             new_payload,
             labels=(f"revision {old.revision}", f"revision {new.revision}"),
             show_all=show_all,
         )
-        return
-    diff_result = _engine.diff_payloads(old_payload, new_payload, show_all=show_all)
-    _render_semantic.render_semantic(diff_result)
+    else:
+        _render_semantic.render_semantic(diff_result)
+    if exit_code and diff_result.changes:
+        raise typer.Exit(code=1)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -282,3 +283,120 @@ def test_both_shared_name_obligations_report_changed_params(
     output = strip_ansi(result.output)
     assert "ssn_hash" in output
     assert "dob_hash" in output
+
+
+def test_output_json_emits_structured_delta_overriding_format(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions differing in description, when running diff with the
+    global --output json together with --format unified, then it emits the
+    structured JSON delta and not the unified text render (json overrides
+    format)."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "--output",
+            "json",
+            "policies",
+            "diff",
+            "10",
+            "--format",
+            "unified",
+        ],
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "@@" not in output
+    payload = json.loads(output)
+    assert "changes" in payload
+
+
+def test_output_json_delta_enumerates_path_kind_old_new(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose description changes, when running diff with the
+    global --output json, then each change entry carries its path, kind, old
+    value and new value."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "10"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.output))
+    changes = payload["changes"]
+    assert changes
+    described = next(c for c in changes if c["path"] == ["description"])
+    assert described["kind"] == "change"
+    assert described["old"] == "allow read access"
+    assert described["new"] == "allow write access"
+
+
+def test_exit_code_flag_exits_nonzero_when_differences_exist(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions that differ after noise filtering, when running diff
+    with --exit-code, then the command exits non-zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--exit-code"]
+    )
+    assert result.exit_code != 0
+
+
+def test_exit_code_flag_exits_zero_when_revisions_equivalent(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions that are equivalent after noise filtering, when
+    running diff with --exit-code, then the command exits zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="same text", deployment_time=200)
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="same text", deployment_time=100)
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--exit-code"]
+    )
+    assert result.exit_code == 0
+
+
+def test_without_exit_code_flag_exits_zero_despite_differences(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions that differ after noise filtering, when running diff
+    without --exit-code, then the command still exits zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes #199

## Summary
- `policies diff` now honours the global `--output json` flag by emitting the structured delta model (each change with its path, kind, old and new value) instead of a human render, overriding `--format`.
- Adds an opt-in `--exit-code` flag that mirrors `git diff --exit-code`: the command exits non-zero when post-filter differences exist and zero otherwise; without the flag it always exits zero.
- Tested via the extended CLI diff suite plus the full unit suite (2366 passed, 95.93% coverage); no new business logic added — the command composes the existing diff engine and SDK calls.

## Tests added (red → green)
- `test_output_json_emits_structured_delta_overriding_format`
- `test_output_json_delta_enumerates_path_kind_old_new`
- `test_exit_code_flag_exits_nonzero_when_differences_exist`
- `test_exit_code_flag_exits_zero_when_revisions_equivalent`
- `test_without_exit_code_flag_exits_zero_despite_differences`

## Notable assumptions
- `--exit-code` reflects the diff actually computed, so combining it with `--show-all` treats revealed noise as a difference; the acceptance criteria only specify post-filter/default behaviour.
