### PR TITLE
feat(diff): cross-policy diff core (diff A B)

### DIFF
--- a/docs/adr/0006-cross-policy-comparison.md
+++ b/docs/adr/0006-cross-policy-comparison.md
@@ -1,0 +1,81 @@
+# ADR 0006: Cross-policy comparison
+
+## Status
+
+Accepted
+
+## Context
+
+The `policies diff` command compares two revisions of a single policy. A new
+demand is to compare two *different* policies — answering "how do these two
+policies differ in what they actually enforce?" rather than "how did this one
+policy change between deployments?".
+
+Two policies always differ in their identity attributes: each has its own
+`id`, `name`, `fullName`, folder placement, version counters and owner. A
+naive reuse of the revision-diff engine would drown the meaningful payload
+delta (subjects, actions, conditions, obligations, tags) under a wall of
+identity noise that is true by construction and tells the reader nothing.
+
+We need a comparison mode that suppresses cross-policy identity noise while
+preserving every genuine difference in policy content, including differences
+nested inside components, obligations and tags — two policies may legitimately
+share a component name while differing in its expression, and that difference
+must survive.
+
+## Decision Drivers
+
+* Reuse the existing `diff_payloads` engine and renderers rather than forking
+  a parallel comparison path.
+* Keep the command surface small and predictable; avoid a proliferation of
+  flags.
+* Suppress only the identity noise that is true by construction, never genuine
+  policy-content differences.
+* Keep the strip behaviour inspectable: a user must be able to see the full,
+  unstripped picture on demand.
+
+## Decision
+
+Extend `policies diff` with an **optional second positional policy id**. Arity
+selects the mode: `diff A` keeps the existing single-policy revision diff;
+`diff A B` enters cross-policy mode. Mode is never chosen by a flag.
+
+In cross-policy mode:
+
+* Each side resolves its revision independently — latest deployed by default.
+  `--from` selects policy A's revision and `--to` selects policy B's; the
+  revision flags are not renamed and gain no aliases.
+* Before diffing, a **fixed built-in set** of top-level identity fields is
+  stripped from each payload:
+  `id`, `name`, `fullName`, `folderId`, `parentId`, `parentName`, `version`,
+  `revisionCount`, `ownerId`, `ownerDisplayName`. The constant is
+  `_CROSS_POLICY_IDENTITY_FIELDS`. There is no user-override flag in this
+  iteration.
+* The strip is **top-level only**. Nested components, obligations and tags are
+  never stripped, so a renamed component or a changed expression still
+  surfaces.
+* Stripped fields are **silent**: removed before diffing, so they neither
+  render as changes nor count toward the hidden-noise total.
+* The strip applies only when `--show-all` is off. `--show-all` reveals every
+  stripped identity field, exactly as it already reveals noise fields.
+* The diff header shows both policy identities (name and id per side) plus a
+  short note that identity fields were ignored.
+* `--format`, `--exit-code` and the JSON output behave identically in both
+  modes; `--exit-code` reflects post-strip differences.
+
+The strip is implemented as a shallow filter in the engine
+(`diff_payloads(..., cross_policy=True)`), with the unified renderer applying
+the same top-level filter to its JSON body so both human formats stay in
+parity.
+
+## Consequences
+
+* Cross-policy comparison reuses one comparison engine and both renderers; the
+  only new surface is one optional positional argument and one engine flag.
+* The identity strip set is a fixed constant, so behaviour is predictable and
+  documented; broadening it (or making it user-configurable) is a deliberate
+  future decision rather than an accident.
+* Because the strip is top-level only, genuine content differences — including
+  those nested inside identically-named components — are never hidden.
+* `--show-all` remains the single escape hatch for seeing the complete,
+  unfiltered comparison, keeping the suppression inspectable.

--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -35,6 +35,21 @@ _NOISE_FIELDS: frozenset[str] = frozenset(
     )
 )
 
+_CROSS_POLICY_IDENTITY_FIELDS: frozenset[str] = frozenset(
+    (
+        "id",
+        "name",
+        "fullName",
+        "folderId",
+        "parentId",
+        "parentName",
+        "version",
+        "revisionCount",
+        "ownerId",
+        "ownerDisplayName",
+    )
+)
+
 
 def canonicalise(payload: Mapping[str, object], *, show_all: bool = False) -> object:
     """Reduce a policy payload to a stable, comparison-ready form.
@@ -86,6 +101,7 @@ def diff_payloads(
     new: Mapping[str, object],
     *,
     show_all: bool = False,
+    cross_policy: bool = False,
 ) -> DiffResult:
     """Compare two alias-keyed policy payload dicts and return a structured delta.
 
