### PR TITLE
fix(PRD): #226 cleanup — capstone findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,9 @@ nextlabs policies search --criteria-file ./criteria.json
 ```
 
 `--criteria-file` is **mutually exclusive** with `--status`, `--effect`,
-`--text`, `--tag`, `--field`, and `--where`; combining them raises a
-`SearchExpressionError`.
+`--text`, `--tag`, `--field`, `--where`, `--sort`, `--page-no`, and
+`--page-size`; combining them raises a `SearchExpressionError`. Encode any
+sorting and paging inside the JSON payload itself.
 
 #### Sorting and paging
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,17 +135,18 @@ transforms in `_cloudaz/_search/`. All three compile to one
 walkthrough lives in the [README](../README.md#searching-policies); the
 design rationale is [ADR 0004](adr/0004-policy-search-expression-grammar.md).
 
-The two parser entry points are reusable by programmatic SDK callers:
+The parser entry points are part of the supported public surface and are
+reusable by programmatic SDK callers — import them from
+`nextlabs_sdk.cloudaz`, never from the internal `_cloudaz` modules:
 
-| Entry point | Module | Input → output |
-| --- | --- | --- |
-| `transpile_where` | `_cloudaz/_search/where.py` | A SCIM `--where` string → `list[SearchField]`. |
-| `parse_field_expr` | `_cloudaz/_search/field_expr.py` | One `NAME[:TYPE]=VALUE` `--field` token → `SearchField`. |
-| `date_value` / `epoch_millis` | `_cloudaz/_search/dates.py` | A DATE keyword or `from..to` ISO range → date payload. |
+| Entry point | Input → output |
+| --- | --- |
+| `transpile_where` | A SCIM `--where` string → `list[SearchField]`. |
+| `parse_field_expr` | One `NAME[:TYPE]=VALUE` `--field` token → `SearchField`. |
+| `date_value` / `epoch_millis` | A DATE keyword or `from..to` ISO range → date payload. |
 
 ```python
-from nextlabs_sdk._cloudaz._search.where import transpile_where
-from nextlabs_sdk._cloudaz._search.field_expr import parse_field_expr
+from nextlabs_sdk.cloudaz import parse_field_expr, transpile_where
 
 fields = transpile_where('name sw "billing" and status eq "APPROVED"')
 fields.append(parse_field_expr("tags.team=finance"))

--- a/src/nextlabs_sdk/_cli/_policies_cmd.py
+++ b/src/nextlabs_sdk/_cli/_policies_cmd.py
@@ -462,8 +462,12 @@ def search(  # noqa: WPS211
             help="Repeatable sort field[:asc|desc] (default desc)",
         ),
     ] = None,
-    page_no: Annotated[int, typer.Option("--page-no", help="Page number")] = 0,
-    page_size: Annotated[int, typer.Option(help="Results per page")] = 20,
+    page_no: Annotated[
+        int | None, typer.Option("--page-no", help="Page number (default 0)")
+    ] = None,
+    page_size: Annotated[
+        int | None, typer.Option(help="Results per page (default 20)")
+    ] = None,
 ) -> None:
     """Search policies."""
     cli_ctx: CliContext = ctx.obj
