### PR TITLE
feat(cli): add identity header to policies diff output (#225)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -24,6 +24,16 @@ class DiffResult:
     hidden_noise_count: int
 
 
+@dataclass(frozen=True)
+class DiffHeader:
+    """Identity of a policy diff: the policy and the two compared revisions."""
+
+    policy_name: str
+    policy_id: int
+    from_rev: int
+    to_rev: int
+
+
 def _to_jsonable(value: object) -> object:  # noqa: WPS110
     """Convert a change value into a JSON-serialisable structure.
 

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -10,13 +10,15 @@ from nextlabs_sdk._cli._diff._identity import (
     TagSummary,
 )
 from nextlabs_sdk._cli._diff._inline import highlight_pair
-from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
 
 _GLYPH_ADD = "[green]+[/green]"
 _GLYPH_REMOVE = "[red]-[/red]"
 _GLYPH_CHANGE = "[yellow]~[/yellow]"
 _KIND_ADD = "add"
 _UNKNOWN = "?"
+_POLICY_LABEL = "Policy:"
+_ARROW = "\u2192"
 
 
 def _format_component(summary: ComponentSummary | None) -> str:
@@ -135,7 +137,9 @@ def _render_change(con: Console, field: str, change: FieldChange) -> None:
         _render_scalar_change(con, field, change)
 
 
-def render_semantic(diff: DiffResult, *, console: Console | None = None) -> None:
+def render_semantic(
+    diff: DiffResult, header: DiffHeader, *, console: Console | None = None
+) -> None:
     """Render a DiffResult as a Rich semantic report.
 
     In-place scalar edits show only the changed words highlighted.
@@ -143,10 +147,16 @@ def render_semantic(diff: DiffResult, *, console: Console | None = None) -> None
 
     Args:
         diff: The structured diff result to render.
+        header: The policy identity and compared revisions, printed as two
+            lines above the change sections.
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
-    con.print("[bold]Policy diff[/bold]")
+    con.print(
+        f"[bold]{_POLICY_LABEL}[/bold] {header.policy_name} (id={header.policy_id})"
+    )
+    con.print(f"Comparing revisions {header.from_rev} {_ARROW} {header.to_rev}")
+    con.print()
 
     sections: dict[str, list[FieldChange]] = {}
     for change in diff.changes:

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -10,13 +10,16 @@ from rich.console import Console
 from rich.markup import escape
 
 from nextlabs_sdk._cli._diff._engine import canonicalise
+from nextlabs_sdk._cli._diff._models import DiffHeader
+
+_REVISION_LABEL = "revision"
 
 
 def render_unified(
     old: Mapping[str, object],
     new: Mapping[str, object],
+    header: DiffHeader,
     *,
-    labels: tuple[str, str],
     show_all: bool = False,
     console: Console | None = None,
 ) -> None:
@@ -29,14 +32,19 @@ def render_unified(
     Args:
         old: The baseline alias-keyed policy payload.
         new: The revised alias-keyed policy payload.
-        labels: The ``(from, to)`` labels for the diff header.
+        header: The policy identity and compared revisions; the policy row is
+            printed first and the ``--- / +++`` labels derive from its revision
+            numbers.
         show_all: When True, reveal ordering and noise differences.
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
+    con.print(f"Policy: {header.policy_name} (id={header.policy_id})")
+    con.print()
     old_lines = _canonical_lines(old, show_all=show_all)
     new_lines = _canonical_lines(new, show_all=show_all)
-    from_label, to_label = labels
+    from_label = f"{_REVISION_LABEL} {header.from_rev}"
+    to_label = f"{_REVISION_LABEL} {header.to_rev}"
     for line in unified_diff(
         old_lines,
         new_lines,

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -648,16 +648,22 @@ def diff(  # noqa: WPS211
     old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)
     new_payload = new.policy_detail.model_dump(mode="json", by_alias=True)
     diff_result = _engine.diff_payloads(old_payload, new_payload, show_all=show_all)
+    header = _models.DiffHeader(
+        policy_name=new.policy_detail.name,
+        policy_id=new.policy_detail.id,
+        from_rev=old.revision,
+        to_rev=new.revision,
+    )
     if cli_ctx.output_format is OutputFormat.JSON:
         print(json.dumps(_models.diff_result_to_dict(diff_result), indent=2))
     elif diff_format is _format.DiffFormat.UNIFIED:
         _render_unified.render_unified(
             old_payload,
             new_payload,
-            labels=(f"revision {old.revision}", f"revision {new.revision}"),
+            header,
             show_all=show_all,
         )
     else:
-        _render_semantic.render_semantic(diff_result)
+        _render_semantic.render_semantic(diff_result, header)
     if exit_code and diff_result.changes:
         raise typer.Exit(code=1)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -162,8 +162,52 @@ def test_diff_format_semantic_renders_semantic_report(stub: tuple[Any, Any]) -> 
     )
     assert result.exit_code == 0
     output = strip_ansi(result.output)
-    assert "Policy diff" in output
+    assert "Policy diff" not in output
     assert "write" in output
+
+
+def test_diff_semantic_shows_identity_header(stub: tuple[Any, Any]) -> None:
+    """Given two deployed revisions, when running diff in the default semantic
+    format, then the output names the policy and the two compared revisions
+    above the change sections."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Policy: P (id=82)" in output
+    assert "Comparing revisions 2 \u2192 3" in output
+    assert output.index("Policy: P (id=82)") < output.index("description")
+
+
+def test_diff_unified_shows_policy_row_and_git_revision_labels(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two deployed revisions, when running diff with --format unified,
+    then the output carries the policy identity row and the git revision labels
+    derived from the compared revision numbers."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Policy: P (id=82)" in output
+    assert "--- revision 2" in output
+    assert "+++ revision 3" in output
 
 
 def test_diff_format_unified_renders_git_style_diff(stub: tuple[Any, Any]) -> None:
@@ -371,6 +415,27 @@ def test_output_json_delta_enumerates_path_kind_old_new(
     assert described["kind"] == "change"
     assert described["old"] == "allow read access"
     assert described["new"] == "allow write access"
+
+
+def test_output_json_has_no_text_header(stub: tuple[Any, Any]) -> None:
+    """Given two revisions, when running diff with --output json, then the
+    structured delta is emitted with no human identity header text."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision(3, description="allow write access")
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision(2, description="allow read access")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "10"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Policy:" not in output
+    assert "Comparing revisions" not in output
+    assert json.loads(output)["changes"]
 
 
 def test_output_json_serializes_component_version_bump(

--- a/tests/test_policy_diff_inline.py
+++ b/tests/test_policy_diff_inline.py
@@ -8,8 +8,10 @@ from rich.console import Console
 
 from nextlabs_sdk._cli._diff._identity import TagSummary
 from nextlabs_sdk._cli._diff._inline import highlight_inline, highlight_pair
-from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
 from nextlabs_sdk._cli._diff._render_semantic import render_semantic
+
+_HEADER = DiffHeader(policy_name="P", policy_id=82, from_rev=2, to_rev=3)
 
 
 def test_highlight_inline_emphasises_only_changed_word():
@@ -97,7 +99,7 @@ def test_render_semantic_shows_inplace_scalar_change():
         file=StringIO(), force_terminal=False, width=120, color_system=None
     )
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     assert "write" in output
     assert "access" in output
@@ -123,7 +125,7 @@ def test_render_semantic_scalar_change_shows_old_and_new_lines():
     )
     # when
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     # then
     assert "- ALLOW" in output
@@ -150,7 +152,7 @@ def test_render_semantic_empty_and_none_use_placeholders():
     )
     # when
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     # then
     assert "(empty)" in output
