### PR TITLE
feat(search): add nested, date and text field value shapes (#229)

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_search/dates.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/dates.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+_DATE_LABEL = "Date"
+_RANGE_SEP = ".."
+_MILLIS_PER_SECOND = 1000
+
+DATE_KEYWORDS = frozenset(
+    (
+        "PAST_7_DAYS",
+        "PAST_30_DAYS",
+        "PAST_3_MONTHS",
+        "PAST_1_YEAR",
+    ),
+)
+
+
+def date_value(raw: str) -> dict[str, Any]:
+    """Parse a DATE value into a CloudAz date payload.
+
+    A keyword (``PAST_7_DAYS``, ``PAST_30_DAYS``, ``PAST_3_MONTHS``,
+    ``PAST_1_YEAR``) yields a ``dateOption`` payload. A ``from..to`` range of
+    ISO dates yields ``fromDate``/``toDate`` bounds in UTC epoch-milliseconds.
+
+    Args:
+        raw: The raw DATE value, either a keyword or a ``from..to`` range.
+
+    Returns:
+        The date payload dict, tagged with a ``Date`` type label.
+
+    Raises:
+        SearchExpressionError: If the value is neither a known keyword nor a
+            valid ISO range.
+    """
+    token = raw.strip()
+    if _RANGE_SEP in token:
+        return _range_payload(token)
+    keyword = token.upper()
+    if keyword in DATE_KEYWORDS:
+        return {"type": _DATE_LABEL, "dateOption": keyword}
+    raise SearchExpressionError(
+        f"date value must be a keyword or from..to range: {raw!r}",
+    )
+
+
+def _range_payload(token: str) -> dict[str, Any]:
+    from_part, _, to_part = token.partition(_RANGE_SEP)
+    return {
+        "type": _DATE_LABEL,
+        "fromDate": _to_epoch_ms(from_part),
+        "toDate": _to_epoch_ms(to_part),
+    }
+
+
+def _to_epoch_ms(bound: str) -> int:
+    text = bound.strip()
+    if not text:
+        raise SearchExpressionError("date range bound is missing")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        raise SearchExpressionError(
+            f"date range bound is not a valid ISO date: {bound!r}",
+        ) from None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * _MILLIS_PER_SECOND)

--- a/src/nextlabs_sdk/_cloudaz/_search/field_expr.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/field_expr.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
+from typing import Any
+
 from nextlabs_sdk._cloudaz._search.criteria import SearchField, SearchFieldType
+from nextlabs_sdk._cloudaz._search.dates import date_value
 from nextlabs_sdk.exceptions import SearchExpressionError
 
 _STRING_LABEL = "String"
+_TEXT_LABEL = "Text"
+_TEXT_DEFAULT_FIELDS = ("name", "description")
 
 
 def parse_field_expr(expr: str) -> SearchField:
     """Parse a ``NAME[:TYPE]=VALUE`` field expression into a search field.
 
     The match type is taken from an explicit ``:TYPE`` token when present
-    (case-insensitive), otherwise inferred: a comma in the value yields a
-    ``MULTI`` list, a bare value yields ``SINGLE_EXACT_MATCH``.
+    (case-insensitive), otherwise inferred: a dotted ``NAME`` yields a
+    ``NESTED`` (``NESTED_MULTI`` with a comma) field, a comma in the value
+    yields a ``MULTI`` list, a bare value yields ``SINGLE_EXACT_MATCH``.
+
+    A dotted ``NAME`` sets ``field`` to the segment before the last dot and
+    ``nested_field`` to the full dotted path. A ``DATE`` value is a keyword or
+    a ``from..to`` ISO range; the reserved ``TEXT`` type carries default
+    ``name``/``description`` subfields.
 
     Args:
         expr: The raw ``NAME[:TYPE]=VALUE`` expression.
@@ -20,8 +31,8 @@ def parse_field_expr(expr: str) -> SearchField:
         The parsed search field.
 
     Raises:
-        SearchExpressionError: If the expression lacks an assignment or
-            carries an unknown type token.
+        SearchExpressionError: If the expression lacks an assignment, carries
+            an unknown type token, or holds a malformed date value.
     """
     name_part, sep, raw_value = expr.partition("=")
     if not sep:
@@ -30,10 +41,20 @@ def parse_field_expr(expr: str) -> SearchField:
         )
 
     name, type_token = _split_name(name_part)
+    field, nested_field = _resolve_field(name)
     is_list = "," in raw_value
