### PR TITLE
feat(cli): add --criteria-file, multi --sort and --page-no to policies search

### DIFF
--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -37,11 +37,14 @@ from nextlabs_sdk._cli._payload_loader import (
 )
 from nextlabs_sdk._cloudaz._policies import PolicyService
 from nextlabs_sdk._cloudaz._policy_models import Policy, PolicyRevision
-from nextlabs_sdk._cloudaz._search import SearchCriteria
+from nextlabs_sdk._cloudaz._search import SearchCriteria, SortOrder
 from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
 from nextlabs_sdk._cloudaz._search.where import transpile_where
+from nextlabs_sdk.exceptions import SearchExpressionError
 
 policies_app = make_group("Policy management commands")
+
+_UTF8 = "utf-8"
 
 _ID_FIELD = "id"
 _ID_COLUMN = ColumnDef("ID", _ID_FIELD)
@@ -260,7 +263,7 @@ def export_all(
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     exported = client.policies.export_all(export_mode=export_mode)
-    write_bytes(output, exported.encode("utf-8"), overwrite=overwrite)
+    write_bytes(output, exported.encode(_UTF8), overwrite=overwrite)
 
 
 @policies_app.command(name="export-options")
@@ -291,7 +294,7 @@ def generate_xacml(
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     xacml = client.policies.generate_xacml([{_ID_FIELD: policy_id}])
-    write_bytes(output, xacml.encode("utf-8"), overwrite=overwrite)
+    write_bytes(output, xacml.encode(_UTF8), overwrite=overwrite)
 
 
 @policies_app.command(name="generate-pdf")
@@ -312,7 +315,7 @@ def generate_pdf(
     cli_ctx: CliContext = ctx.obj
     client = _client_factory.make_cloudaz_client(cli_ctx)
     pdf = client.policies.generate_pdf([{_ID_FIELD: policy_id}])
-    write_bytes(output, pdf.encode("utf-8"), overwrite=overwrite)
+    write_bytes(output, pdf.encode(_UTF8), overwrite=overwrite)
 
 
 @policies_app.command(name="import-xacml")
@@ -442,19 +445,40 @@ def search(  # noqa: WPS211
             help="SCIM filter, e.g. 'status eq \"DRAFT\"'",
         ),
     ] = None,
-    sort: Annotated[str | None, typer.Option(help="Sort field (e.g. name)")] = None,
+    criteria_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--criteria-file",
+            help=(
+                "Path to a JSON SearchCriteria posted verbatim; "
+                "mutually exclusive with the expression flags"
+            ),
+        ),
+    ] = None,
+    sort: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--sort",
+            help="Repeatable sort field[:asc|desc] (default desc)",
+        ),
+    ] = None,
+    page_no: Annotated[int, typer.Option("--page-no", help="Page number")] = 0,
     page_size: Annotated[int, typer.Option(help="Results per page")] = 20,
 ) -> None:
     """Search policies."""
     cli_ctx: CliContext = ctx.obj
