### PR TITLE
fix(PRD): #235 cleanup — capstone findings

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_identity.py
+++ b/src/nextlabs_sdk/_cli/_diff/_identity.py
@@ -10,7 +10,7 @@ matched identically.
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Iterator, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TypeAlias
@@ -106,19 +106,32 @@ def identity_key(schema_type: str, element: Mapping[str, object]) -> Hashable | 
     return resolver(element)
 
 
-def _collect_component(
+def walk_group_components(
+    group: Mapping[str, object],
+) -> Iterator[Mapping[str, object]]:
+    """Yield every component in a group, descending into nested subComponents.
+
+    This is the single traversal of the component-group shape (``components``
+    holding ``ComponentDTORes`` elements, each reachable sub-tree under
+    ``subComponents``). Callers that key components by identity or summarise
+    them share this walk so schema-shape changes touch one place.
+
+    Args:
+        group: An alias-keyed component group (a mapping with ``components``).
+
+    Yields:
+        Each component mapping in the group, including nested subcomponents.
+    """
+    for component in _as_mappings(group.get("components")):
+        yield from _walk_component(component)
+
+
+def _walk_component(
     component: Mapping[str, object],
-    collected: dict[Hashable, ComponentSummary],
-) -> None:
-    key = identity_key("ComponentDTORes", component)
-    if key is not None and key not in collected:
-        collected[key] = ComponentSummary(
-            component_id=_as_int(component.get("id")),
-            name=_as_str(component.get("name")),
-            version=_as_int(component.get("version")),
-        )
+) -> Iterator[Mapping[str, object]]:
+    yield component
     for sub in _as_mappings(component.get("subComponents")):
-        _collect_component(sub, collected)
+        yield from _walk_component(sub)
 
 
 def flatten_slot(slot_value: object) -> dict[Hashable, ComponentSummary]:
