### PR TITLE
fix(PRD): #194 cleanup — capstone findings

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -278,7 +278,7 @@ def _diff_lists(
             changes.append(FieldChange(path=path, kind=_KIND_CHANGE, old=old, new=new))
         return
 
-    old_set = {_canonical(elem) for elem in old}
-    new_set = {_canonical(elem) for elem in new}
-    if old_set != new_set:
+    old_canonical = sorted(_canonical(elem) for elem in old)
+    new_canonical = sorted(_canonical(elem) for elem in new)
+    if old_canonical != new_canonical:
         changes.append(FieldChange(path=path, kind=_KIND_CHANGE, old=old, new=new))

--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Literal
 
 
@@ -24,6 +24,23 @@ class DiffResult:
     hidden_noise_count: int
 
 
+def _to_jsonable(value: object) -> object:  # noqa: WPS110
+    """Convert a change value into a JSON-serialisable structure.
+
+    Identity summaries (``ComponentSummary``, ``ObligationSummary``) reach the
+    JSON path as frozen dataclass instances, which ``json.dumps`` cannot encode;
+    they are expanded to plain mappings here so component and obligation deltas
+    serialise alongside scalar ones.
+    """
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, list):
+        return [_to_jsonable(element) for element in value]
+    if isinstance(value, dict):
+        return {key: _to_jsonable(child) for key, child in value.items()}
+    return value
+
+
 def diff_result_to_dict(delta: DiffResult) -> dict[str, object]:
     """Render a :class:`DiffResult` as a JSON-serialisable mapping.
 
@@ -35,8 +52,8 @@ def diff_result_to_dict(delta: DiffResult) -> dict[str, object]:
             {
                 "path": list(change.path),
                 "kind": change.kind,
-                "old": change.old,
-                "new": change.new,
+                "old": _to_jsonable(change.old),
+                "new": _to_jsonable(change.new),
             }
             for change in delta.changes
         ],

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -347,6 +347,56 @@ def test_output_json_delta_enumerates_path_kind_old_new(
     assert described["new"] == "allow write access"
 
 
+def test_output_json_serializes_component_version_bump(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions where a subject component's version is bumped, when
+    running diff with the global --output json, then the change entry's old and
+    new carry JSON objects describing the component identity and version."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subjects(2, [_component(5, "Engineers", version=1)])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subjects(3, [_component(5, "Engineers", version=2)])
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "10"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.output))
+    component_change = next(
+        change for change in payload["changes"] if change["kind"] == "change"
+    )
+    assert component_change["old"]["version"] == 1
+    assert component_change["new"]["version"] == 2
+    assert component_change["new"]["name"] == "Engineers"
+
+
+def test_output_json_serializes_obligation_addition(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions where an obligation is added, when running diff with
+    the global --output json, then the added change entry's new carries a JSON
+    object identifying the obligation by name."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_obligations(2, [])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_obligations(3, [_obligation("data_masking", {"col": "ssn"})])
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "10"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.output))
+    added = next(change for change in payload["changes"] if change["kind"] == "add")
+    assert added["new"]["name"] == "data_masking"
+
+
 def test_exit_code_flag_exits_nonzero_when_differences_exist(
     stub: tuple[Any, Any],
 ) -> None:

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -17,6 +17,21 @@ def test_reordered_idless_array_yields_no_change():
     assert result.changes == ()
 
 
+def test_dropped_duplicate_idless_element_is_reported():
+    """Given two payloads where a duplicated id-less array element is removed.
+
+    When diffing without show_all, so the semantic path normalises the array.
+    Then the change is reported, because list multiplicity is significant and
+    matches the canonicalised array the unified renderer would emit.
+    """
+    old = {"name": "P", "tags": [{"key": "a"}, {"key": "a"}]}
+    new = {"name": "P", "tags": [{"key": "a"}]}
+
+    result = diff_payloads(old, new)
+
+    assert result.changes != ()
+
+
 def test_deployment_noise_excluded_by_default():
     """Given payloads differing only in deployment-noise leaf fields.
 


### PR DESCRIPTION
Addresses capstone findings from the local `<prd-review>` for PRD #194
(`policies diff` command).

Finding IDs addressed:
  - F1 (high, alignment): `--output json` failed for component and obligation semantic deltas because their dataclass summaries are not JSON-serializable. The structured delta now expands summaries to plain mappings before serialisation.
  - F4 (medium, test-strategy): JSON-output tests covered only scalar deltas. Added explicit JSON-shape assertions for component version bumps and obligation additions.
  - US9 (coverage-matrix, partially covered): structured JSON now serialises and is tested for the high-value component/obligation deltas.
  - F3 (high, architectural-coherence): the semantic path compared id-less arrays as sets while the unified renderer canonicalised by sorting, so the two formats could disagree and multiplicity was lost. Both paths now share one notion of array equality (sorted canonical content).

Finding IDs skipped (with reason):
  - F2 (medium, scope): the devcontainer sudo hardening is out of PRD scope, but it is already merged on `main` and is a useful security improvement. Reverting it as PRD cleanup provides no value; flagged for separate tracking rather than removed here.

No decisions excerpt was persisted in this cleanup (optional step deferred).

Closes #194 (capstone cleanup).
