### PR TITLE
feat(cli): add --field expression option to policies search (#228)

### DIFF
--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -38,6 +38,7 @@ from nextlabs_sdk._cli._payload_loader import (
 from nextlabs_sdk._cloudaz._policies import PolicyService
 from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyRevision
 from nextlabs_sdk._cloudaz._search import SearchCriteria
+from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
 
 policies_app = make_group("Policy management commands")
 
@@ -426,6 +427,13 @@ def search(  # noqa: WPS211
     ] = None,
     text: Annotated[str | None, typer.Option(help="Text search")] = None,
     tag: Annotated[str | None, typer.Option(help="Filter by tag key")] = None,
+    field: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--field",
+            help="Repeatable NAME[:TYPE]=VALUE field expression",
+        ),
+    ] = None,
     sort: Annotated[str | None, typer.Option(help="Sort field (e.g. name)")] = None,
     page_size: Annotated[int, typer.Option(help="Results per page")] = 20,
 ) -> None:
@@ -440,6 +448,8 @@ def search(  # noqa: WPS211
         criteria.filter_text(text)
     if tag:
         criteria.filter_tags(tag)
+    for field_expr in field or []:
+        criteria.filter_field(parse_field_expr(field_expr))
     if sort:
         criteria.sort_by(sort)
     criteria.page(page_no=1, page_size=page_size)

--- a/src/nextlabs_sdk/_cloudaz/_search/field_expr.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/field_expr.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from nextlabs_sdk._cloudaz._search.criteria import SearchField, SearchFieldType
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+_STRING_LABEL = "String"
+
+
+def parse_field_expr(expr: str) -> SearchField:
+    """Parse a ``NAME[:TYPE]=VALUE`` field expression into a search field.
+
+    The match type is taken from an explicit ``:TYPE`` token when present
+    (case-insensitive), otherwise inferred: a comma in the value yields a
+    ``MULTI`` list, a bare value yields ``SINGLE_EXACT_MATCH``.
+
+    Args:
+        expr: The raw ``NAME[:TYPE]=VALUE`` expression.
+
+    Returns:
+        The parsed search field.
+
+    Raises:
+        SearchExpressionError: If the expression lacks an assignment or
+            carries an unknown type token.
+    """
+    name_part, sep, raw_value = expr.partition("=")
+    if not sep:
+        raise SearchExpressionError(
+            f"field expression must be NAME[:TYPE]=VALUE: {expr!r}",
+        )
+
+    name, type_token = _split_name(name_part)
+    is_list = "," in raw_value
+    field_type = _resolve_type(type_token, is_list=is_list)
+    payload = _value_payload(raw_value, is_list=is_list)
+    return SearchField(field=name, type=field_type, value=payload)
+
+
+def _split_name(name_part: str) -> tuple[str, str | None]:
+    name, sep, type_token = name_part.partition(":")
+    if not name:
+        raise SearchExpressionError("field expression is missing a NAME")
+    return name, type_token if sep else None
+
+
+def _resolve_type(type_token: str | None, *, is_list: bool) -> SearchFieldType:
+    if type_token is None:
+        return SearchFieldType.MULTI if is_list else SearchFieldType.SINGLE_EXACT_MATCH
+    try:
+        return SearchFieldType[type_token.strip().upper()]
+    except KeyError:
+        raise SearchExpressionError(
+            f"unknown field type token: {type_token!r}",
+        ) from None
+
+
+def _value_payload(raw_value: str, *, is_list: bool) -> dict[str, object]:
+    if is_list:
+        parsed: object = [part.strip() for part in raw_value.split(",")]
+    else:
+        parsed = raw_value
+    return {"type": _STRING_LABEL, "value": parsed}

--- a/tests/test_policies_search_cmd.py
+++ b/tests/test_policies_search_cmd.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mockito import ANY, mock, when
+from typer.testing import CliRunner
+
+from nextlabs_sdk._cli import _client_factory
+from nextlabs_sdk._cli._app import app
+from nextlabs_sdk._cloudaz._search import SearchCriteria
+from nextlabs_sdk._pagination import PageResult, SyncPaginator
+from nextlabs_sdk.cloudaz import (
+    CloudAzClient,
+    PolicyLite,
+    PolicySearchService,
+)
+
+runner = CliRunner()
+
+_GLOBAL_OPTS = (
+    "--base-url",
+    "https://example.com",
+    "--username",
+    "admin",
+    "--password",
+    "secret",
+)
+
+
+@pytest.fixture
+def search_stub() -> tuple[Any, list[SearchCriteria]]:
+    captured: list[SearchCriteria] = []
+    mock_client = mock(CloudAzClient)
+    mock_search = mock(PolicySearchService)
+    mock_client.policy_search = mock_search
+
+    def _answer(criteria: SearchCriteria) -> SyncPaginator[PolicyLite]:
+        captured.append(criteria)
+        return _make_paginator([_make_policy_lite()])
+
+    when(mock_search).search(ANY).thenAnswer(_answer)
+    when(_client_factory).make_cloudaz_client(...).thenReturn(mock_client)
+    return mock_search, captured
+
+
+def _make_policy_lite() -> PolicyLite:
+    return PolicyLite(
+        id=82,
+        folder_id=1,
+        name="Allow IT Access",
+        lowercase_name="allow it access",
+        policy_full_name="Allow IT Access",
+        description="Allow IT dept access",
+        status="DRAFT",
+        effect_type="ALLOW",
+        last_updated_date=0,
+        created_date=0,
+        has_parent=False,
+        has_sub_policies=False,
+        owner_id=1,
+        owner_display_name="admin",
+        modified_by_id=1,
+        modified_by="admin",
+        tags=[],
+        no_of_tags=0,
+        authorities=[],
+        manual_deploy=False,
+        deployment_time=0,
+        deployed=False,
+        revision_count=0,
+        hide_more_details=False,
+        deployment_pending=False,
+    )
+
+
+def _make_paginator(items: list[PolicyLite]) -> SyncPaginator[PolicyLite]:
+    page = PageResult(
+        entries=items,
+        page_no=0,
+        page_size=len(items),
+        total_pages=1,
+        total_records=len(items),
+    )
+
+    def fetch_page(page_no: int) -> PageResult[PolicyLite]:
+        return page
+
+    return SyncPaginator(fetch_page=fetch_page)
+
+
+def _fields(criteria: SearchCriteria) -> list[dict[str, Any]]:
+    return criteria.to_dict()["criteria"]["fields"]
+
+
+def test_field_option_issues_single_exact_match_and_renders_rows(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when searching with a single bare --field expression
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "search", "--field", "status=DRAFT"],
+    )
+
+    # then the result rows render and the criteria carry a SINGLE_EXACT_MATCH field
+    assert result.exit_code == 0
+    assert "Allow IT Access" in result.output
+    assert _fields(captured[0]) == [
+        {
+            "field": "status",
+            "type": "SINGLE_EXACT_MATCH",
+            "value": {"type": "String", "value": "DRAFT"},
+        },
+    ]
+
+
+def test_repeated_field_options_and_into_one_payload(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when passing two --field flags
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--field",
+            "status=DRAFT",
+            "--field",
+            "effectType=ALLOW",
+        ],
+    )
+
+    # then both fields are ANDed together in a single criteria payload
+    assert result.exit_code == 0
+    fields = _fields(captured[0])
+    assert {entry["field"] for entry in fields} == {"status", "effectType"}
+    assert len(fields) == 2
+
+
+def test_unknown_field_type_token_exits_with_error(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub
+    _, captured = search_stub
+
+    # when passing a --field with an unknown :TYPE token
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "search", "--field", "status:BOGUS=DRAFT"],
+    )
+
+    # then the command exits non-zero and no search is issued
+    assert result.exit_code != 0
+    assert captured == []
+
+
+def test_shorthand_status_flag_keeps_original_criteria(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when searching with the shorthand --status flag
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "search", "--status", "DRAFT"],
+    )
+
+    # then the original MULTI status criteria are produced unchanged
+    assert result.exit_code == 0
+    assert _fields(captured[0]) == [
+        {
+            "field": "status",
+            "type": "MULTI",
+            "value": {"type": "String", "value": ["DRAFT"]},
+        },
+    ]