@@ -94,11 +110,18 @@ def diff_payloads(
         new: The revised policy payload (alias-keyed JSON dict).
         show_all: When True, disables noise filtering and array-order
             normalisation so every raw difference is reported.
+        cross_policy: When True, drop the top-level policy identity fields from
+            each side before diffing so they never surface as changes. Nested
+            structures are untouched. Ignored when ``show_all`` is set.
 
     Returns:
         A DiffResult with all detected changes and a count of suppressed
         noise-field differences.
     """
+    if cross_policy and not show_all:
+        old = _strip_identity_fields(old)
+        new = _strip_identity_fields(new)
+
     changes: list[FieldChange] = []
 
     _diff_dicts(old, new, path=(), show_all=show_all, changes=changes)
@@ -116,6 +139,20 @@ def diff_payloads(
         changes=tuple(visible_changes),
         hidden_noise_count=hidden_noise_count,
     )
+
+
+def _strip_identity_fields(payload: Mapping[str, object]) -> dict[str, object]:
+    """Drop top-level cross-policy identity fields from a payload.
+
+    The strip is shallow on purpose: only the policy's own identity attributes
+    are removed, so nested components, obligations and tags keep their own
+    identity fields and still diff normally.
+    """
+    return {
+        key: child
+        for key, child in payload.items()
+        if key not in _CROSS_POLICY_IDENTITY_FIELDS
+    }
 
 
 def _diff_dicts(

--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -26,12 +26,25 @@ class DiffResult:
 
 @dataclass(frozen=True)
 class DiffHeader:
-    """Identity of a policy diff: the policy and the two compared revisions."""
+    """Identity of a policy diff: the policy and the two compared revisions.
+
+    In cross-policy mode the two sides are different policies. ``policy_name``
+    and ``policy_id`` then describe side A (the ``from`` policy) and
+    ``to_policy_name``/``to_policy_id`` describe side B (the ``to`` policy); both
+    are ``None`` for a single-policy revision diff.
+    """
 
     policy_name: str
     policy_id: int
     from_rev: int
     to_rev: int
+    to_policy_name: str | None = None
+    to_policy_id: int | None = None
+
+    @property
+    def is_cross_policy(self) -> bool:
+        """Whether this header compares two distinct policies."""
+        return self.to_policy_id is not None
 
 
 def _to_jsonable(value: object) -> object:  # noqa: WPS110

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -21,6 +21,27 @@ _POLICY_LABEL = "Policy:"
 _ARROW = "\u2192"
 _GROUPING_SEGMENT = "grouping"
 _CONTINUATION_PREFIX = "AND "
+_IDENTITY_NOTE = "identity fields ignored"
+
+
+def _render_header(con: Console, header: DiffHeader) -> None:
+    """Print the identity header for a single- or cross-policy diff."""
+    if header.is_cross_policy:
+        con.print(
+            f"[bold]A:[/bold] {header.policy_name} (id={header.policy_id}) "
+            f"revision {header.from_rev}"
+        )
+        con.print(
+            f"[bold]B:[/bold] {header.to_policy_name} (id={header.to_policy_id}) "
+            f"revision {header.to_rev}"
+        )
+        con.print(f"[dim]{_IDENTITY_NOTE}[/dim]")
+    else:
+        con.print(
+            f"[bold]{_POLICY_LABEL}[/bold] {header.policy_name} "
+            f"(id={header.policy_id})"
+        )
+        con.print(f"Comparing revisions {header.from_rev} {_ARROW} {header.to_rev}")
 
 
 def _format_component(summary: ComponentSummary | None) -> str:
@@ -180,10 +201,7 @@ def render_semantic(
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
-    con.print(
-        f"[bold]{_POLICY_LABEL}[/bold] {header.policy_name} (id={header.policy_id})"
-    )
-    con.print(f"Comparing revisions {header.from_rev} {_ARROW} {header.to_rev}")
+    _render_header(con, header)
     con.print()
 
     sections: dict[str, list[FieldChange]] = {}

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -10,13 +10,14 @@ from difflib import unified_diff
 from rich.console import Console
 from rich.markup import escape
 
-from nextlabs_sdk._cli._diff._engine import canonicalise
+from nextlabs_sdk._cli._diff._engine import _CROSS_POLICY_IDENTITY_FIELDS, canonicalise
 from nextlabs_sdk._cli._diff._identity import COMPONENT_SLOT_FIELDS
 from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
 
 _REVISION_LABEL = "revision"
 _OPERATOR_FIELD = "operator"
 _GROUPING_SEGMENT = "grouping"
+_IDENTITY_NOTE = "identity fields ignored"
 
 
 @dataclass(frozen=True)
@@ -66,10 +67,11 @@ def render_unified(
     """
     con = Console() if console is None else console
     header = diff.header
-    con.print(f"Policy: {header.policy_name} (id={header.policy_id})")
+    _render_unified_header(con, header)
     con.print()
-    old_lines = _canonical_lines(diff.old, show_all=show_all)
-    new_lines = _canonical_lines(diff.new, show_all=show_all)
+    cross_policy = header.is_cross_policy
+    old_lines = _canonical_lines(diff.old, show_all=show_all, cross_policy=cross_policy)
+    new_lines = _canonical_lines(diff.new, show_all=show_all, cross_policy=cross_policy)
     from_label = f"{_REVISION_LABEL} {header.from_rev}"
     to_label = f"{_REVISION_LABEL} {header.to_rev}"
     for line in unified_diff(
@@ -85,6 +87,15 @@ def render_unified(
             _render_grouping_change(con, change)
 
 
+def _render_unified_header(con: Console, header: DiffHeader) -> None:
+    if header.is_cross_policy:
+        con.print(f"A: {header.policy_name} (id={header.policy_id})")
+        con.print(f"B: {header.to_policy_name} (id={header.to_policy_id})")
+        con.print(f"({_IDENTITY_NOTE})")
+    else:
+        con.print(f"Policy: {header.policy_name} (id={header.policy_id})")
+
+
 def _grouping_changes(diff_result: DiffResult) -> list[FieldChange]:
     return [
         change
@@ -93,11 +104,30 @@ def _grouping_changes(diff_result: DiffResult) -> list[FieldChange]:
     ]
 
 
-def _canonical_lines(payload: Mapping[str, object], *, show_all: bool) -> list[str]:
+def _canonical_lines(
+    payload: Mapping[str, object], *, show_all: bool, cross_policy: bool = False
+) -> list[str]:
     canonical = canonicalise(payload, show_all=show_all)
     if not show_all:
         canonical = _strip_slot_operators(canonical)
+        if cross_policy:
+            canonical = _strip_identity_fields(canonical)
     return json.dumps(canonical, indent=2, sort_keys=True).splitlines()
+
+
+def _strip_identity_fields(canonical: object) -> object:
+    """Drop top-level cross-policy identity keys from a canonical payload.
+
+    Mirrors the engine strip so the unified JSON body never renders identity
+    fields that the structured diff already suppresses in cross-policy mode.
+    """
+    if not isinstance(canonical, Mapping):
+        return canonical
+    return {
+        key: child
+        for key, child in canonical.items()
+        if key not in _CROSS_POLICY_IDENTITY_FIELDS
+    }
 
 
 def _strip_slot_operators(canonical: object) -> object:

--- a/src/nextlabs_sdk/_cli/_diff/_revision_select.py
+++ b/src/nextlabs_sdk/_cli/_diff/_revision_select.py
@@ -72,6 +72,55 @@ def _deployed_newest_first(
     )
 
 
+def select_policy_revision(
+    policies: PolicyService,
+    policy_id: int,
+    *,
+    revision: int | None = None,
+) -> PolicyRevision:
+    """Resolve a single policy revision for one side of a cross-policy diff.
+
+    Each side of a cross-policy comparison resolves independently: the latest
+    deployed revision by default, or an explicit revision number when given.
+
+    Args:
+        policies: The policy service used to query history and fetch revisions.
+        policy_id: The policy whose revision is being resolved.
+        revision: Explicit revision number. When given, bypasses the
+            deployed-only filter; otherwise the newest deployed revision wins.
+
+    Returns:
+        The resolved :class:`PolicyRevision`, fetched via the history entry's
+        own ``id``.
+
+    Raises:
+        InsufficientRevisionsError: When no revision can be auto-selected
+            because the policy has no deployed revision and none was supplied.
+        UnknownRevisionError: When an explicit revision number is absent from
+            the policy's history.
+    """
+    entries = policies.list_history(policy_id)
+    by_revision = {entry.revision: entry for entry in entries}
+    resolved = _resolve_latest(entries, policy_id, revision)
+    entry = _require_entry(by_revision, policy_id, resolved)
+    return policies.get_revision(entry.id, entry.revision)
+
+
+def _resolve_latest(
+    entries: list[PolicyHistoryEntry],
+    policy_id: int,
+    revision: int | None,
+) -> int:
+    if revision is not None:
+        return revision
+    deployed = _deployed_newest_first(entries)
+    if not deployed:
+        raise InsufficientRevisionsError(
+            f"Policy {policy_id} has no deployed revision to compare."
+        )
+    return deployed[0].revision
+
+
 def _resolve_to(
     entries: list[PolicyHistoryEntry],
     policy_id: int,

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -23,6 +23,7 @@ from nextlabs_sdk._cli._diff import (
 from nextlabs_sdk._cli._diff._revision_select import (
     InsufficientRevisionsError,
     UnknownRevisionError,
+    select_policy_revision,
     select_revisions,
 )
 from nextlabs_sdk._cli._error_handler import cli_error_handler
@@ -34,7 +35,8 @@ from nextlabs_sdk._cli._payload_loader import (
     reject_data_flag,
     require_payload,
 )
-from nextlabs_sdk._cloudaz._policy_models import Policy
+from nextlabs_sdk._cloudaz._policies import PolicyService
+from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyRevision
 from nextlabs_sdk._cloudaz._search import SearchCriteria
 
 policies_app = make_group("Policy management commands")
@@ -614,6 +616,10 @@ register_detail_renderer(Policy, _render_policy_detail)
 def diff(  # noqa: WPS211
     ctx: typer.Context,
     policy_id: Annotated[int, typer.Argument(help="Policy ID")],
+    policy_id_b: Annotated[
+        int | None,
+        typer.Argument(help="Second policy ID; when given, compares the two policies"),
+    ] = None,
     from_rev: Annotated[
         int | None, typer.Option("--from", help="Override the 'from' revision")
     ] = None,
@@ -635,25 +641,33 @@ def diff(  # noqa: WPS211
         ),
     ] = False,
 ) -> None:
-    """Show a diff between two revisions of a policy."""
+    """Show a diff between two revisions of a policy, or between two policies.
+
+    With one policy id, compares two revisions of that policy. With a second
+    policy id, compares each policy's latest revision (``--from`` selects the
+    first policy's revision, ``--to`` the second's), ignoring top-level identity
+    fields.
+    """
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
+    cross_policy = policy_id_b is not None
     try:
-        old, new = select_revisions(
-            client.policies, policy_id, from_rev=from_rev, to_rev=to_rev
+        old, new = _resolve_diff_revisions(
+            client.policies,
+            policy_id,
+            policy_id_b,
+            from_rev=from_rev,
+            to_rev=to_rev,
         )
     except (InsufficientRevisionsError, UnknownRevisionError) as exc:
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
     old_payload = old.policy_detail.model_dump(mode="json", by_alias=True)
     new_payload = new.policy_detail.model_dump(mode="json", by_alias=True)
-    diff_result = _engine.diff_payloads(old_payload, new_payload, show_all=show_all)
-    header = _models.DiffHeader(
-        policy_name=new.policy_detail.name,
-        policy_id=new.policy_detail.id,
-        from_rev=old.revision,
-        to_rev=new.revision,
+    diff_result = _engine.diff_payloads(
+        old_payload, new_payload, show_all=show_all, cross_policy=cross_policy
     )
+    header = _build_diff_header(old, new, cross_policy=cross_policy)
     if cli_ctx.output_format is OutputFormat.JSON:
         print(json.dumps(_models.diff_result_to_dict(diff_result), indent=2))
     elif diff_format is _format.DiffFormat.UNIFIED:
@@ -670,3 +684,38 @@ def diff(  # noqa: WPS211
         _render_semantic.render_semantic(diff_result, header)
     if exit_code and diff_result.changes:
         raise typer.Exit(code=1)
+
+
+def _resolve_diff_revisions(
+    policies: PolicyService,
+    policy_id: int,
+    policy_id_b: int | None,
+    *,
+    from_rev: int | None,
+    to_rev: int | None,
+) -> tuple[PolicyRevision, PolicyRevision]:
+    if policy_id_b is None:
+        return select_revisions(policies, policy_id, from_rev=from_rev, to_rev=to_rev)
+    old = select_policy_revision(policies, policy_id, revision=from_rev)
+    new = select_policy_revision(policies, policy_id_b, revision=to_rev)
+    return old, new
+
+
+def _build_diff_header(
+    old: PolicyRevision, new: PolicyRevision, *, cross_policy: bool
+) -> _models.DiffHeader:
+    if cross_policy:
+        return _models.DiffHeader(
+            policy_name=old.policy_detail.name,
+            policy_id=old.policy_detail.id,
+            from_rev=old.revision,
+            to_rev=new.revision,
+            to_policy_name=new.policy_detail.name,
+            to_policy_id=new.policy_detail.id,
+        )
+    return _models.DiffHeader(
+        policy_name=new.policy_detail.name,
+        policy_id=new.policy_detail.id,
+        from_rev=old.revision,
+        to_rev=new.revision,
+    )

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -820,3 +820,225 @@ def test_diff_unified_ignores_cosmetic_operator_change_matching_semantic(
     output = strip_ansi(result.output)
     assert "operator" not in output
     assert "grouping" not in output
+
+
+def _cross_revision(
+    policy_id: int,
+    name: str,
+    revision: int,
+    description: str = "d",
+    components: list[dict[str, Any]] | None = None,
+) -> PolicyRevision:
+    payload: dict[str, Any] = {
+        "id": policy_id,
+        "name": name,
+        "status": "DRAFT",
+        "effectType": "ALLOW",
+        "description": description,
+    }
+    if components is not None:
+        payload["subjectComponents"] = [{"operator": "AND", "components": components}]
+    return PolicyRevision(
+        id=policy_id * 10,
+        revision=revision,
+        action_type="DE",
+        policy_detail=Policy.model_validate(payload),
+    )
+
+
+def test_diff_two_policies_compares_latest_revisions_semantic(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policy ids each with deployed revisions, when running
+    diff with two positional ids, then it compares each policy's latest revision
+    and renders a semantic diff of their bodies."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(1), _entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=5, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 5).thenReturn(
+        _cross_revision(20, "Beta", 5, description="write")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "description" in output
+    assert "read" in output and "write" in output
+
+
+def test_diff_cross_policy_strips_top_level_identity_fields(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies that differ only in top-level identity fields, when
+    running cross-policy diff, then those identity fields never appear as
+    changes."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="same")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="same")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    change_lines = [
+        line
+        for line in output.splitlines()
+        if line.lstrip().startswith(("~", "+", "-"))
+    ]
+    assert not any("name" in line or "id" in line for line in change_lines)
+
+
+def test_diff_cross_policy_header_shows_both_identities(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policies, when running cross-policy diff, then the
+    header shows both policy identities (name and id for each side)."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=5, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 5).thenReturn(
+        _cross_revision(20, "Beta", 5, description="write")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Alpha (id=10)" in output
+    assert "Beta (id=20)" in output
+
+
+def test_diff_cross_policy_nested_difference_surfaces(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies whose only difference is a nested component name, when
+    running cross-policy diff, then the nested difference still surfaces."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, components=[_component(5, "Engineers")])
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, components=[_component(5, "Managers")])
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "Engineers" in output or "Managers" in output
+
+
+def test_diff_cross_policy_from_to_select_each_side_revision(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies, when running cross-policy diff with --from and --to,
+    then --from selects policy A's revision and --to selects policy B's."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn(
+        [PolicyHistoryEntry(id=100, revision=1, action_type="DR")]
+    )
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=7, action_type="DR")]
+    )
+    when(mock_policies).get_revision(100, 1).thenReturn(
+        _cross_revision(10, "Alpha", 1, description="read")
+    )
+    when(mock_policies).get_revision(200, 7).thenReturn(
+        _cross_revision(20, "Beta", 7, description="write")
+    )
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "diff", "10", "20", "--from", "1", "--to", "7"],
+    )
+    assert result.exit_code == 0
+    assert "write" in strip_ansi(result.output)
+
+
+def test_diff_cross_policy_exit_code_nonzero_on_post_strip_difference(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies that differ only in identity fields, when running
+    cross-policy diff with --exit-code, then it exits zero because the only
+    differences were stripped; a genuine body difference exits non-zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="same")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="same")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20", "--exit-code"]
+    )
+    assert result.exit_code == 0
+
+
+def test_diff_cross_policy_exit_code_nonzero_when_body_differs(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies whose bodies differ, when running cross-policy diff
+    with --exit-code, then it exits non-zero."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20", "--exit-code"]
+    )
+    assert result.exit_code == 1
+
+
+def test_diff_cross_policy_unified_header_and_strips_identity(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two policies differing in identity fields and description, when
+    running cross-policy diff with --format unified, then the header names both
+    policies and the identity fields never appear as unified diff lines while
+    the body difference does."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "A: Alpha (id=10)" in output
+    assert "B: Beta (id=20)" in output
+    diff_lines = [line for line in output.splitlines() if line.startswith(("+", "-"))]
+    assert not any('"name"' in line or '"id"' in line for line in diff_lines)
+    assert any("write" in line and line.startswith("+") for line in diff_lines)

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -154,3 +154,91 @@ def test_tag_changes_serialise_per_element():
     # then
     assert tag_entries
     assert tag_entries[0]["new"] == {"key": "fresh", "label": "FRESH"}
+
+
+from nextlabs_sdk._cli._diff._engine import _CROSS_POLICY_IDENTITY_FIELDS
+
+
+def test_cross_policy_strips_top_level_identity_fields():
+    """Given two policies differing in top-level identity fields and one body field.
+
+    When diffing in cross-policy mode without show_all.
+    Then identity fields never surface and are not counted as noise; only the
+        genuine body difference is reported.
+    """
+    # given
+    old = {
+        "id": 1,
+        "name": "Alpha",
+        "fullName": "/Alpha",
+        "folderId": 7,
+        "parentId": 3,
+        "parentName": "root",
+        "version": 2,
+        "revisionCount": 5,
+        "ownerId": 11,
+        "ownerDisplayName": "Ann",
+        "description": "read",
+    }
+    new = {
+        "id": 2,
+        "name": "Beta",
+        "fullName": "/Beta",
+        "folderId": 9,
+        "parentId": 4,
+        "parentName": "other",
+        "version": 8,
+        "revisionCount": 1,
+        "ownerId": 22,
+        "ownerDisplayName": "Bob",
+        "description": "write",
+    }
+
+    result = diff_payloads(old, new, cross_policy=True)
+
+    paths = {change.path[0] for change in result.changes}
+    assert paths == {"description"}
+    assert _CROSS_POLICY_IDENTITY_FIELDS & paths == set()
+    assert result.hidden_noise_count == 0
+
+
+def test_cross_policy_keeps_nested_identity_like_fields():
+    """Given two policies whose only difference is a nested component name.
+
+    When diffing in cross-policy mode.
+    Then the nested name change still surfaces, proving the strip is top-level only.
+    """
+    # given
+    old = {
+        "id": 1,
+        "name": "Alpha",
+        "subjectComponents": [
+            {"operator": "AND", "components": [{"id": 5, "name": "Old", "version": 1}]}
+        ],
+    }
+    new = {
+        "id": 2,
+        "name": "Beta",
+        "subjectComponents": [
+            {"operator": "AND", "components": [{"id": 5, "name": "New", "version": 1}]}
+        ],
+    }
+
+    result = diff_payloads(old, new, cross_policy=True)
+
+    assert any(c.path and c.path[0] == "subjectComponents" for c in result.changes)
+
+
+def test_cross_policy_show_all_reveals_identity_fields():
+    """Given two policies differing in a top-level identity field.
+
+    When diffing in cross-policy mode with show_all.
+    Then the identity field difference is revealed.
+    """
+    # given
+    old = {"id": 1, "name": "Alpha", "description": "x"}
+    new = {"id": 2, "name": "Beta", "description": "x"}
+
+    result = diff_payloads(old, new, cross_policy=True, show_all=True)
+
+    assert any(c.path == ("name",) for c in result.changes)

--- a/tests/test_policy_diff_revision_select.py
+++ b/tests/test_policy_diff_revision_select.py
@@ -115,3 +115,65 @@ def test_fewer_than_two_comparable_raises():
     # when / then
     with pytest.raises(InsufficientRevisionsError):
         select_revisions(policies, POLICY_ID)
+
+
+from nextlabs_sdk._cli._diff._revision_select import select_policy_revision
+
+
+def test_select_policy_revision_defaults_to_latest_deployed():
+    """Given a policy whose history has several deployed revisions.
+
+    When resolving a single side with no explicit revision.
+    Then the newest deployed revision is fetched via its own entry id.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [
+            _entry(1, entry_id=101),
+            _entry(3, entry_id=103),
+            _entry(2, entry_id=102),
+            _entry(4, entry_id=104, action_type="DR"),
+        ]
+    )
+    when(policies).get_revision(103, 3).thenReturn(_revision(3, entry_id=103))
+    # when
+    revision = select_policy_revision(policies, POLICY_ID)
+    # then
+    assert revision.revision == 3
+    verify(policies).get_revision(103, 3)
+
+
+def test_select_policy_revision_uses_explicit_override():
+    """Given a policy whose requested revision is not deployed.
+
+    When resolving a single side with an explicit revision number.
+    Then that revision is fetched, bypassing the deployed-only filter.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [_entry(7, entry_id=207, action_type="DR")]
+    )
+    when(policies).get_revision(207, 7).thenReturn(_revision(7, entry_id=207))
+    # when
+    revision = select_policy_revision(policies, POLICY_ID, revision=7)
+    # then
+    assert revision.revision == 7
+    verify(policies).get_revision(207, 7)
+
+
+def test_select_policy_revision_no_deployed_raises():
+    """Given a policy with no deployed revision and no override.
+
+    When resolving a single side.
+    Then a clear domain error is raised.
+    """
+    # given
+    policies = mock(PolicyService)
+    when(policies).list_history(POLICY_ID).thenReturn(
+        [_entry(1, entry_id=101, action_type="DR")]
+    )
+    # when / then
+    with pytest.raises(InsufficientRevisionsError):
+        select_policy_revision(policies, POLICY_ID)


### PR DESCRIPTION
Closes #242

## Summary
- Extend `policies diff` with an optional second positional policy id: `diff A` keeps the revision diff, `diff A B` enters cross-policy mode. Each side resolves its own latest revision (`--from` for policy A, `--to` for policy B), the engine strips the fixed top-level identity set (`_CROSS_POLICY_IDENTITY_FIELDS`) so identity noise never surfaces, the semantic and unified headers name both policies, and `--show-all`/`--exit-code`/JSON behave identically to single-policy mode.
- Tested with unit coverage for the engine strip (top-level only, nested untouched, `--show-all` reveal), per-side revision selection, and CLI arity branching (header, nested diff, `--from`/`--to`, exit-code, unified parity). Full suite green (2438 passed, 95.93% coverage).
- The identity strip is top-level only and nested components/obligations/tags are diffed normally, so genuine differences inside identically-named components still surface.

## Tests added (red → green)
- `test_cross_policy_strips_top_level_identity_fields`
- `test_cross_policy_keeps_nested_identity_like_fields`
- `test_cross_policy_show_all_reveals_identity_fields`
- `test_select_policy_revision_defaults_to_latest_deployed`
- `test_select_policy_revision_uses_explicit_override`
- `test_select_policy_revision_no_deployed_raises`
- `test_diff_two_policies_compares_latest_revisions_semantic`
- `test_diff_cross_policy_strips_top_level_identity_fields`
- `test_diff_cross_policy_header_shows_both_identities`
- `test_diff_cross_policy_nested_difference_surfaces`
- `test_diff_cross_policy_from_to_select_each_side_revision`
- `test_diff_cross_policy_exit_code_nonzero_on_post_strip_difference`
- `test_diff_cross_policy_exit_code_nonzero_when_body_differs`
- `test_diff_cross_policy_unified_header_and_strips_identity`
