### PR TITLE
feat(diff): render grouping drift in unified format with semantic parity (#237)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -9,10 +9,13 @@ from difflib import unified_diff
 from rich.console import Console
 from rich.markup import escape
 
-from nextlabs_sdk._cli._diff._engine import canonicalise
-from nextlabs_sdk._cli._diff._models import DiffHeader
+from nextlabs_sdk._cli._diff._engine import canonicalise, diff_payloads
+from nextlabs_sdk._cli._diff._identity import COMPONENT_SLOT_FIELDS
+from nextlabs_sdk._cli._diff._models import DiffHeader, FieldChange
 
 _REVISION_LABEL = "revision"
+_OPERATOR_FIELD = "operator"
+_GROUPING_SEGMENT = "grouping"
 
 
 def render_unified(
@@ -27,7 +30,11 @@ def render_unified(
 
     Both revisions are canonicalised first (keys sorted on serialisation,
     arrays sorted by identity, noise stripped), so element re-ordering and
-    deployment noise produce no diff lines.
+    deployment noise produce no diff lines. Raw component-slot group operators
+    are dropped from the JSON body so cosmetic operator differences (case or
+    whitespace) never produce a line; genuine operator/grouping drift is
+    rendered as a structured block instead, keeping the unified output in
+    parity with the semantic format and ``--exit-code``.
 
     Args:
         old: The baseline alias-keyed policy payload.
@@ -35,7 +42,8 @@ def render_unified(
         header: The policy identity and compared revisions; the policy row is
             printed first and the ``--- / +++`` labels derive from its revision
             numbers.
-        show_all: When True, reveal ordering and noise differences.
+        show_all: When True, reveal ordering and noise differences and keep raw
+            group operators in the body.
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
@@ -53,11 +61,65 @@ def render_unified(
         lineterm="",
     ):
         con.print(_colourise(line), highlight=False)
+    if not show_all:
+        for change in _grouping_changes(old, new):
+            _render_grouping_change(con, change)
+
+
+def _grouping_changes(
+    old: Mapping[str, object], new: Mapping[str, object]
+) -> list[FieldChange]:
+    return [
+        change
+        for change in diff_payloads(old, new).changes
+        if change.path and change.path[-1] == _GROUPING_SEGMENT
+    ]
 
 
 def _canonical_lines(payload: Mapping[str, object], *, show_all: bool) -> list[str]:
     canonical = canonicalise(payload, show_all=show_all)
+    if not show_all:
+        canonical = _strip_slot_operators(canonical)
     return json.dumps(canonical, indent=2, sort_keys=True).splitlines()
+
+
+def _strip_slot_operators(canonical: object) -> object:
+    """Drop group ``operator`` keys from component slots in a canonical payload.
+
+    Group operators are surfaced via the structured grouping block, so leaving
+    them in the JSON body would double-report genuine flips and false-report
+    cosmetic case/whitespace differences that the semantic format ignores.
+    """
+    if not isinstance(canonical, Mapping):
+        return canonical
+    stripped: dict[str, object] = {}
+    for key, child in canonical.items():
+        if key in COMPONENT_SLOT_FIELDS and isinstance(child, list):
+            stripped[key] = [_strip_group_operator(group) for group in child]
+        else:
+            stripped[key] = child
+    return stripped
+
+
+def _strip_group_operator(group: object) -> object:
+    if not isinstance(group, Mapping):
+        return group
+    return {key: member for key, member in group.items() if key != _OPERATOR_FIELD}
+
+
+def _render_grouping_change(con: Console, change: FieldChange) -> None:
+    path = ".".join(str(segment) for segment in change.path)
+    _render_structure_lines(con, "-", path, change.old)
+    _render_structure_lines(con, "+", path, change.new)
+
+
+def _render_structure_lines(
+    con: Console, glyph: str, path: str, structure: object
+) -> None:
+    lines = str(structure).split("\n")
+    con.print(_colourise(f"{glyph}  {path}: {lines[0]}"))
+    for line in lines[1:]:
+        con.print(_colourise(f"{glyph}    {line}"))
 
 
 def _colourise(line: str) -> str:

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -770,3 +770,53 @@ def test_diff_grouping_change_appears_in_unified_format(
     output = strip_ansi(result.output)
     assert any(line.startswith("-") and "OR" in line for line in output.splitlines())
     assert any(line.startswith("+") and "AND" in line for line in output.splitlines())
+
+
+def test_diff_unified_renders_structured_grouping_block(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given a subject group operator flip, when running diff with --format
+    unified, then the grouping change renders as a structured block keyed by
+    the slot's grouping path rather than as a raw operator JSON line."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subject_groups(2, [_grouped("OR", _component(5, "Engineers"))])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subject_groups(3, [_grouped("AND", _component(5, "Engineers"))])
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "subjectComponents.grouping" in output
+    assert any(line.startswith("-") and "[OR" in line for line in output.splitlines())
+    assert any(line.startswith("+") and "[AND" in line for line in output.splitlines())
+    assert '"operator"' not in output
+
+
+def test_diff_unified_ignores_cosmetic_operator_change_matching_semantic(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose group operator differs only in case and
+    trailing whitespace (semantically identical), when running diff with
+    --format unified, then no operator change surfaces, matching the semantic
+    format which reports no change and a zero exit code."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2), _entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_subject_groups(2, [_grouped("OR", _component(5, "Engineers"))])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_subject_groups(3, [_grouped("or ", _component(5, "Engineers"))])
+    )
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified", "--exit-code"],
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "operator" not in output
+    assert "grouping" not in output


### PR DESCRIPTION
Closes #237

## Summary
- Made `policies diff --format unified` surface group operator/grouping drift as a structured `<slot>.grouping: [OP: members]` block (rendered with git-style `-`/`+` glyphs), reusing the same structure strings as the semantic format.
- Stripped raw component-slot group `operator` keys from the unified JSON body (non `--show-all`) so cosmetic case/whitespace operator differences no longer disagree with the semantic format or `--exit-code`.
- Verified by the full suite (2424 passed); no public renderer signature change.

## Tests added (red → green)
- `test_diff_unified_renders_structured_grouping_block`
- `test_diff_unified_ignores_cosmetic_operator_change_matching_semantic`

## Notable assumptions
- Unified grouping render reuses `compare_slot`'s structure strings and is emitted after the JSON body as `-  <slot>.grouping: [OP: members]` / `+ ...` lines.
- `render_unified` recomputes `diff_payloads` internally (gated on non `--show-all`) rather than receiving grouping changes from the command, keeping its signature unchanged.