@@ -189,7 +191,7 @@ def test_render_semantic_shows_tag_glyph_lines():
     )
     # when
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     # then
     assert "+ adr6 (ADR6)" in output
@@ -220,7 +222,7 @@ def test_render_semantic_nests_inplace_tag_field_change():
     )
     # when
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     # then
     assert "- ON" in output
@@ -247,8 +249,58 @@ def test_render_semantic_add_remove_stay_single_line():
     )
     # when
     with console.capture() as capture:
-        render_semantic(result, console=console)
+        render_semantic(result, _HEADER, console=console)
     output = capture.get()
     # then
     assert "+ addedField: hello" in output
     assert "- goneField: bye" in output
+
+
+def test_diff_header_constructs_and_exposes_fields():
+    """Test that DiffHeader holds the policy identity and the compared revisions.
+
+    Given policy name, id and a from/to revision pair,
+    when constructing a DiffHeader,
+    then it exposes each value through its matching attribute.
+    """
+    header = DiffHeader(policy_name="Acme", policy_id=42, from_rev=7, to_rev=9)
+    assert header.policy_name == "Acme"
+    assert header.policy_id == 42
+    assert header.from_rev == 7
+    assert header.to_rev == 9
+
+
+def test_render_semantic_prints_identity_lines_above_sections():
+    """Test that the semantic renderer prints the two identity lines first.
+
+    Given a diff with a single change and a DiffHeader,
+    when rendering to a captured console,
+    then the policy line and the comparing-revisions line appear above the
+    change section, and the old hardcoded title is gone.
+    """
+    result = DiffResult(
+        changes=(
+            FieldChange(
+                path=("description",),
+                kind="change",
+                old="allow read access",
+                new="allow write access",
+            ),
+        ),
+        hidden_noise_count=0,
+    )
+    header = DiffHeader(policy_name="Acme", policy_id=42, from_rev=7, to_rev=9)
+    console = Console(
+        file=StringIO(), force_terminal=False, width=120, color_system=None
+    )
+    with console.capture() as capture:
+        render_semantic(result, header, console=console)
+    output = capture.get()
+    lines = output.splitlines()
+    assert lines[0] == "Policy: Acme (id=42)"
+    assert lines[1] == "Comparing revisions 7 \u2192 9"
+    assert lines[2] == ""
+    assert "Policy diff" not in output
+    policy_index = output.index("Policy: Acme (id=42)")
+    description_index = output.index("description")
+    assert policy_index < description_index

