### PR TITLE
feat(cli): show help instead of error for incomplete commands

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,11 @@ per-file-ignores =
   # inline noqa in this file, so WPS211 stays here too.
   src/nextlabs_sdk/_cli/_app.py: WPS211, WPS404
 
+  # CLI command groups
+  src/nextlabs_sdk/_cli/_auth_cmd.py: WPS201
+  src/nextlabs_sdk/_cli/_pdp_cmd.py: WPS201
+  src/nextlabs_sdk/_cli/_policies_cmd.py: WPS201
+
   # Internal registry: re-exports all internal symbols with __all__ metadata.
   src/nextlabs_sdk/_cloudaz/__init__.py: WPS201, WPS203, WPS410, WPS412
   src/nextlabs_sdk/_pdp/__init__.py: WPS201, WPS410, WPS412

--- a/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_activity_logs_cmd.py
@@ -12,9 +12,10 @@ from nextlabs_sdk._cli._activity_log_query_builder import build_activity_log_que
 from nextlabs_sdk._cli._binary_output import write_bytes
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, render
 
-activity_logs_app = typer.Typer(help="Report activity log commands.")
+activity_logs_app = make_group("Report activity log commands.")
 
 _ENFORCEMENT_COLUMNS = (
     ColumnDef("Row ID", "row_id"),

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -26,7 +26,7 @@ _DEFAULT_TIMEOUT_SECONDS = 30.0
 app = typer.Typer(
     name="nextlabs",
     help="NextLabs CloudAz SDK CLI",
-    invoke_without_command=True,
+    no_args_is_help=True,
 )
 
 app.add_typer(audit_logs_app, name="audit-logs")
@@ -162,5 +162,3 @@ def main(
         pdp_auth=pdp_auth,
         pdp_client_id=pdp_client_id,
     )
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.get_help())

--- a/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_audit_logs_cmd.py
@@ -13,6 +13,7 @@ from nextlabs_sdk._cli._bulk_ids import parse_bulk_ids
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, print_error, render
 from nextlabs_sdk._cli._payload_loader import load_payload
 from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
@@ -22,7 +23,7 @@ from nextlabs_sdk._cloudaz._audit_log_models import (
     ExportAuditLogsRequest,
 )
 