@@ -136,8 +149,14 @@ def flatten_slot(slot_value: object) -> dict[Hashable, ComponentSummary]:
     """
     collected: dict[Hashable, ComponentSummary] = {}
     for group in _as_mappings(slot_value):
-        for component in _as_mappings(group.get("components")):
-            _collect_component(component, collected)
+        for component in walk_group_components(group):
+            key = identity_key("ComponentDTORes", component)
+            if key is not None and key not in collected:
+                collected[key] = ComponentSummary(
+                    component_id=_as_int(component.get("id")),
+                    name=_as_str(component.get("name")),
+                    version=_as_int(component.get("version")),
+                )
     return collected
 
 

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -4,24 +4,44 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from difflib import unified_diff
 
 from rich.console import Console
 from rich.markup import escape
 
-from nextlabs_sdk._cli._diff._engine import canonicalise, diff_payloads
+from nextlabs_sdk._cli._diff._engine import canonicalise
 from nextlabs_sdk._cli._diff._identity import COMPONENT_SLOT_FIELDS
-from nextlabs_sdk._cli._diff._models import DiffHeader, FieldChange
+from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
 
 _REVISION_LABEL = "revision"
 _OPERATOR_FIELD = "operator"
 _GROUPING_SEGMENT = "grouping"
 
 
+@dataclass(frozen=True)
+class UnifiedDiffInput:
+    """Inputs for a unified render of one policy revision pair.
+
+    Bundles the raw payloads (rendered as the JSON body), the identity header
+    (labels), and the engine-computed delta (the source of grouping drift), so
+    the renderer never recomputes the comparison it is handed.
+
+    Attributes:
+        old: The baseline alias-keyed policy payload.
+        new: The revised alias-keyed policy payload.
+        header: The policy identity and the compared revision numbers.
+        diff_result: The structured delta already computed for this pair.
+    """
+
+    old: Mapping[str, object]
+    new: Mapping[str, object]
+    header: DiffHeader
+    diff_result: DiffResult
+
+
 def render_unified(
-    old: Mapping[str, object],
-    new: Mapping[str, object],
-    header: DiffHeader,
+    diff: UnifiedDiffInput,
     *,
     show_all: bool = False,
     console: Console | None = None,
@@ -37,20 +57,19 @@ def render_unified(
     parity with the semantic format and ``--exit-code``.
 
     Args:
-        old: The baseline alias-keyed policy payload.
-        new: The revised alias-keyed policy payload.
-        header: The policy identity and compared revisions; the policy row is
-            printed first and the ``--- / +++`` labels derive from its revision
-            numbers.
+        diff: The revision payloads, identity header, and engine-computed delta
+            to render; grouping drift is read from ``diff.diff_result`` rather
+            than recomputed, so the renderer shares one comparison source.
         show_all: When True, reveal ordering and noise differences and keep raw
             group operators in the body.
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
+    header = diff.header
     con.print(f"Policy: {header.policy_name} (id={header.policy_id})")
     con.print()
-    old_lines = _canonical_lines(old, show_all=show_all)
-    new_lines = _canonical_lines(new, show_all=show_all)
+    old_lines = _canonical_lines(diff.old, show_all=show_all)
+    new_lines = _canonical_lines(diff.new, show_all=show_all)
     from_label = f"{_REVISION_LABEL} {header.from_rev}"
     to_label = f"{_REVISION_LABEL} {header.to_rev}"
     for line in unified_diff(
@@ -62,16 +81,14 @@ def render_unified(
     ):
         con.print(_colourise(line), highlight=False)
     if not show_all:
-        for change in _grouping_changes(old, new):
+        for change in _grouping_changes(diff.diff_result):
             _render_grouping_change(con, change)
 
 
-def _grouping_changes(
-    old: Mapping[str, object], new: Mapping[str, object]
-) -> list[FieldChange]:
+def _grouping_changes(diff_result: DiffResult) -> list[FieldChange]:
     return [
         change
-        for change in diff_payloads(old, new).changes
+        for change in diff_result.changes
         if change.path and change.path[-1] == _GROUPING_SEGMENT
     ]
 

--- a/src/nextlabs_sdk/_cli/_diff/_slot.py
+++ b/src/nextlabs_sdk/_cli/_diff/_slot.py
@@ -16,8 +16,10 @@ from typing import Literal, TypeAlias
 
 from nextlabs_sdk._cli._diff._identity import (
     ComponentSummary,
+    _as_mappings,
     flatten_slot,
     identity_key,
+    walk_group_components,
 )
 from nextlabs_sdk._cli._diff._models import FieldChange
 
@@ -28,8 +30,6 @@ _KIND_CHANGE: Literal["change"] = "change"
 _GROUPING_SEGMENT = "grouping"
 _SCHEMA_TYPE = "ComponentDTORes"
 _OPERATOR_FIELD = "operator"
-_COMPONENTS_FIELD = "components"
-_SUBCOMPONENTS_FIELD = "subComponents"
 _OPERATOR_WIDTH = 3
 _UNKNOWN_MEMBER = "?"
 
@@ -110,7 +110,7 @@ def _grouping_change(
 
 def _partition(slot_value: object, shared: frozenset[Hashable]) -> list[_Group]:
     groups: list[_Group] = []
-    for group in _mappings(slot_value):
+    for group in _as_mappings(slot_value):
         operator = group.get(_OPERATOR_FIELD)
         operator_str = operator if isinstance(operator, str) else ""
         members = frozenset(key for key in _group_identities(group) if key in shared)
@@ -127,17 +127,11 @@ def _normalised(groups: list[_Group]) -> frozenset[_Group]:
 
 def _group_identities(group: Mapping[str, object]) -> set[Hashable]:
     keys: set[Hashable] = set()
-    for component in _mappings(group.get(_COMPONENTS_FIELD)):
-        _collect_identities(component, keys)
+    for component in walk_group_components(group):
+        key = identity_key(_SCHEMA_TYPE, component)
+        if key is not None:
+            keys.add(key)
     return keys
-
-
-def _collect_identities(component: Mapping[str, object], keys: set[Hashable]) -> None:
-    key = identity_key(_SCHEMA_TYPE, component)
-    if key is not None:
-        keys.add(key)
-    for sub in _mappings(component.get(_SUBCOMPONENTS_FIELD)):
-        _collect_identities(sub, keys)
 
 
 def _render_structure(groups: list[_Group], summaries: _Summaries) -> str:
@@ -175,9 +169,3 @@ def _group_sort_key(group: _Group) -> tuple[list[str], str]:
 
 def _identity_sort_key(key: Hashable) -> str:
     return str(key)
-
-
-def _mappings(value: object) -> list[Mapping[str, object]]:  # noqa: WPS110
-    if not isinstance(value, list):
-        return []
-    return [element for element in value if isinstance(element, Mapping)]

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -658,9 +658,12 @@ def diff(  # noqa: WPS211
         print(json.dumps(_models.diff_result_to_dict(diff_result), indent=2))
     elif diff_format is _format.DiffFormat.UNIFIED:
         _render_unified.render_unified(
-            old_payload,
-            new_payload,
-            header,
+            _render_unified.UnifiedDiffInput(
+                old=old_payload,
+                new=new_payload,
+                header=header,
+                diff_result=diff_result,
+            ),
             show_all=show_all,
         )
     else:

--- a/tests/test_policy_diff_unified.py
+++ b/tests/test_policy_diff_unified.py
@@ -6,8 +6,9 @@ from typing import Any
 from rich.console import Console
 from strip_ansi import strip_ansi
 
+from nextlabs_sdk._cli._diff._engine import diff_payloads
 from nextlabs_sdk._cli._diff._models import DiffHeader
-from nextlabs_sdk._cli._diff._render_unified import render_unified
+from nextlabs_sdk._cli._diff._render_unified import UnifiedDiffInput, render_unified
 
 _HEADER = DiffHeader(policy_name="P", policy_id=82, from_rev=2, to_rev=3)
 
@@ -15,10 +16,9 @@ _HEADER = DiffHeader(policy_name="P", policy_id=82, from_rev=2, to_rev=3)
 def _render(old: dict[str, Any], new: dict[str, Any], **kwargs: Any) -> str:
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, width=200)
+    diff_result = diff_payloads(old, new, show_all=kwargs.get("show_all", False))
     render_unified(
-        old,
-        new,
-        _HEADER,
+        UnifiedDiffInput(old=old, new=new, header=_HEADER, diff_result=diff_result),
         console=console,
         **kwargs,
     )


### PR DESCRIPTION
Addresses capstone findings from the local `<prd-review>` for PRD #235 (operator/grouping-aware `policies diff`).

Finding IDs addressed:
  - F1 (high): unified renderer recomputed `diff_payloads` instead of consuming the already-computed `DiffResult` from the command flow. The renderer now takes a `UnifiedDiffInput` bundle carrying the engine's `DiffResult`, so engine and renderer share one comparison source of truth.
  - F2 (medium): component-slot traversal was duplicated between `_identity` (summary collection) and `_slot` (identity-key collection). Both now share a single `walk_group_components` walker, so the components/subComponents schema shape lives in one place.

Finding IDs skipped: none.

No behavior change — existing diff suite (66 tests across slot/identity/unified/CLI) and the full unit suite (2424 passed) remain green.

Closes #235 (capstone cleanup).