--- a/tests/test_policy_diff_unified.py
+++ b/tests/test_policy_diff_unified.py
@@ -6,7 +6,10 @@ from typing import Any
 from rich.console import Console
 from strip_ansi import strip_ansi
 
+from nextlabs_sdk._cli._diff._models import DiffHeader
 from nextlabs_sdk._cli._diff._render_unified import render_unified
+
+_HEADER = DiffHeader(policy_name="P", policy_id=82, from_rev=2, to_rev=3)
 
 
 def _render(old: dict[str, Any], new: dict[str, Any], **kwargs: Any) -> str:
@@ -15,7 +18,7 @@ def _render(old: dict[str, Any], new: dict[str, Any], **kwargs: Any) -> str:
     render_unified(
         old,
         new,
-        labels=("revision 2", "revision 3"),
+        _HEADER,
         console=console,
         **kwargs,
     )
@@ -74,3 +77,27 @@ def test_show_all_reveals_noise_field_in_unified_diff() -> None:
     output = _render(old, new, show_all=True)
     assert "deploymentTime" in output
     assert _body_change_lines(output) != []
+
+
+def test_header_renders_policy_row_and_derives_revision_labels() -> None:
+    """Given a DiffHeader and two differing payloads, when rendering the unified
+    diff, then a single 'Policy: <name> (id=<id>)' row precedes the diff and the
+    git --- / +++ labels are derived from the header's revision numbers."""
+    old = {"name": "P", "description": "allow read access"}
+    new = {"name": "P", "description": "allow write access"}
+    output = _render(old, new)
+    lines = output.splitlines()
+    assert lines[0] == "Policy: P (id=82)"
+    assert lines[1] == ""
+    assert "--- revision 2" in output
+    assert "+++ revision 3" in output
+
+
+def test_header_renders_when_revisions_are_identical() -> None:
+    """Given two identical payloads, when rendering the unified diff, then the
+    'Policy:' row is still emitted where the renderer previously printed
+    nothing."""
+    payload = {"name": "P", "description": "allow read access"}
+    output = _render(dict(payload), dict(payload))
+    assert output.splitlines()[0] == "Policy: P (id=82)"
+    assert _body_change_lines(output) == []


### PR DESCRIPTION
Closes #225

## Summary
- `policies diff` now builds a `DiffHeader` from the two selected revisions and passes it to the chosen human renderer, so the output states which policy and which two revisions were compared. The semantic renderer prints two identity lines (replacing the old `Policy diff` title); the unified renderer prints a `Policy:` row and derives its `--- / +++` revision labels from the header. The `--output json` path is untouched.
- Covered by red→green unit tests for `DiffHeader`, both renderers, and CLI wiring across semantic / unified / json; full suite green.
- Notable trade-off: none.

## Tests added (red → green)
- `test_diff_header_constructs_and_exposes_fields`
- `test_render_semantic_prints_identity_lines_above_sections`
- `test_header_renders_policy_row_and_derives_revision_labels`
- `test_header_renders_when_revisions_are_identical`
- `test_diff_semantic_shows_identity_header`
- `test_diff_unified_shows_policy_row_and_git_revision_labels`
- `test_output_json_has_no_text_header`

## Notable assumptions
- The header's `policy_name` / `policy_id` are read from the newer revision's embedded policy detail; both revisions belong to the same policy, so either side yields the same identity.
