### PR TITLE
docs(search): document policy-search expressions and mark ADR 0004 implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,111 @@ nextlabs -o detail policies get 17
 nextlabs --output json components search    # machine-readable
 ```
 
+### Searching policies
+
+`nextlabs policies search` accepts three composable front-ends, all of
+which compile to the same backend `SearchCriteria` (an array of
+`SearchField` entries the server combines with **AND**). Pick the register
+that fits the job:
+
+| Flag | Register | Shape |
+| --- | --- | --- |
+| `--where '<SCIM filter>'` | Human | An RFC 7644 (SCIM) filter string. |
+| `--field 'NAME[:TYPE]=VALUE'` (repeatable) | Scriptable | One explicit field per flag. |
+| `--criteria-file <path>` | Raw escape | A JSON `SearchCriteria` posted verbatim. |
+
+The six original shorthand flags (`--status`, `--effect`, `--text`,
+`--tag`, plus `--sort` and the paging flags) still work and **desugar** to
+the equivalent `SearchField`(s); their behavior is unchanged.
+
+#### `--where` — SCIM filter (human register)
+
+```bash
+# Prefix match on name, exact match on status (AND-combined):
+nextlabs policies search --where 'name sw "billing" and status eq "APPROVED"'
+
+# Same-field OR collapses into one MULTI list:
+nextlabs policies search --where 'status eq "DRAFT" or status eq "APPROVED"'
+
+# Nested attribute group (tags.team):
+nextlabs policies search --where 'tags[team eq "finance"]'
+
+# Date window on an updated-at field:
+nextlabs policies search --where 'updatedAt ge "2024-01-01" and updatedAt le "2024-03-31"'
+
+# Reserved 'text' attribute → bundled TEXT search over name + description:
+nextlabs policies search --where 'text co "invoice"'
+```
+
+The `--where` parser maps SCIM operators to backend **match types** as
+follows:
+
+| SCIM input | Match type |
+| --- | --- |
+| `field sw "v"` (prefix) | `SINGLE` |
+| `field eq "v"` / `field co "v"` (scalar) | `SINGLE_EXACT_MATCH` |
+| `field co "a" or field co "b"` (same field) | `MULTI` |
+| `field eq "a" or field eq "b"` (same field) | `MULTI_EXACT_MATCH` |
+| `field ge/gt/le/lt "<iso-date>"` | `DATE` (`fromDate`/`toDate`) |
+| `attr[sub op "v"]` (nested) | `NESTED` |
+| `attr[sub op "a" or sub op "b"]` (same sub) | `NESTED_MULTI` |
+| `text co "v"` (reserved attribute) | `TEXT` (subfields `name`, `description`) |
+
+Because the backend ANDs fields and has no cross-field `OR`/negation,
+**cross-field `OR` and any `NOT` are rejected** with a
+`SearchExpressionError` that points you at running separate searches.
+There is no `in` operator — express lists as a same-field paren-OR group
+(`status eq "a" or status eq "b"`), or use the terser `--field f=a,b`.
+
+#### `--field` — explicit field (scriptable register)
+
+`--field` is repeatable and takes `NAME[:TYPE]=VALUE`. `TYPE` is a
+`SearchFieldType` token (case-insensitive); when omitted it is inferred:
+
+| Expression | Inferred match type |
+| --- | --- |
+| `--field 'status=APPROVED'` | `SINGLE_EXACT_MATCH` |
+| `--field 'status=DRAFT,APPROVED'` (comma → list) | `MULTI` |
+| `--field 'tags.team=finance'` (dotted → nested) | `NESTED` |
+| `--field 'tags.team=finance,legal'` (dotted + comma) | `NESTED_MULTI` |
+| `--field 'name:SINGLE=billing'` (explicit `:TYPE`) | `SINGLE` |
+| `--field 'updatedAt:DATE=2024-01-01..2024-03-31'` | `DATE` |
+| `--field 'text:TEXT=invoice'` | `TEXT` |
+
+A comma in `VALUE` always splits it into a list. A dotted `NAME` sets the
+backend `field` to the segment before the last dot and `nestedField` to
+the full dotted path. `DATE` values are either a keyword (`PAST_7_DAYS`,
+`PAST_30_DAYS`, `PAST_3_MONTHS`, `PAST_1_YEAR`) or a `from..to` range of
+ISO dates parsed to epoch-milliseconds.
+
+```bash
+nextlabs policies search \
+  --field 'status=APPROVED' \
+  --field 'tags.team=finance' \
+  --sort updatedAt:desc --page-size 50
+```
+
+#### `--criteria-file` — raw JSON escape
+
+```bash
+nextlabs policies search --criteria-file ./criteria.json
+```
+
+`--criteria-file` is **mutually exclusive** with `--status`, `--effect`,
+`--text`, `--tag`, `--field`, and `--where`; combining them raises a
+`SearchExpressionError`.
+
+#### Sorting and paging
+
+`--sort` is repeatable, takes `field[:asc|desc]` (default `desc`), and
+preserves order. Paging is `--page-no` (default `0`) and `--page-size`
+(default `20`).
+
+> **Field names are server-defined.** The CLI does not validate them
+> client-side — a misspelled field name passes through to the backend,
+> which typically returns an empty result set rather than an error. See
+> [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ### Recipes
 
 Real workflows assembled from the commands shipped today.

--- a/docs/adr/0004-policy-search-expression-grammar.md
+++ b/docs/adr/0004-policy-search-expression-grammar.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Implemented
 
 <!--
 Lifecycle: Draft (recorded, not yet realised) → Implemented (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ notice — do not import from tests outside their own module, examples, or docs.
 | `_auth/_active_account/` | Active-account selection and persistence. |
 | `_auth/_token_cache/` | File-backed token store (`CachedToken`, `FileTokenCache`). |
 | `_cloudaz/` | CloudAz client internals: request builders, pagination, response helpers. |
+| `_cloudaz/_search/` | Policy-search core: `SearchCriteria`/`SearchField`/`SearchFieldType` models (`criteria.py`), the SCIM `--where` transpiler (`where.py`, `transpile_where`), the `--field` parser (`field_expr.py`, `parse_field_expr`), and DATE parsing (`dates.py`). Pure transforms; see [ADR 0004](adr/0004-policy-search-expression-grammar.md). |
 | `_pdp/` | PDP client internals: token-url resolution, evaluation request/response models. |
 | `_pdp/_payload/` | PDP evaluation payload Pydantic models. |
 | `_cli/` | Typer + Rich CLI: entrypoints, context resolvers, error handler, subcommands. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,3 +125,54 @@ This writes the latest spec to
 `tests/_openapi/fixtures/nextlabs-openapi.json`. Review the diff, run the test
 suite (including `--e2e`), fix any new round-trip or model-registry failures,
 then commit. The helper refuses to run in CI.
+
+## Policy search expressions
+
+The `nextlabs policies search` front-ends (`--where`, `--field`,
+`--criteria-file`) are thin CLI wrappers over pure, side-effect-free
+transforms in `_cloudaz/_search/`. All three compile to one
+`SearchField` list that the backend combines with **AND**. The CLI-facing
+walkthrough lives in the [README](../README.md#searching-policies); the
+design rationale is [ADR 0004](adr/0004-policy-search-expression-grammar.md).
+
+The two parser entry points are reusable by programmatic SDK callers:
+
+| Entry point | Module | Input → output |
+| --- | --- | --- |
+| `transpile_where` | `_cloudaz/_search/where.py` | A SCIM `--where` string → `list[SearchField]`. |
+| `parse_field_expr` | `_cloudaz/_search/field_expr.py` | One `NAME[:TYPE]=VALUE` `--field` token → `SearchField`. |
+| `date_value` / `epoch_millis` | `_cloudaz/_search/dates.py` | A DATE keyword or `from..to` ISO range → date payload. |
+
+```python
+from nextlabs_sdk._cloudaz._search.where import transpile_where
+from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
+
+fields = transpile_where('name sw "billing" and status eq "APPROVED"')
+fields.append(parse_field_expr("tags.team=finance"))
+```
+
+### SCIM operator → match-type mapping
+
+`--where` maps SCIM operators onto the eight backend `SearchFieldType`
+values:
+
+| SCIM input | Match type |
+| --- | --- |
+| `field sw "v"` (prefix) | `SINGLE` |
+| `field eq "v"` / `field co "v"` (scalar) | `SINGLE_EXACT_MATCH` |
+| `field co "a" or field co "b"` (same field) | `MULTI` |
+| `field eq "a" or field eq "b"` (same field) | `MULTI_EXACT_MATCH` |
+| `field ge/gt/le/lt "<iso-date>"` | `DATE` (`fromDate`/`toDate`) |
+| `attr[sub op "v"]` (nested) | `NESTED` |
+| `attr[sub op "a" or sub op "b"]` (same sub) | `NESTED_MULTI` |
+| `text co "v"` (reserved attribute) | `TEXT` (subfields `name`, `description`) |
+
+`--field` uses the same `SearchFieldType` tokens explicitly
+(case-insensitive after `:`) and otherwise infers: a dotted `NAME` →
+`NESTED`/`NESTED_MULTI`, a comma in `VALUE` → `MULTI`, else
+`SINGLE_EXACT_MATCH`.
+
+All parsers raise `SearchExpressionError` (a `NextLabsError` subclass) on
+malformed input, an unsupported operator, a cross-field `OR`/`NOT`, or a
+`--criteria-file` combined with an expression flag — never a raw parser,
+`ValueError`, or `httpx` exception.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,3 +179,55 @@ nextlabs -vv pdp eval \
 Use `-v` (single) to add only request context to errors; `-vv` (double)
 prints every HTTP request and response body. Add the missing attribute
 with `--subject-attr key=value`, `--resource-attr key=value`, etc.
+
+## `SearchExpressionError: cross-field 'or'/'not' is unsupported in --where`
+
+**Symptom:** `nextlabs policies search --where '...'` fails with
+`cross-field 'or'/'not' is unsupported in --where; run separate searches
+instead`.
+
+**Cause:** the backend combines search fields with **AND** only — it has
+no server-side `OR`, negation, or grouping *across different fields*. The
+`--where` transpiler therefore rejects an `or` that spans two field names
+(e.g. `status eq "DRAFT" or effect eq "DENY"`) and any `not`.
+
+**Fix:** a same-field `or` *is* supported and collapses into one `MULTI`
+list — keep the field name identical on both sides:
+
+```bash
+# OK — same field, becomes one MULTI_EXACT_MATCH list:
+nextlabs policies search --where 'status eq "DRAFT" or status eq "APPROVED"'
+```
+
+For a true cross-field `OR`, run one search per branch and union the
+results client-side:
+
+```bash
+nextlabs -o json policies search --where 'status eq "DRAFT"'  > a.json
+nextlabs -o json policies search --where 'effect eq "DENY"'   > b.json
+jq -s 'add | unique_by(.id)' a.json b.json
+```
+
+## `policies search` returns nothing for a field you know has data
+
+**Symptom:** a `--where` or `--field` query with a perfectly valid syntax
+returns an empty table, even though matching policies clearly exist.
+
+**Cause:** **field names are server-defined and are passed through
+verbatim** — the CLI does not (and cannot) validate them client-side,
+because there is no field-discovery API. A misspelled or wrong-case field
+name (`updateAt` instead of `updatedAt`, `Status` instead of `status`)
+reaches the backend unchanged, matches nothing, and yields an empty
+result set rather than a `SearchExpressionError`.
+
+**Fix:** confirm the exact field name the backend expects (check an
+existing policy's JSON with `nextlabs -o json policies get <id>`), then
+re-run. To see the request the CLI actually sent, add `-vv`:
+
+```bash
+nextlabs -vv policies search --where 'status eq "APPROVED"'
+```
+
+A `SearchExpressionError` means the *expression* was malformed (bad
+operator, unbalanced quotes, cross-field `or`); an empty result with no
+error usually means a valid expression over a non-existent field.

--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -54,6 +54,12 @@
 | **Folder** | The hierarchical container in which **Policies** and **Components** live. | directory |
 | **Deployment** | The act and state of pushing a **Policy** or **Component** revision out to enforcement points. | publish, push |
 | **DPS** | A Deployment Push Service target referenced by `dps_url` in **PushResults**. | endpoint URL |
+| **SearchCriteria** | The policy-search request: an array of **SearchField** entries (server-combined with **AND**), plus sort and paging. Built from `--where`, `--field`, the shorthand flags, or `--criteria-file`. | query, filter |
+| **SearchField** | One criterion in a **SearchCriteria**: a `field`, a **SearchFieldType**, a value payload, and an optional `nestedField`. | criterion, filter entry |
+| **SearchFieldType** | The backend **match type** of a **SearchField**: `SINGLE`, `SINGLE_EXACT_MATCH`, `TEXT`, `DATE`, `MULTI`, `MULTI_EXACT_MATCH`, `NESTED`, or `NESTED_MULTI`. | operator, mode |
+| **`--where` filter** | A SCIM (RFC 7644) filter string the CLI transpiles into **SearchField**s (the human search register). | query string |
+| **`--field` expression** | A `NAME[:TYPE]=VALUE` token parsed into a single **SearchField** (the scriptable search register). | field flag |
+| **Reserved `text` attribute** | The special `--where`/`--field` name that emits one `TEXT` **SearchField** over the bundled subfields `name` and `description`. | full-text |
 
 ## Authorization runtime (PDP domain)
 
@@ -88,6 +94,7 @@ escape public APIs, see [`architecture.md`](./architecture.md).
 | **AuthorizationError** | HTTP 403. | forbidden |
 | **PdpStatusError** | HTTP 200 with a non-ok XACML **Status** from the **PDP**. Subclass of **ApiError**. | xacml error |
 | **PdpPayloadError** | Local failure to read or parse a PDP request payload file. | payload error |
+| **SearchExpressionError** | Client-side failure to parse or transpile a `--where`/`--field` expression, or an illegal flag combination (e.g. `--criteria-file` with an expression flag). Subclass of **NextLabsError**. | parse error, filter error |
 
 ## Relationships
 


### PR DESCRIPTION
Closes #233

## Summary
- Documented the new policy-search surface (`--where`, `--field`, `--criteria-file`) end-to-end: a new "Searching policies" section in `README.md` with worked examples and the SCIM operator → match-type mapping, a programmatic-API counterpart in `docs/development.md` (entry points `transpile_where` / `parse_field_expr` / `date_value`, plus the same mapping), the `_cloudaz/_search/` module row in `docs/architecture.md`, SearchCriteria/SearchField/SearchFieldType/`--where`/`--field`/`SearchExpressionError` terms in `docs/ubiquitous_language.md`, and two new troubleshooting entries (cross-field `OR`/`NOT` rejection and server-defined field-name passthrough).
- Flipped ADR 0004 Status from Draft to Implemented now that the delivering slices (#228–#232) have landed.
- Documentation-only change; verified against the live implementation in `src/nextlabs_sdk/_cloudaz/_search/` and the CLI `policies search` command. No source or test behavior changed.

## Notable assumptions
- The `docs/development.md` acceptance criterion is satisfied from the contributor/SDK angle (parser entry points + mapping) with a link to the README walkthrough, to avoid duplicating the full CLI tutorial verbatim across both docs.
- Worked `--where`/`--field` examples use representative field names (`name`, `status`, `updatedAt`, `tags.team`); field names are server-defined, so these illustrate shape rather than a fixed schema.
