### PR TITLE
feat(search): complete --where with nested, date and text match types (#231)

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_search/dates.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/dates.py
@@ -51,12 +51,25 @@ def _range_payload(token: str) -> dict[str, Any]:
     from_part, _, to_part = token.partition(_RANGE_SEP)
     return {
         "type": _DATE_LABEL,
-        "fromDate": _to_epoch_ms(from_part),
-        "toDate": _to_epoch_ms(to_part),
+        "fromDate": epoch_millis(from_part),
+        "toDate": epoch_millis(to_part),
     }
 
 
-def _to_epoch_ms(bound: str) -> int:
+def epoch_millis(bound: str) -> int:
+    """Parse an ISO date bound into UTC epoch-milliseconds.
+
+    A naive date is interpreted as UTC; an explicit offset is honoured.
+
+    Args:
+        bound: The raw ISO date bound.
+
+    Returns:
+        The bound as integer milliseconds since the Unix epoch.
+
+    Raises:
+        SearchExpressionError: If the bound is empty or not a valid ISO date.
+    """
     text = bound.strip()
     if not text:
         raise SearchExpressionError("date range bound is missing")

--- a/src/nextlabs_sdk/_cloudaz/_search/where.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/where.py
@@ -1,16 +1,30 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import cast
+from typing import Any, cast
 
-from scim2_filter_parser.ast import AttrExpr, Filter, LogExpr
+from scim2_filter_parser.ast import AttrExpr, AttrPath, Filter, LogExpr
 from scim2_filter_parser.lexer import SCIMLexer
 from scim2_filter_parser.parser import SCIMParser, SCIMParserError
 
 from nextlabs_sdk._cloudaz._search.criteria import SearchField, SearchFieldType
+from nextlabs_sdk._cloudaz._search.dates import (
+    DATE_KEYWORDS,
+    date_value,
+    epoch_millis,
+)
 from nextlabs_sdk.exceptions import SearchExpressionError
 
 _STRING_LABEL = "String"
+_TEXT_LABEL = "Text"
+_DATE_LABEL = "Date"
+_TEXT_ATTR = "text"
+_TEXT_DEFAULT_FIELDS = ("name", "description")
+_FROM_DATE = "fromDate"
+_TO_DATE = "toDate"
+_TYPE_KEY = "type"
+_VALUE_KEY = "value"
+_FIELDS_KEY = "fields"
 
 _SCALAR_TYPES: MappingProxyType[str, SearchFieldType] = MappingProxyType(
     {
@@ -27,11 +41,22 @@ _OR_GROUP_TYPES: MappingProxyType[str, SearchFieldType] = MappingProxyType(
     },
 )
 
+_DATE_BOUND_KEYS: MappingProxyType[str, str] = MappingProxyType(
+    {
+        "ge": _FROM_DATE,
+        "gt": _FROM_DATE,
+        "le": _TO_DATE,
+        "lt": _TO_DATE,
+    },
+)
+
 
 def transpile_where(expr: str) -> list[SearchField]:
     """Transpile a SCIM ``--where`` filter into a list of search fields.
 
-    The supported subset is scalar ``eq``/``co``/``sw`` comparisons,
+    The supported subset is scalar ``eq``/``co``/``sw`` comparisons, the
+    reserved ``text`` attribute, ``ge``/``gt``/``le``/``lt`` date bounds and
+    date keywords, SCIM nested-attribute groupings (``attr[sub op val]``),
     ``and``-chaining (each term becomes its own field), and same-field
     parenthesised ``or`` groups (a single list-valued field). Cross-field
     ``or`` and any ``not`` are rejected as out of scope for a single
@@ -41,13 +66,14 @@ def transpile_where(expr: str) -> list[SearchField]:
         expr: The raw SCIM filter string.
 
     Returns:
-        The transpiled search fields, one entry per ``and``-chained term.
+        The transpiled search fields. Same-field date bounds collapse into a
+        single ``DATE`` window; every other term yields its own entry.
 
     Raises:
         SearchExpressionError: If the filter is malformed, uses an
             unsupported operator, or mixes fields across an ``or``/``not``.
     """
-    return _transpile_filter(_parse(expr))
+    return _merge_date_windows(_transpile_filter(_parse(expr)))
 
 
 def _parse(expr: str) -> Filter:
@@ -65,6 +91,8 @@ def _transpile_filter(node: Filter) -> list[SearchField]:
         raise _cross_field_error()
     inner = node.expr
     if isinstance(inner, Filter):
+        if inner.namespace is not None:
+            return [_nested_field(inner)]
         return _transpile_filter(inner)
     if isinstance(inner, AttrExpr):
         return [_scalar_field(inner)]
@@ -80,6 +108,32 @@ def _transpile_log(node: LogExpr) -> list[SearchField]:
     if operator == "or":
         return [_or_group_field(node)]
     raise _cross_field_error()
+
+
+def _nested_field(node: Filter) -> SearchField:
+    namespace = cast(AttrPath, node.namespace)
+    base = namespace.attr_name
+    terms = _flatten_or_side(cast(Filter, node.expr))
+    sub_names = {term.attr_path.attr_name for term in terms}
+    if len(sub_names) != 1:
+        raise SearchExpressionError(
+            "a nested --where group must target a single sub-attribute",
+        )
+    nested_field = f"{base}.{next(iter(sub_names))}"
+    comp_values = [term.comp_value.value for term in terms]
+    if len(terms) == 1:
+        return SearchField(
+            field=base,
+            type=SearchFieldType.NESTED,
+            value={_TYPE_KEY: _STRING_LABEL, _VALUE_KEY: comp_values[0]},
+            nestedField=nested_field,
+        )
+    return SearchField(
+        field=base,
+        type=SearchFieldType.NESTED_MULTI,
+        value={_TYPE_KEY: _STRING_LABEL, _VALUE_KEY: comp_values},
+        nestedField=nested_field,
+    )
 
 
 def _or_group_field(node: LogExpr) -> SearchField:
@@ -101,8 +155,8 @@ def _or_group_field(node: LogExpr) -> SearchField:
         field=next(iter(names)),
         type=field_type,
         value={
-            "type": _STRING_LABEL,
-            "value": [term.comp_value.value for term in terms],
+            _TYPE_KEY: _STRING_LABEL,
+            _VALUE_KEY: [term.comp_value.value for term in terms],
         },
     )
 
@@ -135,11 +189,77 @@ def _or_group_type(operator: str) -> SearchFieldType:
 
 def _scalar_field(node: AttrExpr) -> SearchField:
     name = _attr_name(node)
-    field_type = _scalar_types(node)
+    operator = node.value.lower()
+    comp_value = node.comp_value.value
+    if operator in _DATE_BOUND_KEYS:
+        return _date_bound_field(name, operator, comp_value)
+    if comp_value.upper() in DATE_KEYWORDS:
+        return _date_keyword_field(name, comp_value)
+    if name == _TEXT_ATTR:
+        return _text_field(name, comp_value)
     return SearchField(
         field=name,
-        type=field_type,
-        value={"type": _STRING_LABEL, "value": node.comp_value.value},
+        type=_scalar_types(operator),
+        value={_TYPE_KEY: _STRING_LABEL, _VALUE_KEY: comp_value},
+    )
+
+
+def _date_bound_field(
+    name: str,
+    operator: str,
+    comp_value: str,
+) -> SearchField:
+    return SearchField(
+        field=name,
+        type=SearchFieldType.DATE,
+        value={
+            _TYPE_KEY: _DATE_LABEL,
+            _DATE_BOUND_KEYS[operator]: epoch_millis(comp_value),
+        },
+    )
+
+
+def _date_keyword_field(name: str, comp_value: str) -> SearchField:
+    return SearchField(
+        field=name,
+        type=SearchFieldType.DATE,
+        value=date_value(comp_value),
+    )
+
+
+def _text_field(name: str, comp_value: str) -> SearchField:
+    return SearchField(
+        field=name,
+        type=SearchFieldType.TEXT,
+        value={
+            _TYPE_KEY: _TEXT_LABEL,
+            _FIELDS_KEY: list(_TEXT_DEFAULT_FIELDS),
+            _VALUE_KEY: comp_value,
+        },
+    )
+
+
+def _merge_date_windows(fields: list[SearchField]) -> list[SearchField]:
+    merged: list[SearchField] = []
+    bound_index: dict[str, int] = {}
+    for field in fields:
+        if _is_date_window_bound(field) and field.field in bound_index:
+            target = merged[bound_index[field.field]]
+            combined: dict[str, Any] = dict(target.value)
+            combined.update(field.value)
+            merged[bound_index[field.field]] = target.model_copy(
+                update={_VALUE_KEY: combined},
+            )
+            continue
+        if _is_date_window_bound(field):
+            bound_index[field.field] = len(merged)
+        merged.append(field)
+    return merged
+
+
+def _is_date_window_bound(field: SearchField) -> bool:
+    return field.type is SearchFieldType.DATE and (
+        _FROM_DATE in field.value or _TO_DATE in field.value
     )
 
 
@@ -151,8 +271,7 @@ def _attr_name(node: AttrExpr) -> str:
     return node.attr_path.attr_name
 
 
-def _scalar_types(node: AttrExpr) -> SearchFieldType:
-    operator = node.value.lower()
+def _scalar_types(operator: str) -> SearchFieldType:
     try:
         return _SCALAR_TYPES[operator]
     except KeyError:

--- a/tests/e2e/test_policy_search_expr.py
+++ b/tests/e2e/test_policy_search_expr.py
@@ -1,0 +1,129 @@
+"""E2E round trip for the ``--where`` transpiler across match types.
+
+Drives ``nextlabs policies search --where`` against a WireMock backend and
+inspects the recorded request body, pinning the ``SINGLE`` /
+``SINGLE_EXACT_MATCH`` operator boundary and the ``DATE`` epoch-millisecond
+window alongside the nested-attribute and list semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+POLICY_SEARCH_PATH = "/console/api/v1/policy/search"
+_STUB_PRIORITY = 1
+
+# 2024-01-01T00:00:00Z and 2024-02-01T00:00:00Z in epoch milliseconds.
+_FROM_DATE_MS = 1704067200000
+_TO_DATE_MS = 1706745600000
+
+
+def _policy_entry() -> dict[str, Any]:
+    return {
+        "id": 1,
+        "name": "Allow helpdesk",
+        "status": "DRAFT",
+        "effectType": "ALLOW",
+        "lastUpdatedDate": _TO_DATE_MS,
+        "createdDate": _FROM_DATE_MS,
+    }
+
+
+def _search_envelope() -> dict[str, Any]:
+    return {
+        "statusCode": "1000",
+        "message": "OK",
+        "data": [_policy_entry()],
+        "pageNo": 0,
+        "pageSize": 20,
+        "totalPages": 1,
+        "totalNoOfRecords": 1,
+    }
+
+
+def _register_search_stub(base_url: str) -> None:
+    response = httpx.post(
+        f"{base_url}/__admin/mappings",
+        json={
+            "priority": _STUB_PRIORITY,
+            "request": {"method": "POST", "urlPath": POLICY_SEARCH_PATH},
+            "response": {
+                "status": 200,
+                "headers": {"Content-Type": "application/json"},
+                "jsonBody": _search_envelope(),
+            },
+        },
+        timeout=5.0,
+    )
+    response.raise_for_status()
+
+
+def _captured_search_body(base_url: str) -> dict[str, Any]:
+    journal = httpx.get(f"{base_url}/__admin/requests", timeout=5.0).json()
+    for entry in journal["requests"]:
+        request = entry["request"]
+        if request["method"] == "POST" and request["url"] == POLICY_SEARCH_PATH:
+            return json.loads(request["body"])
+    raise AssertionError("no policy search request was recorded")
+
+
+def test_where_round_trips_every_match_type(
+    seeded_wiremock: str,
+    cli_runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    # given a stubbed policy-search backend and a multi-criteria filter
+    _register_search_stub(seeded_wiremock)
+    where = (
+        'name sw "Allow" '
+        'and effectType co "ALLOW" '
+        'and (status eq "DRAFT" or status eq "APPROVED") '
+        'and tags[key eq "helpdesk"] '
+        'and text co "ticket" '
+        'and lastUpdatedDate ge "2024-01-01" '
+        'and lastUpdatedDate le "2024-02-01"'
+    )
+
+    # when the CLI runs the search end to end
+    result = cli_runner("policies", "search", "--where", where)
+
+    # then the command succeeds and the request body round-trips every shape
+    assert result.returncode == 0, result.stderr
+    fields = {
+        field["field"]: field
+        for field in _captured_search_body(seeded_wiremock)["criteria"]["fields"]
+    }
+
+    assert fields["name"]["type"] == "SINGLE"
+    assert fields["name"]["value"] == {"type": "String", "value": "Allow"}
+
+    assert fields["effectType"]["type"] == "SINGLE_EXACT_MATCH"
+    assert fields["effectType"]["value"] == {"type": "String", "value": "ALLOW"}
+
+    assert fields["status"]["type"] == "MULTI_EXACT_MATCH"
+    assert fields["status"]["value"] == {
+        "type": "String",
+        "value": ["DRAFT", "APPROVED"],
+    }
+
+    assert fields["tags"]["type"] == "NESTED"
+    assert fields["tags"]["nestedField"] == "tags.key"
+    assert fields["tags"]["value"] == {"type": "String", "value": "helpdesk"}
+
+    assert fields["text"]["type"] == "TEXT"
+    assert fields["text"]["value"] == {
+        "type": "Text",
+        "fields": ["name", "description"],
+        "value": "ticket",
+    }
+
+    assert fields["lastUpdatedDate"]["type"] == "DATE"
+    assert fields["lastUpdatedDate"]["value"] == {
+        "type": "Date",
+        "fromDate": _FROM_DATE_MS,
+        "toDate": _TO_DATE_MS,
+    }

--- a/tests/test_search_where.py
+++ b/tests/test_search_where.py
@@ -196,3 +196,134 @@ def test_negated_term_inside_and_chain_raises():
     # then the negation is rejected
     with pytest.raises(SearchExpressionError):
         transpile_where(where)
+
+
+def test_nested_attribute_group_maps_to_nested():
+    # given a SCIM nested-attribute grouping
+    where = 'tags[key eq "helpdesk"]'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one NESTED field carries the dotted nested path and scalar value
+    assert len(fields) == 1
+    assert fields[0].field == "tags"
+    assert fields[0].type == SearchFieldType.NESTED
+    assert fields[0].nested_field == "tags.key"
+    assert fields[0].value == {"type": "String", "value": "helpdesk"}
+
+
+def test_nested_same_sub_or_group_maps_to_nested_multi():
+    # given a nested grouping with a same-sub or-group
+    where = 'tags[key eq "helpdesk" or key eq "billing"]'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one NESTED_MULTI field collects the sub-attribute values
+    assert len(fields) == 1
+    assert fields[0].field == "tags"
+    assert fields[0].type == SearchFieldType.NESTED_MULTI
+    assert fields[0].nested_field == "tags.key"
+    assert fields[0].value == {
+        "type": "String",
+        "value": ["helpdesk", "billing"],
+    }
+
+
+def test_nested_group_anded_with_scalar_term():
+    # given a nested grouping AND-chained with a scalar term
+    where = 'status eq "DRAFT" and tags[key eq "helpdesk"]'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then the scalar and the nested field both appear
+    assert len(fields) == 2
+    by_field = {entry.field: entry for entry in fields}
+    assert by_field["status"].type == SearchFieldType.SINGLE_EXACT_MATCH
+    assert by_field["tags"].type == SearchFieldType.NESTED
+    assert by_field["tags"].nested_field == "tags.key"
+
+
+def test_nested_group_mixing_sub_attributes_raises():
+    # given a nested or-group mixing two sub-attributes
+    where = 'tags[key eq "a" or label eq "b"]'
+
+    # when the filter is transpiled
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)
+
+
+def test_date_ge_le_pair_maps_to_date_window():
+    # given a same-field ge/le pair of ISO dates
+    where = 'lastUpdatedDate ge "2024-01-01" ' 'and lastUpdatedDate le "2024-02-01"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one DATE field carries the epoch-millisecond window
+    assert len(fields) == 1
+    assert fields[0].field == "lastUpdatedDate"
+    assert fields[0].type == SearchFieldType.DATE
+    assert fields[0].value == {
+        "type": "Date",
+        "fromDate": 1704067200000,
+        "toDate": 1706745600000,
+    }
+
+
+def test_date_keyword_maps_to_date_option():
+    # given a date field compared to a reserved keyword
+    where = 'lastUpdatedDate eq "PAST_7_DAYS"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one DATE field carries the dateOption keyword
+    assert len(fields) == 1
+    assert fields[0].field == "lastUpdatedDate"
+    assert fields[0].type == SearchFieldType.DATE
+    assert fields[0].value == {"type": "Date", "dateOption": "PAST_7_DAYS"}
+
+
+def test_date_single_lower_bound_maps_to_from_date():
+    # given a lone ge lower-bound comparison
+    where = 'lastUpdatedDate ge "2024-01-01"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one DATE field carries only the fromDate bound
+    assert len(fields) == 1
+    assert fields[0].type == SearchFieldType.DATE
+    assert fields[0].value == {"type": "Date", "fromDate": 1704067200000}
+
+
+def test_invalid_date_bound_raises():
+    # given a date bound that is not a valid ISO date
+    where = 'lastUpdatedDate ge "not-a-date"'
+
+    # when the filter is transpiled
+    # then a SearchExpressionError is raised
+    with pytest.raises(SearchExpressionError):
+        transpile_where(where)
+
+
+def test_reserved_text_attribute_maps_to_text():
+    # given the reserved text attribute
+    where = 'text co "ticket"'
+
+    # when the filter is transpiled
+    fields = transpile_where(where)
+
+    # then one TEXT field carries the default name/description subfields
+    assert len(fields) == 1
+    assert fields[0].field == "text"
+    assert fields[0].type == SearchFieldType.TEXT
+    assert fields[0].value == {
+        "type": "Text",
+        "fields": ["name", "description"],
+        "value": "ticket",
+    }


### PR DESCRIPTION
Closes #231

## Summary
- Complete the `--where` SCIM transpiler with the remaining match types: nested-attribute groupings (`tags[key eq "x"]` → `NESTED`, same-sub `or`-group → `NESTED_MULTI`), date bounds and keywords (`ge`/`gt`/`le`/`lt` → a `DATE` window via `fromDate`/`toDate`, reserved keyword → `dateOption`), and the reserved `text` attribute (`text co "term"` → `TEXT` with default `name`/`description` subfields).
- Reuses the date helper from 226/3: extracts a public `epoch_millis` in `_search/dates.py` so both the `from..to` range path and the new `--where` bound path share one ISO→epoch-millisecond conversion.
- Verified with red→green unit tests for each match type plus a CLI end-to-end round trip that drives `nextlabs policies search --where` against a WireMock backend and pins the request-body shape.

## Tests added (red → green)
- `test_nested_attribute_group_maps_to_nested`
- `test_nested_same_sub_or_group_maps_to_nested_multi`
- `test_nested_group_anded_with_scalar_term`
- `test_nested_group_mixing_sub_attributes_raises`
- `test_date_ge_le_pair_maps_to_date_window`
- `test_date_keyword_maps_to_date_option`
- `test_date_single_lower_bound_maps_to_from_date`
- `test_invalid_date_bound_raises`
- `test_reserved_text_attribute_maps_to_text`
- `test_where_round_trips_every_match_type`

## Notable assumptions
- `blocked_by: 229 230` are both merged/closed on `main`, so the slice is unblocked despite the non-empty front-matter field.
- A lone `ge`/`gt` (or `le`/`lt`) bound yields a one-sided `DATE` window (only `fromDate` or `toDate`); the acceptance criteria only exercise the full `ge`+`le` range.