--- a/tests/test_search_field_expr.py
+++ b/tests/test_search_field_expr.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+from nextlabs_sdk._cloudaz._search import SearchFieldType
+from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+
+def test_scalar_value_infers_single_exact_match():
+    # given a bare NAME=VALUE with no type and no comma
+    expr = "status=DRAFT"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then it carries a SINGLE_EXACT_MATCH field with a scalar value
+    assert parsed.field == "status"
+    assert parsed.type == SearchFieldType.SINGLE_EXACT_MATCH
+    assert parsed.value == {"type": "String", "value": "DRAFT"}
+
+
+def test_comma_value_infers_multi_list():
+    # given a value containing a comma
+    expr = "status=DRAFT,APPROVED"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then the type is inferred as MULTI and the value is a list
+    assert parsed.type == SearchFieldType.MULTI
+    assert parsed.value == {"type": "String", "value": ["DRAFT", "APPROVED"]}
+
+
+@pytest.mark.parametrize(
+    "expr,expected_type",
+    [
+        pytest.param("status:MULTI=DRAFT", SearchFieldType.MULTI, id="multi"),
+        pytest.param(
+            "effectType:MULTI_EXACT_MATCH=ALLOW",
+            SearchFieldType.MULTI_EXACT_MATCH,
+            id="multi-exact-match",
+        ),
+        pytest.param("name:SINGLE=Allow", SearchFieldType.SINGLE, id="single"),
+    ],
+)
+def test_explicit_type_overrides_inference(
+    expr: str,
+    expected_type: SearchFieldType,
+):
+    # given an expression with an explicit :TYPE token
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then the explicit type wins over what inference would have chosen
+    assert parsed.type == expected_type
+
+
+def test_explicit_type_is_case_insensitive():
+    # given an explicit type token in lower case
+    expr = "status:multi=DRAFT"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then the token resolves to the matching SearchFieldType member
+    assert parsed.type == SearchFieldType.MULTI
+
+
+def test_unknown_type_token_raises_search_expression_error():
+    # given an expression with an unknown :TYPE token
+    expr = "status:BOGUS=DRAFT"
+
+    # when the expression is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        parse_field_expr(expr)
+
+
+def test_missing_assignment_raises_search_expression_error():
+    # given an expression without an = assignment
+    expr = "status"
+
+    # when the expression is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        parse_field_expr(expr)