-    field_type = _resolve_type(type_token, is_list=is_list)
-    payload = _value_payload(raw_value, is_list=is_list)
-    return SearchField(field=name, type=field_type, value=payload)
+    field_type = _resolve_type(
+        type_token,
+        is_list=is_list,
+        is_nested=nested_field is not None,
+    )
+    payload = _value_payload(raw_value, field_type, is_list=is_list)
+    return SearchField(
+        field=field,
+        type=field_type,
+        value=payload,
+        nestedField=nested_field,
+    )
 
 
 def _split_name(name_part: str) -> tuple[str, str | None]:
@@ -43,9 +64,27 @@ def _split_name(name_part: str) -> tuple[str, str | None]:
     return name, type_token if sep else None
 
 
-def _resolve_type(type_token: str | None, *, is_list: bool) -> SearchFieldType:
-    if type_token is None:
-        return SearchFieldType.MULTI if is_list else SearchFieldType.SINGLE_EXACT_MATCH
+def _resolve_field(name: str) -> tuple[str, str | None]:
+    if "." not in name:
+        return name, None
+    base, _, _leaf = name.rpartition(".")
+    return base, name
+
+
+def _resolve_type(
+    type_token: str | None,
+    *,
+    is_list: bool,
+    is_nested: bool,
+) -> SearchFieldType:
+    if type_token is not None:
+        return _explicit_type(type_token)
+    if is_nested:
+        return SearchFieldType.NESTED_MULTI if is_list else SearchFieldType.NESTED
+    return SearchFieldType.MULTI if is_list else SearchFieldType.SINGLE_EXACT_MATCH
+
+
+def _explicit_type(type_token: str) -> SearchFieldType:
     try:
         return SearchFieldType[type_token.strip().upper()]
     except KeyError:
@@ -54,7 +93,20 @@ def _resolve_type(type_token: str | None, *, is_list: bool) -> SearchFieldType:
         ) from None
 
 
-def _value_payload(raw_value: str, *, is_list: bool) -> dict[str, object]:
+def _value_payload(
+    raw_value: str,
+    field_type: SearchFieldType,
+    *,
+    is_list: bool,
+) -> dict[str, Any]:
+    if field_type is SearchFieldType.DATE:
+        return date_value(raw_value)
+    if field_type is SearchFieldType.TEXT:
+        return {
+            "type": _TEXT_LABEL,
+            "fields": list(_TEXT_DEFAULT_FIELDS),
+            "value": raw_value,
+        }
     if is_list:
         parsed: object = [part.strip() for part in raw_value.split(",")]
     else:

--- a/tests/test_search_dates.py
+++ b/tests/test_search_dates.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from nextlabs_sdk._cloudaz._search.dates import date_value
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+
+def test_keyword_sets_date_option():
+    # given a recognised date keyword
+    raw = "PAST_7_DAYS"
+
+    # when the date value is parsed
+    payload = date_value(raw)
+
+    # then it carries a Date payload with the keyword as dateOption
+    assert payload == {"type": "Date", "dateOption": "PAST_7_DAYS"}
+
+
+def test_keyword_is_case_insensitive():
+    # given a date keyword in lower case
+    raw = "past_30_days"
+
+    # when the date value is parsed
+    payload = date_value(raw)
+
+    # then the keyword resolves to the upper-case dateOption
+    assert payload == {"type": "Date", "dateOption": "PAST_30_DAYS"}
+
+
+def test_iso_range_parses_to_epoch_milliseconds():
+    # given an explicit from..to ISO date range
+    raw = "2024-01-01..2024-02-01"
+
+    # when the date value is parsed
+    payload = date_value(raw)
+
+    # then both bounds become UTC epoch-millisecond fromDate/toDate
+    assert payload == {
+        "type": "Date",
+        "fromDate": 1704067200000,
+        "toDate": 1706745600000,
+    }
+
+
+def test_unknown_keyword_raises_search_expression_error():
+    # given a value that is neither a known keyword nor a range
+    raw = "BOGUS"
+
+    # when the date value is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        date_value(raw)
+
+
+def test_malformed_range_bound_raises_search_expression_error():
+    # given a range with an unparseable ISO bound
+    raw = "2024-01-01..not-a-date"
+
+    # when the date value is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        date_value(raw)
+
+
+def test_range_missing_upper_bound_raises_search_expression_error():
+    # given a range with an empty upper bound
+    raw = "2024-01-01.."
+
+    # when the date value is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        date_value(raw)