-audit_logs_app = typer.Typer(help="Entity audit log commands")
+audit_logs_app = make_group("Entity audit log commands")
 
 _AUDIT_LOG_COLUMNS = (
     ColumnDef("ID", "id"),

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -30,10 +30,11 @@ from nextlabs_sdk._cli._account_status_label import account_status_and_refreshab
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
 from nextlabs_sdk._cli._expiry_format import format_expiry
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
 
-auth_app = typer.Typer(help="Authentication commands")
+auth_app = make_group("Authentication commands")
 
 _NO_ACCOUNTS_MESSAGE = "No cached accounts. Run `nextlabs auth login` to create one."
 _NO_ACTIVE_MESSAGE = (

--- a/src/nextlabs_sdk/_cli/_component_types_cmd.py
+++ b/src/nextlabs_sdk/_cli/_component_types_cmd.py
@@ -12,12 +12,13 @@ from nextlabs_sdk._cli._bulk_ids import parse_bulk_ids
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, print_success, render
 from nextlabs_sdk._cli._payload_loader import reject_data_flag, require_payload
 from nextlabs_sdk._cloudaz._component_type_models import ComponentType
 from nextlabs_sdk._cloudaz._search import SearchCriteria
 
-component_types_app = typer.Typer(help="Component type management commands")
+component_types_app = make_group("Component type management commands")
 
 _CT_COLUMNS = (
     ColumnDef("ID", "id"),

--- a/src/nextlabs_sdk/_cli/_components_cmd.py
+++ b/src/nextlabs_sdk/_cli/_components_cmd.py
@@ -12,12 +12,13 @@ from nextlabs_sdk._cli._bulk_ids import parse_bulk_ids
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, print_success, render
 from nextlabs_sdk._cli._payload_loader import reject_data_flag, require_payload
 from nextlabs_sdk._cloudaz._component_models import Component
 from nextlabs_sdk._cloudaz._search import SearchCriteria
 
-components_app = typer.Typer(help="Component management commands")
+components_app = make_group("Component management commands")
 
 _ID_COLUMN = ColumnDef("ID", "id")
 _NAME_COLUMN = ColumnDef("Name", "name")

--- a/src/nextlabs_sdk/_cli/_dashboard_cmd.py
+++ b/src/nextlabs_sdk/_cli/_dashboard_cmd.py
@@ -10,11 +10,12 @@ from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, render
 from nextlabs_sdk._cli._time_parser import now_epoch_ms, parse_time
 from nextlabs_sdk._cloudaz._dashboard_models import PolicyActivity
 
-dashboard_app = typer.Typer(help="Reporter dashboard commands")
+dashboard_app = make_group("Reporter dashboard commands")
 
 _DATE_HELP = (
     "Accepts epoch milliseconds (e.g. 1737014400000), ISO 8601 datetime "

--- a/src/nextlabs_sdk/_cli/_factory.py
+++ b/src/nextlabs_sdk/_cli/_factory.py
@@ -1,0 +1,18 @@
+"""Factory for CLI sub-group Typer instances."""
+
+from __future__ import annotations
+
+import typer
+
+
+def make_group(help_text: str) -> typer.Typer:
+    """Construct a sub-group Typer that auto-shows help on bare invocation.
+
+    Args:
+        help_text: Help string shown in the group's usage screen.
+
+    Returns:
+        A Typer configured with ``no_args_is_help=True`` so invoking the
+        group without a subcommand prints help instead of erroring.
+    """
+    return typer.Typer(help=help_text, no_args_is_help=True)

--- a/src/nextlabs_sdk/_cli/_operators_cmd.py
+++ b/src/nextlabs_sdk/_cli/_operators_cmd.py
@@ -11,10 +11,11 @@ from rich.console import Console
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, render
 from nextlabs_sdk._cli._output_format import OutputFormat
 
-operators_app = typer.Typer(help="Operator (data-type) metadata commands.")
+operators_app = make_group("Operator (data-type) metadata commands.")
 
 _OPERATOR_COLUMNS = (
     ColumnDef("ID", "id"),

--- a/src/nextlabs_sdk/_cli/_pdp_cmd.py
+++ b/src/nextlabs_sdk/_cli/_pdp_cmd.py
@@ -14,6 +14,7 @@ from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import render_json
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cli._pdp_payload_helpers import (
@@ -45,7 +46,7 @@ from nextlabs_sdk._pdp._payload import (
     load_permissions_payload,
 )
 
-pdp_app = typer.Typer(help="PDP evaluation commands")
+pdp_app = make_group("PDP evaluation commands")
 
 _DECISION_COLORS: MappingProxyType[Decision, str] = MappingProxyType(
     {

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -25,6 +25,7 @@ from nextlabs_sdk._cli._diff._revision_select import (
     select_revisions,
 )
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, print_error, print_success, render
 from nextlabs_sdk._cli._output_format import OutputFormat
 from nextlabs_sdk._cli._payload_loader import (
@@ -35,7 +36,7 @@ from nextlabs_sdk._cli._payload_loader import (
 from nextlabs_sdk._cloudaz._policy_models import Policy
 from nextlabs_sdk._cloudaz._search import SearchCriteria
 
-policies_app = typer.Typer(help="Policy management commands")
+policies_app = make_group("Policy management commands")
 
 _ID_FIELD = "id"
 _ID_COLUMN = ColumnDef("ID", _ID_FIELD)

--- a/src/nextlabs_sdk/_cli/_reporter_audit_logs_cmd.py
+++ b/src/nextlabs_sdk/_cli/_reporter_audit_logs_cmd.py
@@ -9,9 +9,10 @@ import typer
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, render
 
-reporter_audit_logs_app = typer.Typer(help="Reporter audit log commands.")
+reporter_audit_logs_app = make_group("Reporter audit log commands.")
 
 _COLUMNS = (
     ColumnDef("ID", "id"),

--- a/src/nextlabs_sdk/_cli/_reports_cmd.py
+++ b/src/nextlabs_sdk/_cli/_reports_cmd.py
@@ -13,6 +13,7 @@ from nextlabs_sdk._cli._binary_output import write_bytes
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import (
     ColumnDef,
     print_success,
@@ -28,7 +29,7 @@ from nextlabs_sdk._cloudaz._report_models import (
     WidgetData,
 )
 
-reports_app = typer.Typer(help="Report management commands")
+reports_app = make_group("Report management commands")
 
 _REPORT_COLUMNS = (
     ColumnDef("ID", "id"),

--- a/src/nextlabs_sdk/_cli/_system_config_cmd.py
+++ b/src/nextlabs_sdk/_cli/_system_config_cmd.py
@@ -11,9 +11,10 @@ from rich.table import Table
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output_format import OutputFormat
 
-system_config_app = typer.Typer(help="Reporter system configuration commands.")
+system_config_app = make_group("Reporter system configuration commands.")
 
 
 @system_config_app.command()

--- a/src/nextlabs_sdk/_cli/_tags_cmd.py
+++ b/src/nextlabs_sdk/_cli/_tags_cmd.py
@@ -10,10 +10,11 @@ from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._context import CliContext
 from nextlabs_sdk._cli._detail_renderers import register_detail_renderer
 from nextlabs_sdk._cli._error_handler import cli_error_handler
+from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import ColumnDef, print_error, print_success, render
 from nextlabs_sdk._cloudaz._models import Tag, TagType
 
-tags_app = typer.Typer(help="Tag management commands")
+tags_app = make_group("Tag management commands")
 
 _TAG_COLUMNS = (
     ColumnDef("ID", "id"),

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -1,19 +1,53 @@
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
 from nextlabs_sdk._cli._app import app
 
 runner = CliRunner()
 
+_GROUPS = (
+    "activity-logs",
+    "audit-logs",
+    "auth",
+    "component-types",
+    "components",
+    "dashboard",
+    "operators",
+    "pdp",
+    "policies",
+    "reporter-audit-logs",
+    "reports",
+    "system-config",
+    "tags",
+)
+
 
 def test_app_shows_help():
+    # Given the root app
+    # When invoked with --help
     result = runner.invoke(app, ["--help"])
+    # Then it prints usage and exits zero
     assert result.exit_code == 0
     assert "nextlabs" in result.output.lower() or "Usage" in result.output
 
 
 def test_app_no_args_shows_help():
+    # Given the root app
+    # When invoked with no arguments
     result = runner.invoke(app, [])
-    assert result.exit_code == 0
+    # Then it prints help and exits two (no_args_is_help)
+    assert result.exit_code == 2
     assert "Usage" in result.output
+
+
+@pytest.mark.parametrize("group", _GROUPS)
+def test_group_without_subcommand_shows_help(group: str):
+    # Given a top-level command group
+    # When invoked without a subcommand
+    result = runner.invoke(app, [group])
+    # Then it prints help (not a "Missing command" error) and exits two
+    assert result.exit_code == 2
+    assert "Usage" in result.output
+    assert "Missing command" not in result.output


### PR DESCRIPTION
## Summary

Invoking a command group without a terminal subcommand now prints the group's **help screen and exits 2**, matching the `smartbroker-plus-sdk` CLI behavior.

Before this change:
- Sub-groups (`nextlabs auth`, `nextlabs audit-logs`, …) raised a Click **"Missing command"** error block (exit 2).
- The root `nextlabs` (no args) printed help but exited **0**.

After this change every group — root and sub-groups alike — prints clean help and exits **2** (uniform, smartbroker parity).

## Changes

- **New** `src/nextlabs_sdk/_cli/_factory.py` — `make_group(help_text)` returning `typer.Typer(help=help_text, no_args_is_help=True)`.
- Converted all 13 sub-groups to `make_group(...)`.
- Root `_cli/_app.py`: `invoke_without_command=True` → `no_args_is_help=True`; removed the manual `ctx.get_help()` echo block.
- `setup.cfg`: WPS201 per-file-ignore for `_auth_cmd.py` / `_pdp_cmd.py` / `_policies_cmd.py` — the shared `make_group` import pushes them to 21 imports (> 20).

## Exit-code note

Intentional behavioral change: **root no-args exit code `0` → `2`** for uniform behavior across all groups.

## Testing

- `tests/test_cli_app.py`: root no-args now asserts exit `2`; added parametrized Given/When/Then tests over all 13 groups (help shown, no "Missing command", exit `2`).
- `python ./tools/checks.py --short` → 4/4 green (black, flake8, mypy, pyright).
- `python ./tools/tests.py --short` → 2382 passed, 12 skipped.
- Manual smoke: `nextlabs`, `nextlabs auth` → help, exit `2`.