-    criteria = SearchCriteria()
-    _apply_shorthands(criteria, status=status, effect=effect, text=text, tag=tag)
-    for field_expr in field or []:
-        criteria.filter_field(parse_field_expr(field_expr))
-    _apply_where(criteria, where)
-    if sort:
-        criteria.sort_by(sort)
-    criteria.page(page_no=1, page_size=page_size)
+    criteria = _build_search_criteria(
+        status=status,
+        effect=effect,
+        text=text,
+        tag=tag,
+        field=field,
+        where=where,
+        criteria_file=criteria_file,
+        sort=sort,
+        page_no=page_no,
+        page_size=page_size,
+    )
     client = _client_factory.make_cloudaz_client(cli_ctx)
     matches = list(client.policy_search.search(criteria))
     render(
@@ -464,6 +488,72 @@ def search(  # noqa: WPS211
         title="Policies",
         wide_columns=_POLICY_WIDE_COLUMNS,
     )
+
+
+_EXPRESSION_FLAGS = ("--status", "--effect", "--text", "--tag", "--field", "--where")
+
+
+def _build_search_criteria(  # noqa: WPS211
+    *,
+    status: str | None,
+    effect: str | None,
+    text: str | None,
+    tag: str | None,
+    field: list[str] | None,
+    where: str | None,
+    criteria_file: Path | None,
+    sort: list[str] | None,
+    page_no: int,
+    page_size: int,
+) -> SearchCriteria:
+    if criteria_file is not None:
+        _reject_expression_flags([status, effect, text, tag, field, where])
+        return SearchCriteria.from_payload(_load_criteria_file(criteria_file))
+    criteria = SearchCriteria()
+    _apply_shorthands(criteria, status=status, effect=effect, text=text, tag=tag)
+    for field_expr in field or []:
+        criteria.filter_field(parse_field_expr(field_expr))
+    _apply_where(criteria, where)
+    for sort_spec in sort or []:
+        sort_field, sort_order = _parse_sort(sort_spec)
+        criteria.sort_by(sort_field, sort_order)
+    criteria.page(page_no=page_no, page_size=page_size)
+    return criteria
+
+
+def _reject_expression_flags(flag_values: list[object]) -> None:
+    provided = [flag for flag, is_set in zip(_EXPRESSION_FLAGS, flag_values) if is_set]
+    if provided:
+        joined = ", ".join(provided)
+        raise SearchExpressionError(
+            f"--criteria-file cannot be combined with {joined}",
+        )
+
+
+def _load_criteria_file(criteria_file: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(criteria_file.read_text(encoding=_UTF8))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SearchExpressionError(
+            f"could not read criteria file {criteria_file}: {exc}",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SearchExpressionError(
+            f"criteria file {criteria_file} must contain a JSON object",
+        )
+    return payload
+
+
+def _parse_sort(sort_spec: str) -> tuple[str, SortOrder]:
+    field_name, _, order_token = sort_spec.partition(":")
+    if not order_token:
+        return field_name, SortOrder.DESC
+    try:
+        return field_name, SortOrder[order_token.upper()]
+    except KeyError as exc:
+        raise SearchExpressionError(
+            f"invalid sort order {order_token!r}; use 'asc' or 'desc'",
+        ) from exc
 
 
 def _apply_shorthands(

--- a/src/nextlabs_sdk/_cloudaz/_search/criteria.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/criteria.py
@@ -58,6 +58,7 @@ class SavedSearch(BaseModel):
 
 
 _STRING_LABEL = "String"
+_DEFAULT_PAGE_SIZE = 20
 
 
 def _typed_payload(label: str, **entries: Any) -> dict[str, Any]:
@@ -74,6 +75,21 @@ class SearchCriteria:  # noqa: WPS214
         self._sort_fields: list[dict[str, str]] = []
         self._page_no: int = 0
         self._page_size: int = 20
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> SearchCriteria:
+        """Build a criteria from a serialised payload, preserving it verbatim.
+
+        Accepts either the full ``{"criteria": {...}}`` envelope produced by
+        :meth:`to_dict` or a bare criteria body.
+        """
+        body = payload.get("criteria", payload)
+        criteria = cls()
+        criteria._fields = list(body.get("fields", []))
+        criteria._sort_fields = list(body.get("sortFields", []))
+        criteria._page_no = body.get("pageNo", 0)
+        criteria._page_size = body.get("pageSize", _DEFAULT_PAGE_SIZE)
+        return criteria
 
     def filter_type(self, *types: str) -> SearchCriteria:
         self._append_entry(

--- a/tests/test_policies_search_cmd.py
+++ b/tests/test_policies_search_cmd.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -254,3 +256,155 @@ def test_where_cross_field_or_exits_with_error(
     # then the command exits non-zero and no search is issued
     assert result.exit_code != 0
     assert captured == []
+
+
+def _sort_fields(criteria: SearchCriteria) -> list[dict[str, str]]:
+    return criteria.to_dict()["criteria"]["sortFields"]
+
+
+def _criteria_body(criteria: SearchCriteria) -> dict[str, Any]:
+    return criteria.to_dict()["criteria"]
+
+
+def test_criteria_file_posts_payload_verbatim_and_renders_rows(
+    search_stub: tuple[Any, list[SearchCriteria]],
+    tmp_path: Path,
+) -> None:
+    # given a criteria file holding a verbatim SearchCriteria payload
+    _, captured = search_stub
+    payload = {
+        "criteria": {
+            "fields": [
+                {
+                    "field": "status",
+                    "type": "MULTI",
+                    "value": {"type": "String", "value": ["DRAFT"]},
+                },
+            ],
+            "sortFields": [{"field": "name", "order": "ASC"}],
+            "pageNo": 3,
+            "pageSize": 50,
+        },
+    }
+    criteria_file = tmp_path / "criteria.json"
+    criteria_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    # when searching with --criteria-file
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--criteria-file",
+            str(criteria_file),
+        ],
+    )
+
+    # then the rows render and the file's criteria are posted verbatim
+    assert result.exit_code == 0
+    assert "Allow IT Access" in result.output
+    assert captured[0].to_dict() == payload
+
+
+def test_criteria_file_with_expression_flag_exits_with_error(
+    search_stub: tuple[Any, list[SearchCriteria]],
+    tmp_path: Path,
+) -> None:
+    # given a valid criteria file
+    _, captured = search_stub
+    criteria_file = tmp_path / "criteria.json"
+    criteria_file.write_text(
+        json.dumps({"criteria": {"fields": []}}),
+        encoding="utf-8",
+    )
+
+    # when combining --criteria-file with an expression flag
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--criteria-file",
+            str(criteria_file),
+            "--where",
+            'status eq "DRAFT"',
+        ],
+    )
+
+    # then the command exits non-zero and no search is issued
+    assert result.exit_code != 0
+    assert captured == []
+
+
+def test_repeated_sort_options_preserve_order_and_explicit_direction(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when passing two --sort flags with explicit directions
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--sort",
+            "name:asc",
+            "--sort",
+            "lastUpdatedDate:desc",
+        ],
+    )
+
+    # then the sort fields keep their order and directions
+    assert result.exit_code == 0
+    assert _sort_fields(captured[0]) == [
+        {"field": "name", "order": "ASC"},
+        {"field": "lastUpdatedDate", "order": "DESC"},
+    ]
+
+
+def test_bare_sort_option_defaults_to_descending(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when passing a bare --sort field with no direction
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "policies", "search", "--sort", "name"],
+    )
+
+    # then the field sorts descending by default
+    assert result.exit_code == 0
+    assert _sort_fields(captured[0]) == [{"field": "name", "order": "DESC"}]
+
+
+def test_page_no_and_page_size_set_pagination_fields(
+    search_stub: tuple[Any, list[SearchCriteria]],
+) -> None:
+    # given a search stub capturing the built criteria
+    _, captured = search_stub
+
+    # when passing --page-no and --page-size
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--page-no",
+            "2",
+            "--page-size",
+            "5",
+        ],
+    )
+
+    # then the criteria carry the requested pagination values
+    assert result.exit_code == 0
+    body = _criteria_body(captured[0])
+    assert body["pageNo"] == 2
+    assert body["pageSize"] == 5