### PR DESCRIPTION
Closes #228

## Summary
- Add a hand-written `parse_field_expr` parser plus a repeatable `--field 'NAME[:TYPE]=VALUE'` option on `nextlabs policies search`, wiring parsed `SearchField`s through the existing `SearchCriteria` builder to the search service and renderer.
- The parser infers match type (`SINGLE_EXACT_MATCH` for a bare value, `MULTI` for a comma list), honours an explicit case-insensitive `:TYPE` token, and raises `SearchExpressionError` for unknown type tokens or a missing assignment.
- Covered by unit tests for the parser and CLI integration tests (red → green); shorthand flags (`--status/--effect/--text/--tag`) are unchanged.

## Tests added (red → green)
- `test_scalar_value_infers_single_exact_match`
- `test_comma_value_infers_multi_list`
- `test_explicit_type_overrides_inference`
- `test_explicit_type_is_case_insensitive`
- `test_unknown_type_token_raises_search_expression_error`
- `test_missing_assignment_raises_search_expression_error`
- `test_field_option_issues_single_exact_match_and_renders_rows`
- `test_repeated_field_options_and_into_one_payload`
- `test_unknown_field_type_token_exits_with_error`
- `test_shorthand_status_flag_keeps_original_criteria`

## Notable assumptions
- Comma-separated `--field` values are whitespace-stripped per item (`a, b` → `["a", "b"]`).
- The parser covers string/enum match types only, matching this slice's scope; dotted-name `NESTED`, `DATE`, and `TEXT` special-casing are deferred to later slices.
