### PR TITLE
feat(search): add --where SCIM filter to policies search (#230)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/stevenengland/nextlabs_rest_api"
 cli = [
     "typer>=0.12,<1.0",
     "rich>=13.0,<14.0",
+    "scim2-filter-parser>=0.5,<1.0",
 ]
 yaml = [
     "PyYAML>=6.0",

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,7 @@ pytest-cov==5.0.0
 pytest-env==1.1.3
 pytest-mock==3.14.0
 pytest-timeout==2.3.1
+scim2-filter-parser==0.7.0
 strip-ansi==0.1.1
 testcontainers==4.14.2
 types-PyYAML==6.0.12.20260408

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -39,6 +39,7 @@ from nextlabs_sdk._cloudaz._policies import PolicyService
 from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyRevision
 from nextlabs_sdk._cloudaz._search import SearchCriteria
 from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
+from nextlabs_sdk._cloudaz._search.where import transpile_where
 
 policies_app = make_group("Policy management commands")
 
@@ -434,22 +435,23 @@ def search(  # noqa: WPS211
             help="Repeatable NAME[:TYPE]=VALUE field expression",
         ),
     ] = None,
+    where: Annotated[
+        str | None,
+        typer.Option(
+            "--where",
+            help="SCIM filter, e.g. 'status eq \"DRAFT\"'",
+        ),
+    ] = None,
     sort: Annotated[str | None, typer.Option(help="Sort field (e.g. name)")] = None,
     page_size: Annotated[int, typer.Option(help="Results per page")] = 20,
 ) -> None:
     """Search policies."""
     cli_ctx: CliContext = ctx.obj
     criteria = SearchCriteria()
-    if status:
-        criteria.filter_status(status)
-    if effect:
-        criteria.filter_effect_type(effect)
-    if text:
-        criteria.filter_text(text)
-    if tag:
-        criteria.filter_tags(tag)
+    _apply_shorthands(criteria, status=status, effect=effect, text=text, tag=tag)
     for field_expr in field or []:
         criteria.filter_field(parse_field_expr(field_expr))
+    _apply_where(criteria, where)
     if sort:
         criteria.sort_by(sort)
     criteria.page(page_no=1, page_size=page_size)
@@ -462,6 +464,31 @@ def search(  # noqa: WPS211
         title="Policies",
         wide_columns=_POLICY_WIDE_COLUMNS,
     )
+
+
+def _apply_shorthands(
+    criteria: SearchCriteria,
+    *,
+    status: str | None,
+    effect: str | None,
+    text: str | None,
+    tag: str | None,
+) -> None:
+    if status:
+        criteria.filter_status(status)
+    if effect:
+        criteria.filter_effect_type(effect)
+    if text:
+        criteria.filter_text(text)
+    if tag:
+        criteria.filter_tags(tag)
+
+
+def _apply_where(criteria: SearchCriteria, where: str | None) -> None:
+    if not where:
+        return
+    for where_field in transpile_where(where):
+        criteria.filter_field(where_field)
 
 
 @policies_app.command()