--- a/tests/test_search_field_expr.py
+++ b/tests/test_search_field_expr.py
@@ -85,3 +85,87 @@ def test_missing_assignment_raises_search_expression_error():
     # then a SearchExpressionError is raised
     with pytest.raises(SearchExpressionError):
         parse_field_expr(expr)
+
+
+def test_dotted_name_infers_nested_field():
+    # given a dotted NAME with a scalar value
+    expr = "tags.key=helpdesk"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then it is a NESTED field whose nestedField is the full dotted path
+    assert parsed.type == SearchFieldType.NESTED
+    assert parsed.field == "tags"
+    assert parsed.nested_field == "tags.key"
+    assert parsed.value == {"type": "String", "value": "helpdesk"}
+
+
+def test_dotted_name_with_comma_infers_nested_multi():
+    # given a dotted NAME with a comma-separated value
+    expr = "tags.key=helpdesk,billing"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then the type is NESTED_MULTI and the value is a list
+    assert parsed.type == SearchFieldType.NESTED_MULTI
+    assert parsed.field == "tags"
+    assert parsed.nested_field == "tags.key"
+    assert parsed.value == {"type": "String", "value": ["helpdesk", "billing"]}
+
+
+def test_date_keyword_builds_date_option():
+    # given an explicit DATE type with a keyword value
+    expr = "lastUpdatedDate:DATE=PAST_7_DAYS"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then it carries a DATE field with the keyword as dateOption
+    assert parsed.field == "lastUpdatedDate"
+    assert parsed.type == SearchFieldType.DATE
+    assert parsed.value == {"type": "Date", "dateOption": "PAST_7_DAYS"}
+
+
+def test_date_range_builds_epoch_millisecond_bounds():
+    # given an explicit DATE type with a from..to ISO range
+    expr = "lastUpdatedDate:DATE=2024-01-01..2024-02-01"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then the bounds become epoch-millisecond fromDate/toDate
+    assert parsed.type == SearchFieldType.DATE
+    assert parsed.value == {
+        "type": "Date",
+        "fromDate": 1704067200000,
+        "toDate": 1706745600000,
+    }
+
+
+def test_malformed_date_value_raises_search_expression_error():
+    # given an explicit DATE type with an unparseable value
+    expr = "lastUpdatedDate:DATE=BOGUS"
+
+    # when the expression is parsed
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        parse_field_expr(expr)
+
+
+def test_text_type_builds_default_subfields():
+    # given the reserved text attribute with an explicit TEXT type
+    expr = "text:TEXT=ticket"
+
+    # when the expression is parsed
+    parsed = parse_field_expr(expr)
+
+    # then it is a TEXT entry carrying the default name/description subfields
+    assert parsed.field == "text"
+    assert parsed.type == SearchFieldType.TEXT
+    assert parsed.value == {
+        "type": "Text",
+        "fields": ["name", "description"],
+        "value": "ticket",
+    }


### PR DESCRIPTION
Closes #229

## Summary
- Extend `parse_field_expr` with the remaining `--field` value shapes: dotted names infer `NESTED`/`NESTED_MULTI` (with `field` set to the segment before the last dot and `nestedField` to the full dotted path), an explicit `:DATE` value resolves keywords/ranges, and `:TEXT` emits a `TEXT` entry with default `name`/`description` subfields.
- Add `_search/dates.py` with `date_value`, mapping the keywords `PAST_7_DAYS`/`PAST_30_DAYS`/`PAST_3_MONTHS`/`PAST_1_YEAR` to `dateOption` and `from..to` ISO ranges to UTC epoch-millisecond `fromDate`/`toDate`; malformed values raise `SearchExpressionError`.
- Trade-off: keyword vs. range is decided purely by the presence of `..`; whether a keyword also needs a computed window is left for E2E verification per the PRD.

## Tests added (red → green)
- `test_dotted_name_infers_nested_field`
- `test_dotted_name_with_comma_infers_nested_multi`
- `test_date_keyword_builds_date_option`
- `test_date_range_builds_epoch_millisecond_bounds`
- `test_malformed_date_value_raises_search_expression_error`
- `test_text_type_builds_default_subfields`
- `test_keyword_sets_date_option`
- `test_keyword_is_case_insensitive`
- `test_iso_range_parses_to_epoch_milliseconds`
- `test_unknown_keyword_raises_search_expression_error`
- `test_malformed_range_bound_raises_search_expression_error`
- `test_range_missing_upper_bound_raises_search_expression_error`
