### PR TITLE
feat(diff): operator/grouping-aware compare_slot for policies diff

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Literal
 
 from nextlabs_sdk._cli._diff._identity import (
     COMPONENT_SLOT_FIELDS,
     OBLIGATION_FIELDS,
     TAG_FIELDS,
-    ComponentSummary,
     ObligationSummary,
-    flatten_slot,
     pair_obligations,
 )
 from nextlabs_sdk._cli._diff._identity import TagSummary, pair_tags
 from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._slot import compare_slot
 
 _KIND_ADD: Literal["add"] = "add"
 _KIND_REMOVE: Literal["remove"] = "remove"
@@ -181,30 +181,8 @@ def _diff_component_slot(
     path: tuple[str, ...],
     changes: list[FieldChange],
 ) -> None:
-    old_components = flatten_slot(old_value)
-    new_components = flatten_slot(new_value)
-    for key in old_components.keys() | new_components.keys():
-        change = _classify_component(
-            path, old_components.get(key), new_components.get(key)
-        )
-        if change is not None:
-            changes.append(change)
-
-
-def _classify_component(
-    path: tuple[str, ...],
-    old_summary: ComponentSummary | None,
-    new_summary: ComponentSummary | None,
-) -> FieldChange | None:
-    if old_summary is not None and new_summary is not None:
-        if old_summary == new_summary:
-            return None
-        return FieldChange(
-            path=path, kind=_KIND_CHANGE, old=old_summary, new=new_summary
-        )
-    if new_summary is not None:
-        return FieldChange(path=path, kind=_KIND_ADD, old=None, new=new_summary)
-    return FieldChange(path=path, kind=_KIND_REMOVE, old=old_summary, new=None)
+    for change in compare_slot(old_value, new_value):
+        changes.append(replace(change, path=path + change.path))
 
 
 def _diff_obligation_field(

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -19,6 +19,8 @@ _KIND_ADD = "add"
 _UNKNOWN = "?"
 _POLICY_LABEL = "Policy:"
 _ARROW = "\u2192"
+_GROUPING_SEGMENT = "grouping"
+_CONTINUATION_PREFIX = "AND "
 
 
 def _format_component(summary: ComponentSummary | None) -> str:
@@ -115,6 +117,25 @@ def _render_tag_change(con: Console, change: FieldChange) -> None:
         con.print(f"  {_GLYPH_REMOVE} {display}")
 
 
+def _render_grouping_change(con: Console, change: FieldChange) -> None:
+    """Print a slot grouping change as aligned ``was``/``now`` structure blocks.
+
+    The first group of each revision prints inline after its label; each
+    continuation group (already carrying the implicit ``AND`` prefix) prints on
+    its own line, indented so every group's opening bracket aligns.
+    """
+    con.print(f"  {_GLYPH_CHANGE} {_GROUPING_SEGMENT}:")
+    _render_structure_block(con, "was", change.old)
+    _render_structure_block(con, "now", change.new)
+
+
+def _render_structure_block(con: Console, label: str, structure: object) -> None:
+    lines = str(structure).split("\n")
+    con.print(f"      {label}:  {lines[0]}")
+    for line in lines[1:]:
+        con.print(f"        {line}")
+
+
 def _render_change(con: Console, field: str, change: FieldChange) -> None:
     """Print a single FieldChange row to *con*.
 
@@ -123,6 +144,13 @@ def _render_change(con: Console, field: str, change: FieldChange) -> None:
         field: Dot-joined path string for display.
         change: The field change to render.
     """
+    if change.path and change.path[-1] == _GROUPING_SEGMENT:
+        _render_grouping_change(con, change)
+    else:
+        _render_typed_change(con, field, change)
+
+
+def _render_typed_change(con: Console, field: str, change: FieldChange) -> None:
     if isinstance(change.old, ObligationSummary) or isinstance(
         change.new, ObligationSummary
     ):

--- a/src/nextlabs_sdk/_cli/_diff/_slot.py
+++ b/src/nextlabs_sdk/_cli/_diff/_slot.py
@@ -1,0 +1,183 @@
+"""Operator/grouping-aware comparison for a single policy component slot.
+
+This module is the slot-comparison seam: the diff engine delegates per-slot
+comparison here instead of flattening every group into one identity set. The
+comparison has two parts over the same slot pair — order-free **membership**
+(today's per-component behaviour, preserved) and **grouping**, which surfaces a
+single change when the ``(operator, members)`` partition drifts over the
+components present in both revisions. Group structure is a plain
+``(operator, frozenset[identity])`` tuple; no new class is introduced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping
+from typing import Literal, TypeAlias
+
+from nextlabs_sdk._cli._diff._identity import (
+    ComponentSummary,
+    flatten_slot,
+    identity_key,
+)
+from nextlabs_sdk._cli._diff._models import FieldChange
+
+_KIND_ADD: Literal["add"] = "add"
+_KIND_REMOVE: Literal["remove"] = "remove"
+_KIND_CHANGE: Literal["change"] = "change"
+
+_GROUPING_SEGMENT = "grouping"
+_SCHEMA_TYPE = "ComponentDTORes"
+_OPERATOR_FIELD = "operator"
+_COMPONENTS_FIELD = "components"
+_SUBCOMPONENTS_FIELD = "subComponents"
+_OPERATOR_WIDTH = 3
+_UNKNOWN_MEMBER = "?"
+
+_Group: TypeAlias = "tuple[str, frozenset[Hashable]]"
+_Summaries: TypeAlias = "Mapping[Hashable, ComponentSummary]"
+
+
+def compare_slot(old_slot: object, new_slot: object) -> list[FieldChange]:
+    """Compare two component-slot values for membership and grouping drift.
+
+    Membership changes are order-free and identity-keyed (id, falling back to
+    name) — a component that merely moves position or moves between groups is
+    still recognised as present. A grouping change is emitted when the
+    ``(normalised-operator, members)`` partition of the components present in
+    both revisions differs; it reuses ``kind="change"`` with a ``grouping``
+    path suffix and carries the canonical structure strings.
+
+    Args:
+        old_slot: The baseline alias-keyed slot value (a list of groups).
+        new_slot: The revised alias-keyed slot value (a list of groups).
+
+    Returns:
+        A list of relative :class:`FieldChange` records — membership changes
+        carry an empty path, the grouping change carries ``("grouping",)`` —
+        for the engine to prefix with the slot name.
+    """
+    old_components = flatten_slot(old_slot)
+    new_components = flatten_slot(new_slot)
+
+    changes: list[FieldChange] = []
+    for key in old_components.keys() | new_components.keys():
+        change = _classify_component(old_components.get(key), new_components.get(key))
+        if change is not None:
+            changes.append(change)
+
+    grouping = _grouping_change(old_slot, new_slot, old_components, new_components)
+    if grouping is not None:
+        changes.append(grouping)
+    return changes
+
+
+def _classify_component(
+    old_summary: ComponentSummary | None,
+    new_summary: ComponentSummary | None,
+) -> FieldChange | None:
+    if old_summary is not None and new_summary is not None:
+        if old_summary == new_summary:
+            return None
+        return FieldChange(path=(), kind=_KIND_CHANGE, old=old_summary, new=new_summary)
+    if new_summary is not None:
+        return FieldChange(path=(), kind=_KIND_ADD, old=None, new=new_summary)
+    return FieldChange(path=(), kind=_KIND_REMOVE, old=old_summary, new=None)
+
+
+def _grouping_change(
+    old_slot: object,
+    new_slot: object,
+    old_components: _Summaries,
+    new_components: _Summaries,
+) -> FieldChange | None:
+    shared = old_components.keys() & new_components.keys()
+    if not shared:
+        return None
+
+    old_groups = _partition(old_slot, frozenset(shared))
+    new_groups = _partition(new_slot, frozenset(shared))
+    if _normalised(old_groups) == _normalised(new_groups):
+        return None
+
+    summaries = {**old_components, **new_components}
+    return FieldChange(
+        path=(_GROUPING_SEGMENT,),
+        kind=_KIND_CHANGE,
+        old=_render_structure(old_groups, summaries),
+        new=_render_structure(new_groups, summaries),
+    )
+
+
+def _partition(slot_value: object, shared: frozenset[Hashable]) -> list[_Group]:
+    groups: list[_Group] = []
+    for group in _mappings(slot_value):
+        operator = group.get(_OPERATOR_FIELD)
+        operator_str = operator if isinstance(operator, str) else ""
+        members = frozenset(key for key in _group_identities(group) if key in shared)
+        if members:
+            groups.append((operator_str, members))
+    return groups
+
+
+def _normalised(groups: list[_Group]) -> frozenset[_Group]:
+    return frozenset(
+        (operator.casefold().strip(), members) for operator, members in groups
+    )
+
+
+def _group_identities(group: Mapping[str, object]) -> set[Hashable]:
+    keys: set[Hashable] = set()
+    for component in _mappings(group.get(_COMPONENTS_FIELD)):
+        _collect_identities(component, keys)
+    return keys
+
+
+def _collect_identities(component: Mapping[str, object], keys: set[Hashable]) -> None:
+    key = identity_key(_SCHEMA_TYPE, component)
+    if key is not None:
+        keys.add(key)
+    for sub in _mappings(component.get(_SUBCOMPONENTS_FIELD)):
+        _collect_identities(sub, keys)
+
+
+def _render_structure(groups: list[_Group], summaries: _Summaries) -> str:
+    lines: list[str] = []
+    for index, (operator, members) in enumerate(sorted(groups, key=_group_sort_key)):
+        rendered = _render_group(operator, members, summaries)
+        lines.append(rendered if index == 0 else f"AND {rendered}")
+    return "\n".join(lines)
+
+
+def _render_group(
+    operator: str, members: frozenset[Hashable], summaries: _Summaries
+) -> str:
+    labels = [
+        _member_label(key, summaries) for key in sorted(members, key=_identity_sort_key)
+    ]
+    return f"[{operator.ljust(_OPERATOR_WIDTH)}: {', '.join(labels)}]"
+
+
+def _member_label(key: Hashable, summaries: _Summaries) -> str:
+    summary = summaries.get(key)
+    if summary is None:
+        return _UNKNOWN_MEMBER
+    if summary.name:
+        return summary.name
+    if summary.component_id is not None:
+        return f"id={summary.component_id}"
+    return _UNKNOWN_MEMBER
+
+
+def _group_sort_key(group: _Group) -> tuple[list[str], str]:
+    operator, members = group
+    return (sorted(_identity_sort_key(key) for key in members), operator.casefold())
+
+
+def _identity_sort_key(key: Hashable) -> str:
+    return str(key)
+
+
+def _mappings(value: object) -> list[Mapping[str, object]]:  # noqa: WPS110
+    if not isinstance(value, list):
+        return []
+    return [element for element in value if isinstance(element, Mapping)]

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -86,6 +86,23 @@ def _revision_with_subjects(
     )
 
 
+def _revision_with_subject_groups(
+    revision: int, groups: list[dict[str, Any]]
+) -> PolicyRevision:
+    policy = Policy.model_validate(
+        {
+            "id": 82,
+            "name": "P",
+            "status": "DRAFT",
+            "effectType": "ALLOW",
+            "subjectComponents": groups,
+        }
+    )
+    return PolicyRevision(
+        id=10, revision=revision, action_type="DE", policy_detail=policy
+    )
+
+
 def test_edited_component_renders_single_modified_entry(stub: tuple[Any, Any]) -> None:
     """Given two revisions where a subject component's version is bumped, when
     running diff, then it shows a single modified entry by name and id, not a
@@ -684,3 +701,72 @@ def test_diff_unified_format_unaffected_by_tag_changes(stub: tuple[Any, Any]) ->
     assert result.exit_code == 0
     assert "@@" in output
     assert any(line.startswith("+") and "write" in line for line in output.splitlines())
+
+
+def _grouped(operator: str, *components: dict[str, Any]) -> dict[str, Any]:
+    return {"operator": operator, "components": list(components)}
+
+
+def test_diff_reports_grouping_change_when_operator_flips(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose subject group operator flips with identical
+    members, when running diff, then a grouping change block is shown rather
+    than a membership change."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subject_groups(
+            2, [_grouped("OR", _component(5, "Engineers"), _component(6, "Ops"))]
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subject_groups(
+            3, [_grouped("AND", _component(5, "Engineers"), _component(6, "Ops"))]
+        )
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "grouping:" in output
+    assert "was:  [OR : Engineers, Ops]" in output
+    assert "now:  [AND: Engineers, Ops]" in output
+
+
+def test_diff_grouping_change_flips_exit_code(stub: tuple[Any, Any]) -> None:
+    """Given a subject group operator flip, when running diff with
+    --exit-code, then the command exits non-zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subject_groups(2, [_grouped("OR", _component(5, "Engineers"))])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subject_groups(3, [_grouped("AND", _component(5, "Engineers"))])
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--exit-code"]
+    )
+    assert result.exit_code == 1
+
+
+def test_diff_grouping_change_appears_in_unified_format(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given a subject group operator flip, when running diff with --format
+    unified, then the operator drift surfaces in the unified output."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subject_groups(2, [_grouped("OR", _component(5, "Engineers"))])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subject_groups(3, [_grouped("AND", _component(5, "Engineers"))])
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert any(line.startswith("-") and "OR" in line for line in output.splitlines())
+    assert any(line.startswith("+") and "AND" in line for line in output.splitlines())

--- a/tests/test_policy_diff_slot.py
+++ b/tests/test_policy_diff_slot.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nextlabs_sdk._cli._diff._models import FieldChange
+from nextlabs_sdk._cli._diff._slot import compare_slot
+
+
+def _comp(component_id: int | None, name: str, version: int = 1) -> dict[str, Any]:
+    return {
+        "id": component_id,
+        "name": name,
+        "version": version,
+        "subComponents": [],
+    }
+
+
+def _group(operator: str, *components: dict[str, Any]) -> dict[str, Any]:
+    return {"operator": operator, "components": list(components)}
+
+
+def _grouping_change(changes: list[FieldChange]) -> FieldChange | None:
+    for change in changes:
+        if change.path == ("grouping",):
+            return change
+    return None
+
+
+def _membership_changes(changes: list[FieldChange]) -> list[FieldChange]:
+    return [change for change in changes if change.path == ()]
+
+
+_A = _comp(1, "A")
+_B = _comp(2, "B")
+_C = _comp(3, "C")
+
+
+def test_operator_flip_with_identical_members_yields_grouping_change() -> None:
+    """Given two slots holding the same members under a flipped group operator.
+
+    When comparing the slots.
+    Then a grouping change is emitted and no per-component change is.
+    """
+    old_slot = [_group("OR", _A, _B)]
+    new_slot = [_group("AND", _A, _B)]
+
+    changes = compare_slot(old_slot, new_slot)
+
+    grouping = _grouping_change(changes)
+    assert grouping is not None
+    assert grouping.kind == "change"
+    assert _membership_changes(changes) == []
+
+
+def test_operator_flip_render_uses_canonical_structure_strings() -> None:
+    """Given a slot whose first group operator flips with a stable second group.
+
+    When comparing the slots.
+    Then the grouping change carries the exact multi-line structure strings,
+    members sorted by identity and continuation groups prefixed with ``AND``.
+    """
+    old_slot = [_group("OR", _A, _B), _group("AND", _C)]
+    new_slot = [_group("AND", _B, _A), _group("AND", _C)]
+
+    grouping = _grouping_change(compare_slot(old_slot, new_slot))
+
+    assert grouping is not None
+    assert grouping.old == "[OR : A, B]\nAND [AND: C]"
+    assert grouping.new == "[AND: A, B]\nAND [AND: C]"
+
+
+def test_in_place_version_change_stays_per_component_without_grouping() -> None:
+    """Given a slot whose only difference is a component version bump.
+
+    When comparing the slots.
+    Then a single per-component change is emitted and no grouping change is.
+    """
+    old_slot = [_group("AND", _comp(1, "A", version=1))]
+    new_slot = [_group("AND", _comp(1, "A", version=2))]
+
+    changes = compare_slot(old_slot, new_slot)
+
+    assert _grouping_change(changes) is None
+    membership = _membership_changes(changes)
+    assert len(membership) == 1
+    assert membership[0].kind == "change"
+
+
+def test_pure_add_and_remove_stays_per_component_without_grouping() -> None:
+    """Given a slot where one component is replaced by another.
+
+    When comparing the slots.
+    Then per-component add and remove are emitted and no grouping change is.
+    """
+    old_slot = [_group("AND", _A)]
+    new_slot = [_group("AND", _B)]
+
+    changes = compare_slot(old_slot, new_slot)
+
+    assert _grouping_change(changes) is None
+    kinds = sorted(change.kind for change in _membership_changes(changes))
+    assert kinds == ["add", "remove"]
+
+
+def test_combined_add_remove_and_operator_flip() -> None:
+    """Given a slot where a member is replaced and the group operator flips.
+
+    When comparing the slots.
+    Then both per-component add/remove and a grouping change are emitted, and
+    the grouping change is scoped to the members present in both revisions.
+    """
+    old_slot = [_group("OR", _A, _C)]
+    new_slot = [_group("AND", _B, _C)]
+
+    changes = compare_slot(old_slot, new_slot)
+
+    grouping = _grouping_change(changes)
+    assert grouping is not None
+    assert grouping.old == "[OR : C]"
+    assert grouping.new == "[AND: C]"
+    kinds = sorted(change.kind for change in _membership_changes(changes))
+    assert kinds == ["add", "remove"]
+
+
+def test_cross_group_move_surfaces_as_grouping_not_add_remove() -> None:
+    """Given a component moved between operator groups with stable membership.
+
+    When comparing the slots.
+    Then the move surfaces as a grouping change, never as removed plus added.
+    """
+    old_slot = [_group("OR", _A, _B), _group("AND", _C)]
+    new_slot = [_group("OR", _A, _C), _group("AND", _B)]
+
+    changes = compare_slot(old_slot, new_slot)
+
+    assert _grouping_change(changes) is not None
+    assert _membership_changes(changes) == []
+
+
+def test_operator_case_and_whitespace_differences_are_ignored() -> None:
+    """Given two slots that differ only in operator casing and whitespace.
+
+    When comparing the slots.
+    Then no grouping change is emitted.
+    """
+    old_slot = [_group("AND", _A, _B)]
+    new_slot = [_group(" and ", _A, _B)]
+
+    assert _grouping_change(compare_slot(old_slot, new_slot)) is None
+
+
+def test_idless_components_render_by_name() -> None:
+    """Given grouped components that carry no id.
+
+    When comparing slots whose group operator flips.
+    Then members render by their name in the structure strings.
+    """
+    old_slot = [_group("OR", _comp(None, "Zebra"), _comp(None, "Ant"))]
+    new_slot = [_group("AND", _comp(None, "Ant"), _comp(None, "Zebra"))]
+
+    grouping = _grouping_change(compare_slot(old_slot, new_slot))
+
+    assert grouping is not None
+    assert grouping.old == "[OR : Ant, Zebra]"
+    assert grouping.new == "[AND: Ant, Zebra]"


### PR DESCRIPTION
Closes #236

## Summary
- Add the `compare_slot` seam (`src/nextlabs_sdk/_cli/_diff/_slot.py`): the diff engine now delegates per-slot comparison to it instead of flattening every component group into one identity set, so group operators are no longer discarded.
- `compare_slot` keeps today's order-free, identity-keyed membership diff and additionally emits one grouping change when the `(normalised-operator, members)` partition over the components present in **both** revisions drifts — a `FieldChange(kind="change")` on a `<slot>.grouping` path carrying canonical multi-line structure strings. The semantic renderer formats it as a `~ grouping` block; `--exit-code` and the unified format inherit it for free.
- Tested via comparator golden scenarios + design-agnostic invariants and CLI integration tests; no behaviour change to pure add/remove/version diffs.

## Tests added (red → green)
- `test_operator_flip_with_identical_members_yields_grouping_change`
- `test_operator_flip_render_uses_canonical_structure_strings`
- `test_in_place_version_change_stays_per_component_without_grouping`
- `test_pure_add_and_remove_stays_per_component_without_grouping`
- `test_combined_add_remove_and_operator_flip`
- `test_cross_group_move_surfaces_as_grouping_not_add_remove`
- `test_operator_case_and_whitespace_differences_are_ignored`
- `test_idless_components_render_by_name`
- `test_diff_reports_grouping_change_when_operator_flips`
- `test_diff_grouping_change_flips_exit_code`
- `test_diff_grouping_change_appears_in_unified_format`

## Notable assumptions
- Operator labels are left-padded to width 3 (`[OR : ...]` vs `[AND: ...]`) to vertically align brackets in the `was`/`now` blocks, matching the PRD worked example.
- Members render by name, falling back to `id=N` when a grouped component has no name; group order within a structure string is deterministic (sorted by member identity).
- Group membership is collected recursively through `subComponents` for identity resolution, consistent with `flatten_slot`, but nested structure is not itself surfaced as grouping (per PRD out-of-scope).
- ADR `docs/adr/0005` referenced by the issue is not authored here — the Files hint scopes this slice to the comparator, engine, renderer, and tests only.