--- a/src/nextlabs_sdk/_cloudaz/_search/where.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/where.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import cast
+
+from scim2_filter_parser.ast import AttrExpr, Filter, LogExpr
+from scim2_filter_parser.lexer import SCIMLexer
+from scim2_filter_parser.parser import SCIMParser, SCIMParserError
+
+from nextlabs_sdk._cloudaz._search.criteria import SearchField, SearchFieldType
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+_STRING_LABEL = "String"
+
+_SCALAR_TYPES: MappingProxyType[str, SearchFieldType] = MappingProxyType(
+    {
+        "eq": SearchFieldType.SINGLE_EXACT_MATCH,
+        "co": SearchFieldType.SINGLE_EXACT_MATCH,
+        "sw": SearchFieldType.SINGLE,
+    },
+)
+
+
+def transpile_where(expr: str) -> list[SearchField]:
+    """Transpile a SCIM ``--where`` filter into a list of search fields.
+
+    The supported subset is scalar ``eq``/``co``/``sw`` comparisons,
+    ``and``-chaining (each term becomes its own field), and same-field
+    parenthesised ``or`` groups (a single list-valued field). Cross-field
+    ``or`` and any ``not`` are rejected as out of scope for a single
+    search request.
+
+    Args:
+        expr: The raw SCIM filter string.
+
+    Returns:
+        The transpiled search fields, one entry per ``and``-chained term.
+
+    Raises:
+        SearchExpressionError: If the filter is malformed, uses an
+            unsupported operator, or mixes fields across an ``or``/``not``.
+    """
+    return _transpile_filter(_parse(expr))
+
+
+def _parse(expr: str) -> Filter:
+    try:
+        tree = SCIMParser().parse(SCIMLexer().tokenize(expr))
+    except (SCIMParserError, ValueError) as exc:
+        raise SearchExpressionError(
+            f"could not parse --where filter: {expr!r}",
+        ) from exc
+    return cast(Filter, tree)
+
+
+def _transpile_filter(node: Filter) -> list[SearchField]:
+    if node.negated:
+        raise _cross_field_error()
+    inner = node.expr
+    if isinstance(inner, Filter):
+        return _transpile_filter(inner)
+    if isinstance(inner, AttrExpr):
+        return [_scalar_field(inner)]
+    if isinstance(inner, LogExpr):
+        return _transpile_log(inner)
+    raise SearchExpressionError("unsupported --where expression")
+
+
+def _transpile_log(node: LogExpr) -> list[SearchField]:
+    if node.op.lower() == "and":
+        return _transpile_filter(node.expr1) + _transpile_filter(node.expr2)
+    raise _cross_field_error()
+
+
+def _scalar_field(node: AttrExpr) -> SearchField:
+    name = _attr_name(node)
+    field_type = _scalar_types(node)
+    return SearchField(
+        field=name,
+        type=field_type,
+        value={"type": _STRING_LABEL, "value": node.comp_value.value},
+    )
+
+
+def _attr_name(node: AttrExpr) -> str:
+    if node.attr_path.sub_attr is not None:
+        raise SearchExpressionError(
+            "nested attributes are not supported in --where",
+        )
+    return node.attr_path.attr_name
+
+
+def _scalar_types(node: AttrExpr) -> SearchFieldType:
+    operator = node.value.lower()
+    try:
+        return _SCALAR_TYPES[operator]
+    except KeyError:
+        raise SearchExpressionError(
+            f"unsupported --where operator: {operator!r}",
+        ) from None
+
+
+def _cross_field_error() -> SearchExpressionError:
+    return SearchExpressionError(
+        "cross-field 'or'/'not' is unsupported in --where; "
+        "run separate searches instead",
+    )

--- a/src/nextlabs_sdk/_cloudaz/_search/where.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/where.py
@@ -20,6 +20,13 @@ _SCALAR_TYPES: MappingProxyType[str, SearchFieldType] = MappingProxyType(
     },
 )
 