### PR DESCRIPTION
Closes #232

## Summary
- Add `--criteria-file` (posts a JSON `SearchCriteria` verbatim, mutually exclusive with the expression flags), a repeatable `--sort field[:asc|desc]` defaulting to `desc`, and `--page-no` to `policies search`.
- Verified by new CLI tests driven through the Typer runner with a mocked `PolicySearchService` capturing the built criteria (red → green).
- Trade-off: `--criteria-file` mutual exclusivity is enforced only against the expression flags (`--status`/`--effect`/`--text`/`--tag`/`--field`/`--where`), per the AC and PRD.

## Tests added (red → green)
- `test_criteria_file_posts_payload_verbatim_and_renders_rows`
- `test_criteria_file_with_expression_flag_exits_with_error`
- `test_repeated_sort_options_preserve_order_and_explicit_direction`
- `test_bare_sort_option_defaults_to_descending`
- `test_page_no_and_page_size_set_pagination_fields`

## Notable assumptions
- `--criteria-file` accepts either the full `{"criteria": {...}}` envelope produced by `SearchCriteria.to_dict()` or a bare criteria body; `SearchCriteria.from_payload` normalises both and preserves `fields`/`sortFields`/`pageNo`/`pageSize` verbatim.
- `--page-no` default changed from the previous hard-coded `1` to `0`, matching the PRD pagination defaults.
- The pre-existing paginator resets `pageSize` to its default on each page fetch in the service layer; that runtime behaviour is outside this slice's scope (the slice modifies `_policies_cmd.py` only). The acceptance criteria assert on the built criteria object.
