### PR TITLE
fix(PRD): #241 cleanup — capstone findings

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -24,7 +24,7 @@ _CONTINUATION_PREFIX = "AND "
 _IDENTITY_NOTE = "identity fields ignored"
 
 
-def _render_header(con: Console, header: DiffHeader) -> None:
+def _render_header(con: Console, header: DiffHeader, *, show_all: bool) -> None:
     """Print the identity header for a single- or cross-policy diff."""
     if header.is_cross_policy:
         con.print(
@@ -35,7 +35,8 @@ def _render_header(con: Console, header: DiffHeader) -> None:
             f"[bold]B:[/bold] {header.to_policy_name} (id={header.to_policy_id}) "
             f"revision {header.to_rev}"
         )
-        con.print(f"[dim]{_IDENTITY_NOTE}[/dim]")
+        if not show_all:
+            con.print(f"[dim]{_IDENTITY_NOTE}[/dim]")
     else:
         con.print(
             f"[bold]{_POLICY_LABEL}[/bold] {header.policy_name} "
@@ -187,7 +188,11 @@ def _render_typed_change(con: Console, field: str, change: FieldChange) -> None:
 
 
 def render_semantic(
-    diff: DiffResult, header: DiffHeader, *, console: Console | None = None
+    diff: DiffResult,
+    header: DiffHeader,
+    *,
+    show_all: bool = False,
+    console: Console | None = None,
 ) -> None:
     """Render a DiffResult as a Rich semantic report.
 
@@ -198,10 +203,12 @@ def render_semantic(
         diff: The structured diff result to render.
         header: The policy identity and compared revisions, printed as two
             lines above the change sections.
+        show_all: When True, identity fields are revealed in cross-policy mode,
+            so the "identity fields ignored" header note is suppressed.
         console: Rich Console to print to; defaults to a new Console().
     """
     con = Console() if console is None else console
-    _render_header(con, header)
+    _render_header(con, header, show_all=show_all)
     con.print()
 
     sections: dict[str, list[FieldChange]] = {}

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -10,7 +10,7 @@ from difflib import unified_diff
 from rich.console import Console
 from rich.markup import escape
 
-from nextlabs_sdk._cli._diff._engine import _CROSS_POLICY_IDENTITY_FIELDS, canonicalise
+from nextlabs_sdk._cli._diff._engine import _strip_identity_fields, canonicalise
 from nextlabs_sdk._cli._diff._identity import COMPONENT_SLOT_FIELDS
 from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
 
@@ -111,24 +111,9 @@ def _canonical_lines(
     canonical = canonicalise(payload, show_all=show_all)
     if not show_all:
         canonical = _strip_slot_operators(canonical)
-        if cross_policy:
+        if cross_policy and isinstance(canonical, Mapping):
             canonical = _strip_identity_fields(canonical)
     return json.dumps(canonical, indent=2, sort_keys=True).splitlines()
-
-
-def _strip_identity_fields(canonical: object) -> object:
-    """Drop top-level cross-policy identity keys from a canonical payload.
-
-    Mirrors the engine strip so the unified JSON body never renders identity
-    fields that the structured diff already suppresses in cross-policy mode.
-    """
-    if not isinstance(canonical, Mapping):
-        return canonical
-    return {
-        key: child
-        for key, child in canonical.items()
-        if key not in _CROSS_POLICY_IDENTITY_FIELDS
-    }
 
 
 def _strip_slot_operators(canonical: object) -> object:

--- a/src/nextlabs_sdk/_cli/_diff/_render_unified.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_unified.py
@@ -67,7 +67,7 @@ def render_unified(
     """
     con = Console() if console is None else console
     header = diff.header
-    _render_unified_header(con, header)
+    _render_unified_header(con, header, show_all=show_all)
     con.print()
     cross_policy = header.is_cross_policy
     old_lines = _canonical_lines(diff.old, show_all=show_all, cross_policy=cross_policy)
@@ -87,11 +87,12 @@ def render_unified(
             _render_grouping_change(con, change)
 
 
-def _render_unified_header(con: Console, header: DiffHeader) -> None:
+def _render_unified_header(con: Console, header: DiffHeader, *, show_all: bool) -> None:
     if header.is_cross_policy:
         con.print(f"A: {header.policy_name} (id={header.policy_id})")
         con.print(f"B: {header.to_policy_name} (id={header.to_policy_id})")
-        con.print(f"({_IDENTITY_NOTE})")
+        if not show_all:
+            con.print(f"({_IDENTITY_NOTE})")
     else:
         con.print(f"Policy: {header.policy_name} (id={header.policy_id})")
 

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -681,7 +681,7 @@ def diff(  # noqa: WPS211
             show_all=show_all,
         )
     else:
-        _render_semantic.render_semantic(diff_result, header)
+        _render_semantic.render_semantic(diff_result, header, show_all=show_all)
     if exit_code and diff_result.changes:
         raise typer.Exit(code=1)
 

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -1108,3 +1108,83 @@ def test_diff_cross_policy_show_all_unified_reveals_identity_fields(
     output = strip_ansi(result.output)
     diff_lines = [line for line in output.splitlines() if line.startswith(("+", "-"))]
     assert any('"name"' in line for line in diff_lines)
+
+
+def test_diff_cross_policy_semantic_header_notes_identity_ignored(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policies, when running cross-policy diff without
+    --show-all in semantic format, then the header notes that identity fields
+    are ignored."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20"])
+    assert result.exit_code == 0
+    assert "identity fields ignored" in strip_ansi(result.output)
+
+
+def test_diff_cross_policy_semantic_show_all_omits_identity_note(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policies, when running cross-policy diff with
+    --show-all in semantic format, then the header does not claim identity
+    fields are ignored, because --show-all reveals them."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "policies", "diff", "10", "20", "--show-all"]
+    )
+    assert result.exit_code == 0
+    assert "identity fields ignored" not in strip_ansi(result.output)
+
+
+def test_diff_cross_policy_unified_show_all_omits_identity_note(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policies, when running cross-policy diff with
+    --show-all --format unified, then the header does not claim identity fields
+    are ignored, because --show-all reveals them in the body."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "diff",
+            "10",
+            "20",
+            "--show-all",
+            "--format",
+            "unified",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "identity fields ignored" not in strip_ansi(result.output)

--- a/tests/test_cli_policy_diff.py
+++ b/tests/test_cli_policy_diff.py
@@ -1188,3 +1188,34 @@ def test_diff_cross_policy_unified_show_all_omits_identity_note(
     )
     assert result.exit_code == 0
     assert "identity fields ignored" not in strip_ansi(result.output)
+
+
+def test_diff_cross_policy_output_json_strips_identity_fields(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two distinct policies differing in top-level identity and in a
+    body field, when running cross-policy diff with the global --output json,
+    then the structured delta surfaces the body change but never the stripped
+    top-level identity fields."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([_entry(2)])
+    when(mock_policies).list_history(20).thenReturn(
+        [PolicyHistoryEntry(id=200, revision=2, action_type="DE")]
+    )
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _cross_revision(10, "Alpha", 2, description="read")
+    )
+    when(mock_policies).get_revision(200, 2).thenReturn(
+        _cross_revision(20, "Beta", 2, description="write")
+    )
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "policies", "diff", "10", "20"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.output))
+    top_level_paths = {
+        change["path"][0] for change in payload["changes"] if change["path"]
+    }
+    assert "name" not in top_level_paths
+    assert "id" not in top_level_paths
+    assert "description" in top_level_paths


### PR DESCRIPTION
Addresses capstone findings from the local `<prd-review>` for PRD #241
(arity-driven cross-policy diff). Only findings verified as real and
worth fixing were applied; two were deliberately skipped after
inspection (see below).

### Findings addressed
- **F1** — Cross-policy headers printed "identity fields ignored" even
  under `--show-all`, which intentionally reveals those fields. The note
  now prints only when identity fields are actually stripped (semantic +
  unified).
- **F2** — The unified renderer duplicated the engine's top-level
  identity-strip and imported the field set to do so. It now reuses the
  engine's single strip helper, removing the duplicated rule and its
  drift risk.
- **F5** — Added a cross-policy `--output json` test locking the
  identity-strip parity contract on the JSON path.

### Findings skipped (with reason)
- **F3** (DiffHeader nullable dual-mode fields): not a real defect. The
  `nullable fields + is_cross_policy` idiom works and headers are always
  constructed atomically in `_build_diff_header`, so no partially-formed
  header can arise. A variant-split is large, behaviour-neutral churn.
- **F4** (`_slot` imports `_identity._as_mappings`): not a real defect.
  Both modules live in the same `_cli/_diff/` subpackage, so this is an
  ordinary intra-package sibling import of a trivial type-narrowing
  helper.

Closes #241 (capstone cleanup).