+_OR_GROUP_TYPES: MappingProxyType[str, SearchFieldType] = MappingProxyType(
+    {
+        "eq": SearchFieldType.MULTI_EXACT_MATCH,
+        "co": SearchFieldType.MULTI,
+    },
+)
+
 
 def transpile_where(expr: str) -> list[SearchField]:
     """Transpile a SCIM ``--where`` filter into a list of search fields.
@@ -67,9 +74,63 @@ def _transpile_filter(node: Filter) -> list[SearchField]:
 
 
 def _transpile_log(node: LogExpr) -> list[SearchField]:
-    if node.op.lower() == "and":
+    operator = node.op.lower()
+    if operator == "and":
         return _transpile_filter(node.expr1) + _transpile_filter(node.expr2)
+    if operator == "or":
+        return [_or_group_field(node)]
     raise _cross_field_error()
+
+
+def _or_group_field(node: LogExpr) -> SearchField:
+    terms = _flatten_or(node)
+    names = {term.attr_path.attr_name for term in terms}
+    if len(names) != 1:
+        raise _cross_field_error()
+    if any(term.attr_path.sub_attr is not None for term in terms):
+        raise SearchExpressionError(
+            "nested attributes are not supported in --where",
+        )
+    operators = {term.value.lower() for term in terms}
+    if len(operators) != 1:
+        raise SearchExpressionError(
+            "an --where or-group must use a single operator",
+        )
+    field_type = _or_group_type(next(iter(operators)))
+    return SearchField(
+        field=next(iter(names)),
+        type=field_type,
+        value={
+            "type": _STRING_LABEL,
+            "value": [term.comp_value.value for term in terms],
+        },
+    )
+
+
+def _flatten_or(node: LogExpr) -> list[AttrExpr]:
+    return _flatten_or_side(node.expr1) + _flatten_or_side(node.expr2)
+
+
+def _flatten_or_side(node: Filter) -> list[AttrExpr]:
+    if node.negated:
+        raise _cross_field_error()
+    inner = node.expr
+    if isinstance(inner, Filter):
+        return _flatten_or_side(inner)
+    if isinstance(inner, AttrExpr):
+        return [inner]
+    if isinstance(inner, LogExpr) and inner.op.lower() == "or":
+        return _flatten_or(inner)
+    raise _cross_field_error()
+
+
+def _or_group_type(operator: str) -> SearchFieldType:
+    try:
+        return _OR_GROUP_TYPES[operator]
+    except KeyError:
+        raise SearchExpressionError(
+            f"unsupported --where or-group operator: {operator!r}",
+        ) from None
 
 
 def _scalar_field(node: AttrExpr) -> SearchField:

--- a/tests/test_policies_search_cmd.py
+++ b/tests/test_policies_search_cmd.py
@@ -182,3 +182,75 @@ def test_shorthand_status_flag_keeps_original_criteria(
             "value": {"type": "String", "value": ["DRAFT"]},
         },
     ]
+
+
+def test_where_option_issues_search_and_renders_rows(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when searching with a scalar --where SCIM filter
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "search", "--where", 'status eq "DRAFT"'],
+    )
+
+    # then the rows render and the criteria carry the transpiled field
+    assert result.exit_code == 0
+    assert "Allow IT Access" in result.output
+    assert _fields(captured[0]) == [
+        {
+            "field": "status",
+            "type": "SINGLE_EXACT_MATCH",
+            "value": {"type": "String", "value": "DRAFT"},
+        },
+    ]
+
+
+def test_where_and_chain_ands_into_one_payload(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when searching with an and-chained --where filter
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--where",
+            'status eq "DRAFT" and effectType eq "ALLOW"',
+        ],
+    )
+
+    # then both terms AND together in one criteria payload
+    assert result.exit_code == 0
+    fields = _fields(captured[0])
+    assert {entry["field"] for entry in fields} == {"status", "effectType"}
+    assert len(fields) == 2
+
+
+def test_where_cross_field_or_exits_with_error(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub
+    _, captured = search_stub
+
+    # when passing a cross-field OR --where filter
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--where",
+            'status eq "DRAFT" or name co "Allow"',
+        ],
+    )
+
+    # then the command exits non-zero and no search is issued
+    assert result.exit_code != 0
+    assert captured == []

--- a/tests/test_search_where.py
+++ b/tests/test_search_where.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from nextlabs_sdk._cloudaz._search import SearchFieldType
+from nextlabs_sdk._cloudaz._search.where import transpile_where
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+
+def test_scalar_eq_maps_to_single_exact_match():
+    # given a scalar eq filter
+    where = 'status eq "DRAFT"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one SINGLE_EXACT_MATCH field carries the scalar value
+    assert len(fields) == 1
+    assert fields[0].field == "status"
+    assert fields[0].type == SearchFieldType.SINGLE_EXACT_MATCH
+    assert fields[0].value == {"type": "String", "value": "DRAFT"}
+
+
+def test_scalar_co_maps_to_single_exact_match():
+    # given a scalar co (contains) filter
+    where = 'name co "Allow"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then it becomes a SINGLE_EXACT_MATCH field
+    assert fields[0].field == "name"
+    assert fields[0].type == SearchFieldType.SINGLE_EXACT_MATCH
+    assert fields[0].value == {"type": "String", "value": "Allow"}
+
+
+def test_scalar_sw_maps_to_single():
+    # given a scalar sw (starts-with) filter
+    where = 'name sw "Allow"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then it becomes a SINGLE (prefix) field
+    assert fields[0].field == "name"
+    assert fields[0].type == SearchFieldType.SINGLE
+    assert fields[0].value == {"type": "String", "value": "Allow"}
+
+
+def test_and_chain_yields_one_field_per_term():
+    # given two terms joined by and
+    where = 'status eq "DRAFT" and name co "Allow"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then both terms AND into the field list, one entry each
+    assert len(fields) == 2
+    assert {entry.field for entry in fields} == {"status", "name"}
+
+
+def test_and_chain_of_three_terms_flattens():
+    # given three terms joined by and
+    where = 'status eq "DRAFT" and effectType eq "ALLOW" and name sw "A"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then all three terms appear as separate fields
+    assert len(fields) == 3
+    assert {entry.field for entry in fields} == {
+        "status",
+        "effectType",
+        "name",
+    }
+
+
+def test_unsupported_scalar_operator_raises():
+    # given a scalar operator outside the MVP set
+    where = 'status pr "x"'
+
+    # when the filter is transpiled
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)
+
+
+def test_malformed_filter_raises_search_expression_error():
+    # given a syntactically invalid filter
+    where = "status eq"
+
+    # when the filter is transpiled
+    # then the parser failure surfaces as a SearchExpressionError
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)

--- a/tests/test_search_where.py
+++ b/tests/test_search_where.py
@@ -93,3 +93,74 @@ def test_malformed_filter_raises_search_expression_error():
     # then the parser failure surfaces as a SearchExpressionError
     with pytest.raises(SearchExpressionError):
         transpile_where(where)
+
+
+def test_same_field_eq_or_group_maps_to_multi_exact_match():
+    # given a same-field paren-OR group of eq terms
+    where = '(status eq "DRAFT" or status eq "APPROVED")'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then it becomes one MULTI_EXACT_MATCH list field
+    assert len(fields) == 1
+    assert fields[0].field == "status"
+    assert fields[0].type == SearchFieldType.MULTI_EXACT_MATCH
+    assert fields[0].value == {
+        "type": "String",
+        "value": ["DRAFT", "APPROVED"],
+    }
+
+
+def test_same_field_co_or_group_maps_to_multi():
+    # given a same-field paren-OR group of co terms
+    where = '(name co "Allow" or name co "Deny")'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then it becomes one MULTI list field
+    assert len(fields) == 1
+    assert fields[0].field == "name"
+    assert fields[0].type == SearchFieldType.MULTI
+    assert fields[0].value == {"type": "String", "value": ["Allow", "Deny"]}
+
+
+def test_three_term_same_field_or_group_collects_all_values():
+    # given a three-term same-field eq OR group
+    where = '(status eq "DRAFT" or status eq "APPROVED" or status eq "RETIRED")'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then all three values collect into one list field
+    assert len(fields) == 1
+    assert fields[0].type == SearchFieldType.MULTI_EXACT_MATCH
+    assert fields[0].value == {
+        "type": "String",
+        "value": ["DRAFT", "APPROVED", "RETIRED"],
+    }
+
+
+def test_or_group_anded_with_scalar_term():
+    # given a same-field OR group AND-chained with a scalar term
+    where = '(status eq "DRAFT" or status eq "APPROVED") and name co "Allow"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then the group yields a list field and the scalar yields its own field
+    assert len(fields) == 2
+    by_field = {entry.field: entry for entry in fields}
+    assert by_field["status"].type == SearchFieldType.MULTI_EXACT_MATCH
+    assert by_field["name"].type == SearchFieldType.SINGLE_EXACT_MATCH
+
+
+def test_or_group_mixing_operators_raises():
+    # given a same-field OR group mixing eq and co operators
+    where = '(status eq "DRAFT" or status co "APP")'
+
+    # when the filter is transpiled
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)

--- a/tests/test_search_where.py
+++ b/tests/test_search_where.py
@@ -164,3 +164,35 @@ def test_or_group_mixing_operators_raises():
     # then a SearchExpressionError is raised
     with pytest.raises(SearchExpressionError):
         transpile_where(where)
+
+
+def test_cross_field_or_raises_pointing_at_separate_searches():
+    # given an OR across two different fields
+    where = 'status eq "DRAFT" or name co "Allow"'
+
+    # when the filter is transpiled
+    # then it is rejected with guidance to run separate searches
+    with pytest.raises(SearchExpressionError) as exc_info:
+        transpile_where(where)
+    assert "separate searches" in str(exc_info.value)
+
+
+def test_top_level_not_raises_pointing_at_separate_searches():
+    # given a negated filter
+    where = 'not (status eq "DRAFT")'
+
+    # when the filter is transpiled
+    # then it is rejected with guidance to run separate searches
+    with pytest.raises(SearchExpressionError) as exc_info:
+        transpile_where(where)
+    assert "separate searches" in str(exc_info.value)
+
+
+def test_negated_term_inside_and_chain_raises():
+    # given an and-chain containing a negated term
+    where = 'status eq "DRAFT" and not (name co "Allow")'
+
+    # when the filter is transpiled
+    # then the negation is rejected
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)


### PR DESCRIPTION
Closes #230

## Summary
- Add `transpile_where` (`src/nextlabs_sdk/_cloudaz/_search/where.py`) converting a SCIM `--where` filter into a `list[SearchField]` for the MVP operator set: scalar `eq`/`co`/`sw`, `and`-chaining, and same-field parenthesised `or` groups; wire a `--where` option into `policies search` feeding the same `SearchCriteria.filter_field` sink as `--field`.
- Covered red→green with unit tests for the transpiler (`tests/test_search_where.py`) and the CLI command (`tests/test_policies_search_cmd.py`); full suite green (2487 passed, 96% coverage) and `checks.py` clean (black/flake8/mypy/pyright).
- Cross-field `or`/`not` is rejected with a `SearchExpressionError` pointing at running separate searches; date/nested/text/`in` paths remain out of scope (sibling slices).

## Tests added (red → green)
- `test_scalar_eq_maps_to_single_exact_match`
- `test_scalar_co_maps_to_single_exact_match`
- `test_scalar_sw_maps_to_single`
- `test_and_chain_yields_one_field_per_term`
- `test_same_field_eq_or_group_maps_to_multi_exact_match`
- `test_same_field_co_or_group_maps_to_multi`
- `test_cross_field_or_raises_pointing_at_separate_searches`
- `test_top_level_not_raises_pointing_at_separate_searches`
- `test_where_option_issues_search_and_renders_rows`
- `test_where_and_chain_ands_into_one_payload`
- `test_where_cross_field_or_exits_with_error`

## Notable assumptions
- An `or`-group must use a single operator; mixing operators (e.g. `eq` with `co`) or using `sw` in an `or`-group raises `SearchExpressionError`, as the PRD defines list shapes only for `eq`-OR (`MULTI_EXACT_MATCH`) and `co`-OR (`MULTI`).
- `scim2-filter-parser` is pinned (`==0.7.0`) in `requirements/constraints.txt` alongside the `pyproject` `cli`-extra range, matching the repo's runtime-dependency pinning for reproducible CI installs.
- Lexer/parser failures (`ValueError`/`SCIMParserError`) are wrapped as `SearchExpressionError` so no raw parser exceptions leak from the public CLI.
