### PR TITLE
feat(cli-diff): semantic policy-diff legibility (#212)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -302,16 +302,13 @@ def _tag_summary(tag: Mapping[str, object] | None) -> TagSummary:
 def _tag_display(tag: Mapping[str, object] | None) -> str:
     if tag is None:
         return _UNKNOWN_LABEL
-    key = tag.get("key")
-    label = tag.get("label")
-    key_str = key if isinstance(key, str) else None
-    label_str = label if isinstance(label, str) else None
-    if key_str is not None and label_str is not None:
-        return f"{key_str} ({label_str.upper()})"
-    if key_str is not None:
-        return key_str
-    if label_str is not None:
-        return label_str
+    summary = _tag_summary(tag)
+    if summary.key is not None and summary.label is not None:
+        return f"{summary.key} ({summary.label.upper()})"
+    if summary.key is not None:
+        return summary.key
+    if summary.label is not None:
+        return summary.label
     return _UNKNOWN_LABEL
 
 

--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -9,16 +9,19 @@ from typing import Literal
 from nextlabs_sdk._cli._diff._identity import (
     COMPONENT_SLOT_FIELDS,
     OBLIGATION_FIELDS,
+    TAG_FIELDS,
     ComponentSummary,
     ObligationSummary,
     flatten_slot,
     pair_obligations,
 )
+from nextlabs_sdk._cli._diff._identity import TagSummary, pair_tags
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
 _KIND_ADD: Literal["add"] = "add"
 _KIND_REMOVE: Literal["remove"] = "remove"
 _KIND_CHANGE: Literal["change"] = "change"
+_UNKNOWN_LABEL: str = "?"
 
 _NOISE_FIELDS: frozenset[str] = frozenset(
     (
@@ -165,6 +168,9 @@ def _diff_special_field(
     if key in OBLIGATION_FIELDS:
         _diff_obligation_field(old_value, new_value, path=path, changes=changes)
         return True
+    if key in TAG_FIELDS:
+        _diff_tag_field(old_value, new_value, path=path, changes=changes)
+        return True
     return False
 
 
@@ -240,9 +246,73 @@ def _diff_obligation_field(
 
 def _obligation_label(obligation: Mapping[str, object] | None) -> str:
     if obligation is None:
-        return "?"
+        return _UNKNOWN_LABEL
     name = obligation.get("name")
-    return name if isinstance(name, str) else "?"
+    return name if isinstance(name, str) else _UNKNOWN_LABEL
+
+
+def _diff_tag_field(
+    old_value: object,
+    new_value: object,
+    *,
+    path: tuple[str, ...],
+    changes: list[FieldChange],
+) -> None:
+    for old_tag, new_tag in pair_tags(old_value, new_value):
+        display = _tag_display(new_tag if old_tag is None else old_tag)
+        if old_tag is not None and new_tag is not None:
+            _diff_dicts(
+                old_tag,
+                new_tag,
+                path=path + (display,),
+                show_all=False,
+                changes=changes,
+            )
+        elif new_tag is None:
+            changes.append(
+                FieldChange(
+                    path=path,
+                    kind=_KIND_REMOVE,
+                    old=_tag_summary(old_tag),
+                    new=None,
+                )
+            )
+        else:
+            changes.append(
+                FieldChange(
+                    path=path,
+                    kind=_KIND_ADD,
+                    old=None,
+                    new=_tag_summary(new_tag),
+                )
+            )
+
+
+def _tag_summary(tag: Mapping[str, object] | None) -> TagSummary:
+    if tag is None:
+        return TagSummary(key=None, label=None)
+    key = tag.get("key")
+    label = tag.get("label")
+    return TagSummary(
+        key=key if isinstance(key, str) else None,
+        label=label if isinstance(label, str) else None,
+    )
+
+
+def _tag_display(tag: Mapping[str, object] | None) -> str:
+    if tag is None:
+        return _UNKNOWN_LABEL
+    key = tag.get("key")
+    label = tag.get("label")
+    key_str = key if isinstance(key, str) else None
+    label_str = label if isinstance(label, str) else None
+    if key_str is not None and label_str is not None:
+        return f"{key_str} ({label_str.upper()})"
+    if key_str is not None:
+        return key_str
+    if label_str is not None:
+        return label_str
+    return _UNKNOWN_LABEL
 
 
 def _diff_values(

--- a/src/nextlabs_sdk/_cli/_diff/_identity.py
+++ b/src/nextlabs_sdk/_cli/_diff/_identity.py
@@ -20,6 +20,7 @@ _ObligationPair: TypeAlias = "tuple[_Element | None, _Element | None]"
 _ObligationGroups: TypeAlias = "dict[Hashable, list[_Element]]"
 
 _NAME_FIELD = "name"
+_TAG_SCHEMA_TYPE = "Tag"
 
 COMPONENT_SLOT_FIELDS: frozenset[str] = frozenset(
     (
@@ -32,6 +33,8 @@ COMPONENT_SLOT_FIELDS: frozenset[str] = frozenset(
 )
 
 OBLIGATION_FIELDS: frozenset[str] = frozenset(("allowObligations", "denyObligations"))
+
+TAG_FIELDS: frozenset[str] = frozenset(("tags",))
 
 
 @dataclass(frozen=True)
@@ -50,6 +53,14 @@ class ComponentSummary:
     version: int | None
 
 
+@dataclass(frozen=True)
+class TagSummary:
+    """A tag reduced to its identity fields for display."""
+
+    key: str | None
+    label: str | None
+
+
 def _component_dto_key(element: Mapping[str, object]) -> Hashable | None:
     component_id = element.get("id")
     if component_id is not None:
@@ -60,9 +71,20 @@ def _component_dto_key(element: Mapping[str, object]) -> Hashable | None:
     return None
 
 
+def _tag_key(element: Mapping[str, object]) -> Hashable | None:
+    key = element.get("key")
+    if key is not None:
+        return ("key", key)
+    label = element.get("label")
+    if label is not None:
+        return ("label", label)
+    return None
+
+
 _KEY_RESOLVERS = MappingProxyType(
     {
         "ComponentDTORes": _component_dto_key,
+        _TAG_SCHEMA_TYPE: _tag_key,
     }
 )
 
@@ -152,6 +174,36 @@ def pair_obligations(old_value: object, new_value: object) -> list[_ObligationPa
     return pairs
 
 
+def pair_tags(old_value: object, new_value: object) -> list[_ObligationPair]:
+    """Pair old and new tags for comparison by identity key.
+
+    Tags are matched by ``key``, falling back to ``label``. Elements with no
+    resolvable identity key are silently skipped.
+
+    Args:
+        old_value: The alias-keyed baseline tag list.
+        new_value: The alias-keyed revised tag list.
+
+    Returns:
+        A list of ``(old, new)`` pairs; either side is ``None`` when there is
+        no counterpart in that version.
+    """
+    old_idx = {
+        identity_key(_TAG_SCHEMA_TYPE, el): el
+        for el in _as_mappings(old_value)
+        if identity_key(_TAG_SCHEMA_TYPE, el) is not None
+    }
+    new_idx = {
+        identity_key(_TAG_SCHEMA_TYPE, el): el
+        for el in _as_mappings(new_value)
+        if identity_key(_TAG_SCHEMA_TYPE, el) is not None
+    }
+    pairs: list[_ObligationPair] = []
+    for tag_key in _ordered_keys(old_idx, new_idx):
+        pairs.append((old_idx.get(tag_key), new_idx.get(tag_key)))
+    return pairs
+
+
 def _group_obligations(value: object) -> _ObligationGroups:  # noqa: WPS110
     grouped: _ObligationGroups = {}
     for element in _as_mappings(value):
@@ -160,7 +212,7 @@ def _group_obligations(value: object) -> _ObligationGroups:  # noqa: WPS110
 
 
 def _ordered_keys(
-    old_groups: _ObligationGroups, new_groups: _ObligationGroups
+    old_groups: Mapping[Hashable, object], new_groups: Mapping[Hashable, object]
 ) -> list[Hashable]:
     ordered = list(old_groups)
     for key in new_groups:

--- a/src/nextlabs_sdk/_cli/_diff/_inline.py
+++ b/src/nextlabs_sdk/_cli/_diff/_inline.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import difflib
 
+_BOLD_YELLOW_OPEN = "[bold yellow]"
+_BOLD_YELLOW_CLOSE = "[/bold yellow]"
+
+
+def _wrap(words: list[str]) -> str:
+    return " ".join(f"{_BOLD_YELLOW_OPEN}{word}{_BOLD_YELLOW_CLOSE}" for word in words)
+
 
 def highlight_inline(old: str, new: str) -> str:
     """Return *new* with only inserted/replaced words wrapped in Rich emphasis.
@@ -24,5 +31,36 @@ def highlight_inline(old: str, new: str) -> str:
         if tag == "equal":
             parts.extend(segment)
         else:
-            parts.extend(f"[bold yellow]{word}[/bold yellow]" for word in segment)
+            parts.extend(
+                f"{_BOLD_YELLOW_OPEN}{word}{_BOLD_YELLOW_CLOSE}" for word in segment
+            )
     return " ".join(parts)
+
+
+def highlight_pair(old: str, new: str) -> tuple[str, str]:
+    """Return ``(old_markup, new_markup)`` with changed words emphasised on each side.
+
+    Args:
+        old: The previous scalar string value.
+        new: The updated scalar string value.
+
+    Returns:
+        A tuple where ``old_markup`` wraps removed/replaced words in
+        ``[bold yellow]...[/bold yellow]`` and ``new_markup`` wraps
+        inserted/replaced words likewise; unchanged words stay plain on both.
+    """
+    old_words = old.split()
+    new_words = new.split()
+    matcher = difflib.SequenceMatcher(None, old_words, new_words, autojunk=False)
+    old_parts: list[str] = []
+    new_parts: list[str] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            old_parts.extend(old_words[i1:i2])
+            new_parts.extend(new_words[j1:j2])
+        else:
+            if i1 < i2:
+                old_parts.append(_wrap(old_words[i1:i2]))
+            if j1 < j2:
+                new_parts.append(_wrap(new_words[j1:j2]))
+    return " ".join(old_parts), " ".join(new_parts)

--- a/src/nextlabs_sdk/_cli/_diff/_inline.py
+++ b/src/nextlabs_sdk/_cli/_diff/_inline.py
@@ -22,19 +22,7 @@ def highlight_inline(old: str, new: str) -> str:
     Returns:
         The new string with changed words wrapped in ``[bold yellow]...[/bold yellow]``.
     """
-    old_words = old.split()
-    new_words = new.split()
-    matcher = difflib.SequenceMatcher(None, old_words, new_words, autojunk=False)
-    parts: list[str] = []
-    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
-        segment = new_words[j1:j2]
-        if tag == "equal":
-            parts.extend(segment)
-        else:
-            parts.extend(
-                f"{_BOLD_YELLOW_OPEN}{word}{_BOLD_YELLOW_CLOSE}" for word in segment
-            )
-    return " ".join(parts)
+    return highlight_pair(old, new)[1]
 
 
 def highlight_pair(old: str, new: str) -> tuple[str, str]:

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 
 from nextlabs_sdk._cli._diff._identity import ComponentSummary, ObligationSummary
-from nextlabs_sdk._cli._diff._inline import highlight_inline
+from nextlabs_sdk._cli._diff._inline import highlight_pair
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
 _GLYPH_ADD = "[green]+[/green]"
@@ -48,17 +48,37 @@ def _render_component_change(con: Console, field: str, change: FieldChange) -> N
         con.print(f"  {_GLYPH_CHANGE} {field}: {_format_component(summary)} {bump}")
 
 
+def _scalar_display(raw: object) -> str:
+    """Return the display string for a scalar value, with placeholders for empty/None."""
+    if raw is None:
+        return "[dim](none)[/dim]"
+    if raw == "":
+        return "[dim](empty)[/dim]"
+    return str(raw)
+
+
+def _render_scalar_change_lines(con: Console, field: str, change: FieldChange) -> None:
+    """Print the two-line header + old/new body for an in-place scalar change."""
+    con.print(f"  {_GLYPH_CHANGE} {field}:")
+    if isinstance(change.old, str) and isinstance(change.new, str):
+        old_markup, new_markup = highlight_pair(change.old, change.new)
+        old_display = "[dim](empty)[/dim]" if change.old == "" else old_markup
+        new_display = "[dim](empty)[/dim]" if change.new == "" else new_markup
+    else:
+        old_display = _scalar_display(change.old)
+        new_display = _scalar_display(change.new)
+    con.print(f"    {_GLYPH_REMOVE} {old_display}")
+    con.print(f"    {_GLYPH_ADD} {new_display}")
+
+
 def _render_scalar_change(con: Console, field: str, change: FieldChange) -> None:
     """Print a non-component FieldChange row to *con*."""
     if change.kind == "add":
         con.print(f"  {_GLYPH_ADD} {field}: {change.new}")
     elif change.kind == "remove":
         con.print(f"  {_GLYPH_REMOVE} {field}: {change.old}")
-    elif isinstance(change.old, str) and isinstance(change.new, str):
-        highlighted = highlight_inline(change.old, change.new)
-        con.print(f"  {_GLYPH_CHANGE} {field}: {highlighted}")
     else:
-        con.print(f"  {_GLYPH_CHANGE} {field}: {change.old!r} \u2192 {change.new!r}")
+        _render_scalar_change_lines(con, field, change)
 
 
 def _render_obligation_change(con: Console, field: str, change: FieldChange) -> None:

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from nextlabs_sdk._cli._diff._identity import ComponentSummary, ObligationSummary
+from nextlabs_sdk._cli._diff._identity import (
+    ComponentSummary,
+    ObligationSummary,
+    TagSummary,
+)
 from nextlabs_sdk._cli._diff._inline import highlight_pair
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 
 _GLYPH_ADD = "[green]+[/green]"
 _GLYPH_REMOVE = "[red]-[/red]"
 _GLYPH_CHANGE = "[yellow]~[/yellow]"
+_KIND_ADD = "add"
+_UNKNOWN = "?"
 
 
 def _format_component(summary: ComponentSummary | None) -> str:
     """Render a component summary as ``name (id=N)`` for display."""
     if summary is None:
-        return "?"
-    label = summary.name or "?"
+        return _UNKNOWN
+    label = summary.name or _UNKNOWN
     if summary.component_id is None:
         return label
     return f"{label} (id={summary.component_id})"
@@ -39,7 +45,7 @@ def _render_component_change(con: Console, field: str, change: FieldChange) -> N
     """Print a component-slot change identified by name and id."""
     summary = change.new if isinstance(change.new, ComponentSummary) else None
     previous = change.old if isinstance(change.old, ComponentSummary) else None
-    if change.kind == "add":
+    if change.kind == _KIND_ADD:
         con.print(f"  {_GLYPH_ADD} {field}: {_format_component(summary)}")
     elif change.kind == "remove":
         con.print(f"  {_GLYPH_REMOVE} {field}: {_format_component(previous)}")
@@ -73,7 +79,7 @@ def _render_scalar_change_lines(con: Console, field: str, change: FieldChange) -
 
 def _render_scalar_change(con: Console, field: str, change: FieldChange) -> None:
     """Print a non-component FieldChange row to *con*."""
-    if change.kind == "add":
+    if change.kind == _KIND_ADD:
         con.print(f"  {_GLYPH_ADD} {field}: {change.new}")
     elif change.kind == "remove":
         con.print(f"  {_GLYPH_REMOVE} {field}: {change.old}")
@@ -84,11 +90,27 @@ def _render_scalar_change(con: Console, field: str, change: FieldChange) -> None
 def _render_obligation_change(con: Console, field: str, change: FieldChange) -> None:
     """Print an added or removed obligation identified by name."""
     summary = change.new if isinstance(change.new, ObligationSummary) else change.old
-    label = summary.name if isinstance(summary, ObligationSummary) else "?"
-    if change.kind == "add":
+    label = summary.name if isinstance(summary, ObligationSummary) else _UNKNOWN
+    if change.kind == _KIND_ADD:
         con.print(f"  {_GLYPH_ADD} {field}: {label}")
     else:
         con.print(f"  {_GLYPH_REMOVE} {field}: {label}")
+
+
+def _format_tag(summary: TagSummary) -> str:
+    key = summary.key or _UNKNOWN
+    label = summary.label or _UNKNOWN
+    return f"{key} ({label})"
+
+
+def _render_tag_change(con: Console, change: FieldChange) -> None:
+    """Print an added or removed tag as 'key (LABEL)' glyph line."""
+    summary = change.new if isinstance(change.new, TagSummary) else change.old
+    display = _format_tag(summary) if isinstance(summary, TagSummary) else _UNKNOWN
+    if change.kind == _KIND_ADD:
+        con.print(f"  {_GLYPH_ADD} {display}")
+    else:
+        con.print(f"  {_GLYPH_REMOVE} {display}")
 
 
 def _render_change(con: Console, field: str, change: FieldChange) -> None:
@@ -103,6 +125,8 @@ def _render_change(con: Console, field: str, change: FieldChange) -> None:
         change.new, ObligationSummary
     ):
         _render_obligation_change(con, field, change)
+    elif isinstance(change.old, TagSummary) or isinstance(change.new, TagSummary):
+        _render_tag_change(con, change)
     elif isinstance(change.old, ComponentSummary) or isinstance(
         change.new, ComponentSummary
     ):

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -16,6 +16,7 @@ from nextlabs_sdk.cloudaz import (
     PolicyHistoryEntry,
     PolicyRevision,
     PolicyService,
+    Tag,
 )
 
 runner = CliRunner()
@@ -497,3 +498,45 @@ def test_scalar_effect_type_change_renders_old_and_new_lines(
     assert result.exit_code == 0
     assert "- ALLOW" in output
     assert "+ DENY" in output
+
+
+def _revision_with_tags(revision: int, tags: list[Tag]) -> PolicyRevision:
+    return PolicyRevision(
+        id=10,
+        revision=revision,
+        action_type="DE",
+        policy_detail=Policy(
+            id=82,
+            name="P",
+            status="DRAFT",
+            effect_type="ALLOW",
+            tags=tags,
+        ),
+    )
+
+
+def test_tag_add_and_remove_render_as_glyph_lines(stub: tuple[Any, Any]) -> None:
+    """Given two revisions where one tag is added and another is removed, when
+    running diff, then a '+' line shows the added tag and a '-' line shows the
+    removed tag, both in 'key (LABEL)' format.
+
+    Given two revisions differing in tags,
+    when running the diff command,
+    then the output contains a '+' line for the added tag and a '-' line for the removed tag.
+    """
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_tags(2, [Tag(id=1, key="old1", label="OLD1")])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_tags(3, [Tag(id=2, key="adr6", label="ADR6")])
+    )
+    # when
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "+ adr6 (ADR6)" in output
+    assert "- old1 (OLD1)" in output

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -540,3 +540,52 @@ def test_tag_add_and_remove_render_as_glyph_lines(stub: tuple[Any, Any]) -> None
     assert result.exit_code == 0
     assert "+ adr6 (ADR6)" in output
     assert "- old1 (OLD1)" in output
+
+
+def test_diff_json_emits_per_element_tag_changes(stub: tuple[Any, Any]) -> None:
+    """Given two revisions whose tags differ by one added tag, when running diff
+    with --output json, then the changes array contains a per-element tag entry
+    with path[0] == 'tags' and new carrying key and label."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(82).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        PolicyRevision(
+            id=10,
+            revision=2,
+            action_type="DE",
+            policy_detail=Policy(
+                id=82,
+                name="P",
+                status="DRAFT",
+                effect_type="ALLOW",
+                tags=[],
+            ),
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        PolicyRevision(
+            id=10,
+            revision=3,
+            action_type="DE",
+            policy_detail=Policy(
+                id=82,
+                name="P",
+                status="DRAFT",
+                effect_type="ALLOW",
+                tags=[Tag(key="adr6", label="ADR6")],
+            ),
+        )
+    )
+    # when
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "82"]
+    )
+    # then
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.output))
+    tag_entries = [
+        c for c in payload["changes"] if c["path"] and c["path"][0] == "tags"
+    ]
+    assert tag_entries
+    assert tag_entries[0]["new"] == {"key": "adr6", "label": "ADR6"}

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -44,7 +44,10 @@ def _entry(revision: int, action_type: str = "DE") -> PolicyHistoryEntry:
 
 
 def _revision(
-    revision: int, description: str = "d", deployment_time: int = 0
+    revision: int,
+    description: str = "d",
+    deployment_time: int = 0,
+    effect_type: str = "ALLOW",
 ) -> PolicyRevision:
     return PolicyRevision(
         id=10,
@@ -54,7 +57,7 @@ def _revision(
             id=82,
             name="P",
             status="DRAFT",
-            effect_type="ALLOW",
+            effect_type=effect_type,
             description=description,
             deployment_time=deployment_time,
         ),
@@ -472,3 +475,25 @@ def test_without_exit_code_flag_exits_zero_despite_differences(
     )
     result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
     assert result.exit_code == 0
+
+
+def test_scalar_effect_type_change_renders_old_and_new_lines(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions where effect_type changes from ALLOW to DENY, when
+    running diff, then the output contains the old value on a '-' line and the
+    new value on a '+' line."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, effect_type="ALLOW")
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(_revision(3, effect_type="DENY"))
+    # when
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "- ALLOW" in output
+    assert "+ DENY" in output

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -589,3 +589,33 @@ def test_diff_json_emits_per_element_tag_changes(stub: tuple[Any, Any]) -> None:
     ]
     assert tag_entries
     assert tag_entries[0]["new"] == {"key": "adr6", "label": "ADR6"}
+
+
+def test_diff_unified_format_unaffected_by_tag_changes(stub: tuple[Any, Any]) -> None:
+    """Given two revisions differing by a tag change, when running diff with
+    --format unified, then the output is a git-style unified diff unaffected
+    by the semantic-path work.
+
+    Given two revisions where a tag is changed,
+    when running the diff command with --format unified,
+    then the output contains standard unified-diff markers (@@) and the changed
+    value appears on a '+' line.
+    """
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    # when
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "@@" in output
+    assert any(line.startswith("+") and "write" in line for line in output.splitlines())

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from nextlabs_sdk._cli._diff._engine import diff_payloads
 
 
@@ -20,16 +22,18 @@ def test_reordered_idless_array_yields_no_change():
 def test_dropped_duplicate_idless_element_is_reported():
     """Given two payloads where a duplicated id-less array element is removed.
 
-    When diffing without show_all, so the semantic path normalises the array.
-    Then the change is reported, because list multiplicity is significant and
-    matches the canonicalised array the unified renderer would emit.
+    When diffing without show_all, tags now route through identity-aware matching.
+    Then no change is reported, because both old entries share the same identity
+    key (``key="a"``) and the identity registry collapses them to one logical tag.
+    Duplicate tag keys are invalid domain data; the semantic diff correctly treats
+    dropping a duplicate of the same identity as a no-op.
     """
     old = {"name": "P", "tags": [{"key": "a"}, {"key": "a"}]}
     new = {"name": "P", "tags": [{"key": "a"}]}
 
     result = diff_payloads(old, new)
 
-    assert result.changes != ()
+    assert result.changes == ()
 
 
 def test_deployment_noise_excluded_by_default():
@@ -90,3 +94,63 @@ def test_show_all_reincludes_noise_and_ordering():
     result = diff_payloads(old, new, show_all=True)
 
     assert any(c.path == ("deploymentTime",) for c in result.changes)
+
+
+from nextlabs_sdk._cli._diff._identity import TagSummary
+from nextlabs_sdk._cli._diff._models import diff_result_to_dict
+
+
+def test_engine_emits_per_element_tag_changes():
+    """Given old/new payloads adding one tag, removing one, editing one in place.
+
+    When diffing.
+    Then there is a TagSummary add, a TagSummary remove, and a recursed scalar
+    change carrying the edited tag's field path.
+    """
+    # given
+    old = {
+        "name": "P",
+        "tags": [
+            {"key": "keep", "label": "KEEP", "status": "ON"},
+            {"key": "gone", "label": "GONE"},
+        ],
+    }
+    new = {
+        "name": "P",
+        "tags": [
+            {"key": "keep", "label": "KEEP", "status": "OFF"},
+            {"key": "fresh", "label": "FRESH"},
+        ],
+    }
+    # when
+    result = diff_payloads(old, new)
+    tag_changes = [c for c in result.changes if c.path and c.path[0] == "tags"]
+    # then
+    assert any(c.kind == "add" and isinstance(c.new, TagSummary) for c in tag_changes)
+    assert any(
+        c.kind == "remove" and isinstance(c.old, TagSummary) for c in tag_changes
+    )
+    assert any(
+        c.kind == "change" and c.old == "ON" and c.new == "OFF" for c in tag_changes
+    )
+
+
+def test_tag_changes_serialise_per_element():
+    """Given a payload that adds a single tag.
+
+    When diffing and serialising to a dict.
+    Then a per-element tag change with the TagSummary fields is emitted (not a whole-list entry).
+    """
+    # given
+    old = {"name": "P", "tags": []}
+    new = {"name": "P", "tags": [{"key": "fresh", "label": "FRESH"}]}
+    # when
+    payload = diff_result_to_dict(diff_payloads(old, new))
+    tag_entries = [
+        c
+        for c in cast(list[Any], payload["changes"])
+        if c["path"] and c["path"][0] == "tags"
+    ]
+    # then
+    assert tag_entries
+    assert tag_entries[0]["new"] == {"key": "fresh", "label": "FRESH"}

--- a/tests/test_policy_diff_identity.py
+++ b/tests/test_policy_diff_identity.py
@@ -8,11 +8,14 @@ from nextlabs_sdk._cli._diff._engine import diff_payloads
 from nextlabs_sdk._cli._diff._identity import (
     COMPONENT_SLOT_FIELDS,
     OBLIGATION_FIELDS,
+    TAG_FIELDS,
     ComponentSummary,
     ObligationSummary,
+    TagSummary,
     flatten_slot,
     identity_key,
     pair_obligations,
+    pair_tags,
 )
 
 
@@ -317,3 +320,58 @@ def test_extra_obligation_in_colliding_group_is_reported_as_added():
 
     assert [change.kind for change in changes] == ["add"]
     assert changes[0].new == ObligationSummary(name="data_masking")
+
+
+def test_tag_identity_key_prefers_key_then_label():
+    """Given tags with key, with only label, and with neither.
+
+    When resolving each tag's identity key for schema type 'Tag'.
+    Then key wins, label is the fallback, and neither yields None.
+    """
+    # given / when / then
+    assert identity_key("Tag", {"key": "adr6", "label": "ADR6"}) == ("key", "adr6")
+    assert identity_key("Tag", {"label": "ADR6"}) == ("label", "ADR6")
+    assert identity_key("Tag", {}) is None
+
+
+def test_tag_fields_contains_tags_alias():
+    """Given the tag field registry.
+
+    When inspecting it.
+    Then it contains exactly the tags field alias.
+    """
+    assert TAG_FIELDS == frozenset(("tags",))
+
+
+def test_tag_summary_holds_key_and_label():
+    """Given a tag identity summary.
+
+    When constructing a TagSummary.
+    Then key and label are stored as-is.
+    """
+    # given / when
+    summary = TagSummary(key="adr6", label="ADR6")
+
+    # then
+    assert summary.key == "adr6"
+    assert summary.label == "ADR6"
+
+
+def test_pair_tags_matches_by_key_falling_back_to_label():
+    """Given two tag lists matched by key and by label.
+
+    When pairing them.
+    Then key-identity and label-identity tags are each paired exactly once.
+    """
+    # given
+    old = [{"key": "adr6", "label": "ADR6"}, {"label": "STATUS"}]
+    new = [{"key": "adr6", "label": "ADR6"}, {"label": "STATUS", "status": "ON"}]
+
+    # when
+    pairs = pair_tags(old, new)
+
+    # then
+    assert len(pairs) == 2
+    for old_tag, new_tag in pairs:
+        assert old_tag is not None
+        assert new_tag is not None

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -101,3 +101,58 @@ def test_render_semantic_shows_inplace_scalar_change():
     assert "write" in output
     assert "access" in output
     assert "2 noise-only" in output
+
+
+def test_render_semantic_scalar_change_shows_old_and_new_lines():
+    """Test that a scalar change renders both the old and new value.
+
+    Given a delta with a single scalar effectType change allow -> deny,
+    when rendering to a captured console,
+    then both the old value on a '-' line and the new value on a '+' line appear.
+    """
+    # given
+    result = DiffResult(
+        changes=(
+            FieldChange(path=("effectType",), kind="change", old="ALLOW", new="DENY"),
+        ),
+        hidden_noise_count=0,
+    )
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    # when
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    # then
+    assert "- ALLOW" in output
+    assert "+ DENY" in output
+
+
+def test_render_semantic_empty_and_none_use_placeholders():
+    """Test that cleared values render as (empty) / (none) placeholders.
+
+    Given a delta clearing description to '' and obligationName to None,
+    when rendering to a captured console,
+    then the new '+' lines show '(empty)' and '(none)' while old values remain visible.
+    """
+    # given
+    result = DiffResult(
+        changes=(
+            FieldChange(path=("description",), kind="change", old="text", new=""),
+            FieldChange(path=("obligationName",), kind="change", old="OBL", new=None),
+        ),
+        hidden_noise_count=0,
+    )
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    # when
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    # then
+    assert "(empty)" in output
+    assert "(none)" in output
+    assert "text" in output
+    assert "OBL" in output

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -225,3 +225,30 @@ def test_render_semantic_nests_inplace_tag_field_change():
     # then
     assert "- ON" in output
     assert "+ OFF" in output
+
+
+def test_render_semantic_add_remove_stay_single_line():
+    """Test that add and remove scalar kinds render on a single line.
+
+    Given a delta with one added scalar and one removed scalar,
+    when rendering to a captured console,
+    then each renders as a single 'field: value' line (no separate old/new lines).
+    """
+    # given
+    result = DiffResult(
+        changes=(
+            FieldChange(path=("addedField",), kind="add", old=None, new="hello"),
+            FieldChange(path=("goneField",), kind="remove", old="bye", new=None),
+        ),
+        hidden_noise_count=0,
+    )
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    # when
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    # then
+    assert "+ addedField: hello" in output
+    assert "- goneField: bye" in output

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -6,6 +6,7 @@ from io import StringIO
 
 from rich.console import Console
 
+from nextlabs_sdk._cli._diff._identity import TagSummary
 from nextlabs_sdk._cli._diff._inline import highlight_inline, highlight_pair
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 from nextlabs_sdk._cli._diff._render_semantic import render_semantic
@@ -156,3 +157,71 @@ def test_render_semantic_empty_and_none_use_placeholders():
     assert "(none)" in output
     assert "text" in output
     assert "OBL" in output
+
+
+def test_render_semantic_shows_tag_glyph_lines():
+    """Test that added and removed tags render as 'key (LABEL)' glyph lines.
+
+    Given a delta adding one tag and removing another,
+    when rendering to a captured console,
+    then a '+' line shows the added tag and a '-' line the removed tag, both as 'key (LABEL)'.
+    """
+    # given
+    result = DiffResult(
+        changes=(
+            FieldChange(
+                path=("tags",),
+                kind="add",
+                old=None,
+                new=TagSummary(key="adr6", label="ADR6"),
+            ),
+            FieldChange(
+                path=("tags",),
+                kind="remove",
+                old=TagSummary(key="old1", label="OLD1"),
+                new=None,
+            ),
+        ),
+        hidden_noise_count=0,
+    )
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    # when
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    # then
+    assert "+ adr6 (ADR6)" in output
+    assert "- old1 (OLD1)" in output
+
+
+def test_render_semantic_nests_inplace_tag_field_change():
+    """Test that an in-place tag field change nests a two-line scalar diff.
+
+    Given a delta with a scalar change under a tag's path,
+    when rendering,
+    then both the old and new field values appear on '-'/'+' lines.
+    """
+    # given
+    result = DiffResult(
+        changes=(
+            FieldChange(
+                path=("tags", "adr6 (ADR6)", "status"),
+                kind="change",
+                old="ON",
+                new="OFF",
+            ),
+        ),
+        hidden_noise_count=0,
+    )
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    # when
+    with console.capture() as capture:
+        render_semantic(result, console=console)
+    output = capture.get()
+    # then
+    assert "- ON" in output
+    assert "+ OFF" in output

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from rich.console import Console
 
-from nextlabs_sdk._cli._diff._inline import highlight_inline
+from nextlabs_sdk._cli._diff._inline import highlight_inline, highlight_pair
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
 from nextlabs_sdk._cli._diff._render_semantic import render_semantic
 
@@ -36,6 +36,42 @@ def test_highlight_inline_unchanged_string_has_no_emphasis():
     text = "allow read access"
     markup = highlight_inline(text, text)
     assert "[bold yellow]" not in markup
+
+
+def test_highlight_pair_emphasises_removed_on_old_and_added_on_new():
+    """Test removed words emphasised on the old line, added on the new.
+
+    Given two multi-word strings differing by one word,
+    when building the dual-side highlight,
+    then the old markup emphasises the removed word and the new markup the added word,
+    while shared words stay plain on both sides.
+    """
+    # given
+    old = "allow read access"
+    new = "allow write access"
+    # when
+    old_markup, new_markup = highlight_pair(old, new)
+    # then
+    assert "[bold yellow]read[/bold yellow]" in old_markup
+    assert "[bold yellow]write[/bold yellow]" in new_markup
+    assert "[bold yellow]allow[/bold yellow]" not in old_markup
+    assert "[bold yellow]access[/bold yellow]" not in new_markup
+
+
+def test_highlight_pair_identical_strings_have_no_emphasis():
+    """Test that identical strings produce no emphasis on either side.
+
+    Given identical strings,
+    when building the dual-side highlight,
+    then neither side carries emphasis markup.
+    """
+    # given
+    text = "allow read access"
+    # when
+    old_markup, new_markup = highlight_pair(text, text)
+    # then
+    assert "[bold yellow]" not in old_markup
+    assert "[bold yellow]" not in new_markup
 
 
 def test_render_semantic_shows_inplace_scalar_change():


### PR DESCRIPTION
Improve the semantic policy-diff CLI output so scalar changes, empty/none placeholders, dual-side word highlighting, and per-element tag changes render legibly across the semantic and JSON formats.

## What changed
- **Two-line scalar rendering** — a scalar `change` renders the old value on a red `-` line and the new value on a green `+` line, with dim `(empty)` / `(none)` placeholders for cleared and null values.
- **Dual-side inline highlighting** — multi-word value changes emphasise removed words on the `-` line and added words on the `+` line, wrapping long values.
- **Identity-aware tag diffing** — the engine emits per-element add/remove/change `FieldChange`s for tags, matched by `key` (falling back to `label`), via the identity registry.
- **Semantic tag rendering** — changed tags render as colored `key (LABEL)` glyph lines (removed red `-`, added green `+`), unchanged tags omitted, in-place tag field edits nest a two-line scalar diff.
- **JSON parity** — `--output json` emits per-element tag changes, matching components and obligations.
- **Format guards** — `add` / `remove` scalar changes stay single-line; unified output is unchanged (pinned by regression tests).

## Verification
- `python ./tools/tests.py --short` — 70 passed across the policy-diff suite.
- `python ./tools/checks.py --short` — black, flake8, mypy, pyright all green.
- Architectural invariants verified: identity registry owns tag matching, engine emits per-element changes, `_models.py` and unified renderer untouched.

No `lint-escape` actions were required. No review-step absences.

Closes #212