@@ -491,6 +495,8 @@ def search(  # noqa: WPS211
 
 
 _EXPRESSION_FLAGS = ("--status", "--effect", "--text", "--tag", "--field", "--where")
+_DEFAULT_PAGE_NO = 0
+_DEFAULT_PAGE_SIZE = 20
 
 
 def _build_search_criteria(  # noqa: WPS211
@@ -503,11 +509,12 @@ def _build_search_criteria(  # noqa: WPS211
     where: str | None,
     criteria_file: Path | None,
     sort: list[str] | None,
-    page_no: int,
-    page_size: int,
+    page_no: int | None,
+    page_size: int | None,
 ) -> SearchCriteria:
     if criteria_file is not None:
         _reject_expression_flags([status, effect, text, tag, field, where])
+        _reject_sort_and_paging(sort=sort, page_no=page_no, page_size=page_size)
         return SearchCriteria.from_payload(_load_criteria_file(criteria_file))
     criteria = SearchCriteria()
     _apply_shorthands(criteria, status=status, effect=effect, text=text, tag=tag)
@@ -517,12 +524,35 @@ def _build_search_criteria(  # noqa: WPS211
     for sort_spec in sort or []:
         sort_field, sort_order = _parse_sort(sort_spec)
         criteria.sort_by(sort_field, sort_order)
-    criteria.page(page_no=page_no, page_size=page_size)
+    criteria.page(
+        page_no=_DEFAULT_PAGE_NO if page_no is None else page_no,
+        page_size=_DEFAULT_PAGE_SIZE if page_size is None else page_size,
+    )
     return criteria
 
 
 def _reject_expression_flags(flag_values: list[object]) -> None:
     provided = [flag for flag, is_set in zip(_EXPRESSION_FLAGS, flag_values) if is_set]
+    if provided:
+        joined = ", ".join(provided)
+        raise SearchExpressionError(
+            f"--criteria-file cannot be combined with {joined}",
+        )
+
+
+def _reject_sort_and_paging(
+    *,
+    sort: list[str] | None,
+    page_no: int | None,
+    page_size: int | None,
+) -> None:
+    provided = []
+    if sort:
+        provided.append("--sort")
+    if page_no is not None:
+        provided.append("--page-no")
+    if page_size is not None:
+        provided.append("--page-size")
     if provided:
         joined = ", ".join(provided)
         raise SearchExpressionError(

--- a/src/nextlabs_sdk/_cloudaz/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/__init__.py
@@ -49,6 +49,8 @@ __all__: list[str] = [
     "SavedReportCriteria",
     "SavedSearch",
     "SearchCriteria",
+    "SearchField",
+    "SearchFieldType",
     "SystemConfig",
     "UserGroup",
     "WidgetData",
@@ -67,6 +69,11 @@ __all__: list[str] = [
     "Operator",
     "Tag",
     "TagType",
+    # Search helpers
+    "date_value",
+    "epoch_millis",
+    "parse_field_expr",
+    "transpile_where",
 ]
 
 from nextlabs_sdk._cloudaz._async_client import (
@@ -204,6 +211,24 @@ from nextlabs_sdk._cloudaz._search import (
 )
 from nextlabs_sdk._cloudaz._search import (
     SearchCriteria as SearchCriteria,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SearchField as SearchField,
+)
+from nextlabs_sdk._cloudaz._search import (
+    SearchFieldType as SearchFieldType,
+)
+from nextlabs_sdk._cloudaz._search import (
+    date_value as date_value,
+)
+from nextlabs_sdk._cloudaz._search import (
+    epoch_millis as epoch_millis,
+)
+from nextlabs_sdk._cloudaz._search import (
+    parse_field_expr as parse_field_expr,
+)
+from nextlabs_sdk._cloudaz._search import (
+    transpile_where as transpile_where,
 )
 from nextlabs_sdk._cloudaz._system_config_models import (
     SystemConfig as SystemConfig,

--- a/src/nextlabs_sdk/_cloudaz/_search/__init__.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/__init__.py
@@ -21,3 +21,15 @@ from nextlabs_sdk._cloudaz._search.criteria import (
 from nextlabs_sdk._cloudaz._search.criteria import (
     SortOrder as SortOrder,
 )
+from nextlabs_sdk._cloudaz._search.dates import (
+    date_value as date_value,
+)
+from nextlabs_sdk._cloudaz._search.dates import (
+    epoch_millis as epoch_millis,
+)
+from nextlabs_sdk._cloudaz._search.field_expr import (
+    parse_field_expr as parse_field_expr,
+)
+from nextlabs_sdk._cloudaz._search.where import (
+    transpile_where as transpile_where,
+)

--- a/src/nextlabs_sdk/cloudaz/__init__.py
+++ b/src/nextlabs_sdk/cloudaz/__init__.py
@@ -52,6 +52,8 @@ __all__: list[str] = [
     "SavedReportCriteria",
     "SavedSearch",
     "SearchCriteria",
+    "SearchField",
+    "SearchFieldType",
     "SystemConfig",
     "UserGroup",
     "WidgetData",
@@ -70,6 +72,11 @@ __all__: list[str] = [
     "Operator",
     "Tag",
     "TagType",
+    # Search helpers
+    "date_value",
+    "epoch_millis",
+    "parse_field_expr",
+    "transpile_where",
 ]
 
 from nextlabs_sdk._cloudaz import ActivityByEntity as ActivityByEntity
@@ -136,9 +143,15 @@ from nextlabs_sdk._cloudaz import SaveInfo as SaveInfo
 from nextlabs_sdk._cloudaz import SavedReportCriteria as SavedReportCriteria
 from nextlabs_sdk._cloudaz import SavedSearch as SavedSearch
 from nextlabs_sdk._cloudaz import SearchCriteria as SearchCriteria
+from nextlabs_sdk._cloudaz import SearchField as SearchField
+from nextlabs_sdk._cloudaz import SearchFieldType as SearchFieldType
 from nextlabs_sdk._cloudaz import SystemConfig as SystemConfig
 from nextlabs_sdk._cloudaz import Tag as Tag
 from nextlabs_sdk._cloudaz import TagService as TagService
 from nextlabs_sdk._cloudaz import TagType as TagType
 from nextlabs_sdk._cloudaz import UserGroup as UserGroup
 from nextlabs_sdk._cloudaz import WidgetData as WidgetData
+from nextlabs_sdk._cloudaz import date_value as date_value
+from nextlabs_sdk._cloudaz import epoch_millis as epoch_millis
+from nextlabs_sdk._cloudaz import parse_field_expr as parse_field_expr
+from nextlabs_sdk._cloudaz import transpile_where as transpile_where

--- a/tests/architecture/test_issue_226_invariants.py
+++ b/tests/architecture/test_issue_226_invariants.py
@@ -1,0 +1,46 @@
+"""Architectural invariants for issue #226.
+
+Pins the policy-search parser helpers (and their supporting types) onto
+the public ``nextlabs_sdk.cloudaz`` surface. User story 12 promises these
+transforms as reusable SDK entry points, so programmatic callers must not
+have to reach into the internal ``_cloudaz._search`` modules.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("public_name", "internal_module", "internal_name"),
+    [
+        ("transpile_where", "nextlabs_sdk._cloudaz._search.where", "transpile_where"),
+        (
+            "parse_field_expr",
+            "nextlabs_sdk._cloudaz._search.field_expr",
+            "parse_field_expr",
+        ),
+        ("date_value", "nextlabs_sdk._cloudaz._search.dates", "date_value"),
+        ("epoch_millis", "nextlabs_sdk._cloudaz._search.dates", "epoch_millis"),
+        ("SearchField", "nextlabs_sdk._cloudaz._search", "SearchField"),
+        ("SearchFieldType", "nextlabs_sdk._cloudaz._search", "SearchFieldType"),
+    ],
+)
+def test_search_helper_is_publicly_re_exported(
+    public_name: str,
+    internal_module: str,
+    internal_name: str,
+) -> None:
+    # given the public CloudAz surface and the internal search module
+    public = importlib.import_module("nextlabs_sdk.cloudaz")
+    internal = importlib.import_module(internal_module)
+
+    # when the helper is resolved from each side
+    public_obj = getattr(public, public_name)
+    internal_obj = getattr(internal, internal_name)
+
+    # then the public name re-exports the exact internal object
+    assert public_obj is internal_obj
+    assert public_name in public.__all__

--- a/tests/test_policies_search_cmd.py
+++ b/tests/test_policies_search_cmd.py
@@ -338,6 +338,45 @@ def test_criteria_file_with_expression_flag_exits_with_error(
     assert captured == []
 
 
+@pytest.mark.parametrize(
+    "extra_flags",
+    [
+        ["--sort", "name:asc"],
+        ["--page-no", "2"],
+        ["--page-size", "50"],
+    ],
+)
+def test_criteria_file_with_sort_or_paging_flag_exits_with_error(
+    search_stub: tuple[Any, list[SearchCriteria]],
+    tmp_path: Path,
+    extra_flags: list[str],
+) -> None:
+    # given a valid criteria file
+    _, captured = search_stub
+    criteria_file = tmp_path / "criteria.json"
+    criteria_file.write_text(
+        json.dumps({"criteria": {"fields": []}}),
+        encoding="utf-8",
+    )
+
+    # when combining --criteria-file with a sort or paging flag
+    result = runner.invoke(
+        app,
+        [
+            *_GLOBAL_OPTS,
+            "policies",
+            "search",
+            "--criteria-file",
+            str(criteria_file),
+            *extra_flags,
+        ],
+    )
+
+    # then the command exits non-zero and no search is issued
+    assert result.exit_code != 0
+    assert captured == []
+
+
 def test_repeated_sort_options_preserve_order_and_explicit_direction(
     search_stub: tuple[Any, list[SearchCriteria]],
 ) -> None:


### PR DESCRIPTION
Addresses capstone findings from the local `<prd-review>` for PRD #226.

Finding IDs addressed:
  - F1 — expose policy-search parsers (`transpile_where`, `parse_field_expr`, `date_value`, `epoch_millis`, `SearchField`, `SearchFieldType`) on the public `nextlabs_sdk.cloudaz` surface (closes US12 coverage gap)
  - F2 — `--criteria-file` now rejects `--sort`/`--page-no`/`--page-size` instead of silently dropping them

Finding IDs skipped (with reason):
  - F3 (scope: capstone diff also carries unrelated `policies diff` work): ignored per request — out of scope for this cleanup
  - F4 (architectural-coherence: extract search builder from the CLI module): not worth it — pure structural refactor with no behavior change; churn/risk on the 848-line module outweighs the value for this selective cleanup

Closes #226 (capstone cleanup).
