### PR TITLE
fix(cli): fetch policy diff revisions by entry id (#209)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_revision_select.py
+++ b/src/nextlabs_sdk/_cli/_diff/_revision_select.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from nextlabs_sdk._cloudaz._policies import PolicyService
-from nextlabs_sdk._cloudaz._policy_models import PolicyRevision
+from nextlabs_sdk._cloudaz._policy_models import PolicyHistoryEntry, PolicyRevision
 from nextlabs_sdk.exceptions import NextLabsError
 
 DEPLOYED_ACTION_TYPE = "DE"
@@ -11,6 +11,10 @@ DEPLOYED_ACTION_TYPE = "DE"
 
 class InsufficientRevisionsError(NextLabsError):
     """Raised when fewer than two comparable revisions exist for a policy."""
+
+
+class UnknownRevisionError(NextLabsError):
+    """Raised when a requested revision number is absent from a policy's history."""
 
 
 def select_revisions(
@@ -21,6 +25,10 @@ def select_revisions(
     to_rev: int | None = None,
 ) -> tuple[PolicyRevision, PolicyRevision]:
     """Resolve the two policy revisions to compare.
+
+    Each side is fetched with the history entry's own ``id`` as the revision-ID
+    path segment, never the policy ID, because the server addresses a revision
+    by that entry ``id``.
 
     Args:
         policies: The policy service used to query history and fetch revisions.
@@ -34,40 +42,79 @@ def select_revisions(
         A ``(old, new)`` tuple where ``new`` is the newer/``to`` side.
 
     Raises:
-        InsufficientRevisionsError: When both sides cannot be resolved because
+        InsufficientRevisionsError: When a side cannot be auto-selected because
             fewer than two deployed revisions exist and overrides do not supply
-            both sides.
+            it.
+        UnknownRevisionError: When an explicitly overridden revision number is
+            absent from the policy's history.
     """
-    if from_rev is not None and to_rev is not None:
-        old = policies.get_revision(policy_id, from_rev)
-        new = policies.get_revision(policy_id, to_rev)
-        return old, new
-
     entries = policies.list_history(policy_id)
-    deployed = sorted(
+    by_revision = {entry.revision: entry for entry in entries}
+
+    resolved_to = _resolve_to(entries, policy_id, to_rev)
+    resolved_from = _resolve_from(entries, policy_id, from_rev, resolved_to)
+
+    old_entry = _require_entry(by_revision, policy_id, resolved_from)
+    new_entry = _require_entry(by_revision, policy_id, resolved_to)
+
+    old = policies.get_revision(old_entry.id, old_entry.revision)
+    new = policies.get_revision(new_entry.id, new_entry.revision)
+    return old, new
+
+
+def _deployed_newest_first(
+    entries: list[PolicyHistoryEntry],
+) -> list[PolicyHistoryEntry]:
+    return sorted(
         (entry for entry in entries if entry.action_type == DEPLOYED_ACTION_TYPE),
         key=lambda entry: entry.revision,
         reverse=True,
     )
 
-    resolved_to = to_rev
-    resolved_from = from_rev
 
-    if resolved_to is None:
-        if not deployed:
-            raise InsufficientRevisionsError(
-                f"Policy {policy_id} has fewer than two comparable revisions to diff."
-            )
-        resolved_to = deployed[0].revision
+def _resolve_to(
+    entries: list[PolicyHistoryEntry],
+    policy_id: int,
+    to_rev: int | None,
+) -> int:
+    if to_rev is not None:
+        return to_rev
+    deployed = _deployed_newest_first(entries)
+    if not deployed:
+        raise InsufficientRevisionsError(
+            f"Policy {policy_id} has fewer than two comparable revisions to diff."
+        )
+    return deployed[0].revision
 
-    if resolved_from is None:
-        remaining = [entry for entry in deployed if entry.revision != resolved_to]
-        if not remaining:
-            raise InsufficientRevisionsError(
-                f"Policy {policy_id} has fewer than two comparable revisions to diff."
-            )
-        resolved_from = remaining[0].revision
 
-    old = policies.get_revision(policy_id, resolved_from)
-    new = policies.get_revision(policy_id, resolved_to)
-    return old, new
+def _resolve_from(
+    entries: list[PolicyHistoryEntry],
+    policy_id: int,
+    from_rev: int | None,
+    resolved_to: int,
+) -> int:
+    if from_rev is not None:
+        return from_rev
+    remaining = [
+        entry
+        for entry in _deployed_newest_first(entries)
+        if entry.revision != resolved_to
+    ]
+    if not remaining:
+        raise InsufficientRevisionsError(
+            f"Policy {policy_id} has fewer than two comparable revisions to diff."
+        )
+    return remaining[0].revision
+
+
+def _require_entry(
+    by_revision: dict[int, PolicyHistoryEntry],
+    policy_id: int,
+    revision: int,
+) -> PolicyHistoryEntry:
+    entry = by_revision.get(revision)
+    if entry is None:
+        raise UnknownRevisionError(
+            f"Revision {revision} is not in policy {policy_id}'s history."
+        )
+    return entry

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -22,6 +22,7 @@ from nextlabs_sdk._cli._diff import (
 )
 from nextlabs_sdk._cli._diff._revision_select import (
     InsufficientRevisionsError,
+    UnknownRevisionError,
     select_revisions,
 )
 from nextlabs_sdk._cli._error_handler import cli_error_handler
@@ -641,7 +642,7 @@ def diff(  # noqa: WPS211
         old, new = select_revisions(
             client.policies, policy_id, from_rev=from_rev, to_rev=to_rev
         )
-    except InsufficientRevisionsError as exc:
+    except (InsufficientRevisionsError, UnknownRevisionError) as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
     old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -237,6 +237,22 @@ def test_diff_too_few_revisions_exits_nonzero_without_traceback(
     assert "fewer than two" in output.lower()
 
 
+def test_diff_unknown_override_revision_exits_nonzero_without_traceback(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given an overridden revision absent from history, when running diff, then
+    it exits non-zero with a clear message and no traceback."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--from", "2", "--to", "9"]
+    )
+    assert result.exit_code != 0
+    output = strip_ansi(result.output)
+    assert "Traceback" not in output
+    assert "9" in output
+
+
 def _obligation(name: str, params: dict[str, str]) -> dict[str, Any]:
     return {"id": None, "policyModelId": 0, "name": name, "params": params}
 

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -204,10 +204,16 @@ def test_diff_from_to_override_fetches_those_revisions(stub: tuple[Any, Any]) ->
     """Given explicit from/to revisions, when overriding both sides, then it
     succeeds using the overridden revisions."""
     _, mock_policies = stub
-    when(mock_policies).get_revision(10, 1).thenReturn(
+    when(mock_policies).list_history(10).thenReturn(
+        [
+            PolicyHistoryEntry(id=21, revision=1, action_type="DR"),
+            PolicyHistoryEntry(id=24, revision=4, action_type="DR"),
+        ]
+    )
+    when(mock_policies).get_revision(21, 1).thenReturn(
         _revision(1, description="allow read access")
     )
-    when(mock_policies).get_revision(10, 4).thenReturn(
+    when(mock_policies).get_revision(24, 4).thenReturn(
         _revision(4, description="allow write access")
     )
     result = runner.invoke(

--- a/tests/test_policy_diff_revision_select.py
+++ b/tests/test_policy_diff_revision_select.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from mockito import mock, when
+from mockito import mock, verify, when
 
 from nextlabs_sdk.cloudaz import (
     Policy,
@@ -11,61 +11,96 @@ from nextlabs_sdk.cloudaz import (
 )
 from nextlabs_sdk._cli._diff._revision_select import (
     InsufficientRevisionsError,
+    UnknownRevisionError,
     select_revisions,
 )
 
-
-def _entry(revision: int, action_type: str = "DE") -> PolicyHistoryEntry:
-    return PolicyHistoryEntry(id=10, revision=revision, action_type=action_type)
+POLICY_ID = 82
 
 
-def _revision(revision: int) -> PolicyRevision:
+def _entry(revision: int, entry_id: int, action_type: str = "DE") -> PolicyHistoryEntry:
+    return PolicyHistoryEntry(id=entry_id, revision=revision, action_type=action_type)
+
+
+def _revision(revision: int, entry_id: int) -> PolicyRevision:
     return PolicyRevision(
-        id=10,
+        id=entry_id,
         revision=revision,
         action_type="DE",
-        policy_detail=Policy(id=82, name="P", status="DRAFT", effect_type="ALLOW"),
+        policy_detail=Policy(
+            id=POLICY_ID, name="P", status="DRAFT", effect_type="ALLOW"
+        ),
     )
 
 
-def test_default_selects_two_most_recent_deployed():
-    """Given history with three deployed revisions and one draft.
+def test_default_selects_two_most_recent_deployed_by_entry_id():
+    """Given history with deployed entries whose ids differ from the policy id.
 
     When selecting with no overrides.
-    Then the two most recent deployed revisions are chosen, newest as "new".
+    Then each revision is fetched via get_revision using the entry's own id,
+        never the policy id, with the newest deployed revision as "new".
     """
     # given
     policies = mock(PolicyService)
-    when(policies).list_history(10).thenReturn(
-        [_entry(1), _entry(2), _entry(3), _entry(4, action_type="DR")]
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [
+            _entry(1, entry_id=101),
+            _entry(2, entry_id=102),
+            _entry(3, entry_id=103),
+            _entry(4, entry_id=104, action_type="DR"),
+        ]
     )
-    when(policies).get_revision(10, 3).thenReturn(_revision(3))
-    when(policies).get_revision(10, 2).thenReturn(_revision(2))
+    when(policies).get_revision(103, 3).thenReturn(_revision(3, entry_id=103))
+    when(policies).get_revision(102, 2).thenReturn(_revision(2, entry_id=102))
     # when
-    old, new = select_revisions(policies, 10)
+    old, new = select_revisions(policies, POLICY_ID)
     # then
     assert old.revision == 2
     assert new.revision == 3
+    verify(policies).get_revision(102, 2)
+    verify(policies).get_revision(103, 3)
 
 
-def test_from_and_to_override_bypass_deployed_filter():
-    """Given history whose entries are all non-deployed drafts.
+def test_from_and_to_overrides_resolve_entry_ids_and_bypass_deployed_filter():
+    """Given history of non-deployed entries whose ids differ from the policy id.
 
-    When overriding both sides explicitly.
-    Then those exact revisions are fetched despite none being deployed.
+    When overriding both sides with explicit revision numbers.
+    Then those revisions are resolved to their entries' ids and fetched with
+        those ids, despite none being deployed.
     """
     # given
     policies = mock(PolicyService)
-    when(policies).list_history(10).thenReturn(
-        [_entry(5, action_type="DR"), _entry(6, action_type="DR")]
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [
+            _entry(5, entry_id=205, action_type="DR"),
+            _entry(6, entry_id=206, action_type="DR"),
+        ]
     )
-    when(policies).get_revision(10, 5).thenReturn(_revision(5))
-    when(policies).get_revision(10, 6).thenReturn(_revision(6))
+    when(policies).get_revision(205, 5).thenReturn(_revision(5, entry_id=205))
+    when(policies).get_revision(206, 6).thenReturn(_revision(6, entry_id=206))
     # when
-    old, new = select_revisions(policies, 10, from_rev=5, to_rev=6)
+    old, new = select_revisions(policies, POLICY_ID, from_rev=5, to_rev=6)
     # then
     assert old.revision == 5
     assert new.revision == 6
+    verify(policies).get_revision(205, 5)
+    verify(policies).get_revision(206, 6)
+
+
+def test_overridden_revision_absent_from_history_raises():
+    """Given history that does not contain an explicitly requested revision.
+
+    When overriding with a revision number absent from the policy's history.
+    Then a clear domain error is raised instead of fetching a revision.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [_entry(5, entry_id=205, action_type="DR")]
+    )
+    # when / then
+    with pytest.raises(UnknownRevisionError):
+        select_revisions(policies, POLICY_ID, from_rev=5, to_rev=9)
 
 
 def test_fewer_than_two_comparable_raises():
@@ -76,7 +111,7 @@ def test_fewer_than_two_comparable_raises():
     """
     # given
     policies = mock(PolicyService)
-    when(policies).list_history(10).thenReturn([_entry(1)])
+    when(policies).list_history(POLICY_ID).thenReturn([_entry(1, entry_id=101)])
     # when / then
     with pytest.raises(InsufficientRevisionsError):
-        select_revisions(policies, 10)
+        select_revisions(policies, POLICY_ID)


### PR DESCRIPTION
Closes #209

## Summary
- `policies diff <policy_id>` now resolves each revision number to its history entry and fetches the revision with that entry's own `id` as the `viewRevision/{revision_id}/{revision}` path segment, instead of the policy ID the server rejects — fixing both auto-selection and the `--from`/`--to` override paths.
- Added a unit test pinning that `get_revision` is called with the entry `id` (entry IDs deliberately differ from the policy ID), plus CLI tests covering a successful override diff and the clean non-zero exit for an unknown overridden revision.
- An explicitly overridden revision number absent from the policy's history now raises a clear `UnknownRevisionError` (surfaced as a non-zero CLI exit with no traceback) instead of issuing a request the server would reject.

## Tests added (red → green)
- `test_default_selects_two_most_recent_deployed_by_entry_id`
- `test_from_and_to_overrides_resolve_entry_ids_and_bypass_deployed_filter`
- `test_overridden_revision_absent_from_history_raises`
- `test_diff_unknown_override_revision_exits_nonzero_without_traceback`
