### PR TITLE
feat(token-cache): encrypt CLI token cache at rest via NEXTLABS_MASTER_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ All imports come from four public entry points:
   `RetryConfig`, `create_http_client`, `create_async_http_client`),
   pagination (`SyncPaginator`, `AsyncPaginator`, `PageResult`), auth
   (`CloudAzAuth`, `PdpAuth`, `StaticTokenAuth`), token cache
-  (`TokenCache`, `CachedToken`, `FileTokenCache`, `NullTokenCache`),
-  and `__version__`.
+  (`TokenCache`, `CachedToken`, `FileTokenCache`,
+  `EncryptedFileTokenCache`, `NullTokenCache`), and `__version__`.
 - `nextlabs_sdk.cloudaz` — CloudAz domain models and enums (`Tag`,
   `TagType`, `Operator`, audit-log / report / dashboard /
   system-config / activity-log models).
@@ -479,6 +479,15 @@ The file is written `0600` inside a `0700` directory; writes are atomic
 (temp file + `os.replace`). The cache key is
 `"{token_url}|{username}|{client_id}"` so multiple profiles coexist.
 
+**Encryption at rest.** When `NEXTLABS_MASTER_PASSWORD` is set, the CLI
+stores the cache as an `EncryptedFileTokenCache` — an `NLBX` envelope
+where a random data key (DEK) encrypts the payload under AES-256-GCM and
+is itself wrapped by a key derived from the passphrase (Argon2id). The
+cache migrates organically: a legacy plaintext `tokens.json` is read
+once and rewritten encrypted on the next write. Without a passphrase the
+CLI keeps a plaintext cache and prints a one-time stderr warning; set
+`NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1` to silence it.
+
 Refresh tokens are used transparently when available; on refresh failure
 the CLI falls back to the password grant (if `--password` /
 `NEXTLABS_PASSWORD` is set) and otherwise raises `AuthenticationError`
@@ -630,6 +639,8 @@ Notes:
 | `NEXTLABS_PDP_CLIENT_ID`   | PDP-specific client ID (required when `--pdp-auth=pdp`)       |
 | `NEXTLABS_TOKEN`           | Pre-issued bearer token; bypasses the login flow and cache    |
 | `NEXTLABS_CACHE_DIR`       | Directory holding `tokens.json` (overrides XDG default)       |
+| `NEXTLABS_MASTER_PASSWORD` | Passphrase that encrypts the token cache at rest (see below)  |
+| `NEXTLABS_DISABLE_TOKEN_ENCRYPTION` | Set to `1` to silence the unencrypted-cache warning |
 
 Top-level CLI flags worth knowing: `--no-verify` (skip TLS verification —
 dev only), `-v` / `-vv` (verbose; `-vv` logs every HTTP request and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ notice — do not import from tests outside their own module, examples, or docs.
 |---|---|
 | `_auth/` | OIDC auth: token acquisition, refresh, bearer injection (`CloudAzAuth`). |
 | `_auth/_active_account/` | Active-account selection and persistence. |
-| `_auth/_token_cache/` | File-backed token store (`CachedToken`, `FileTokenCache`). |
+| `_auth/_token_cache/` | File-backed token store (`CachedToken`, `FileTokenCache`) plus encryption at rest: the IO-free `NLBX` envelope crypto (`_secret_box.py`), the encrypting cache with organic plaintext migration (`_encrypted_file_token_cache.py`), passphrase resolution and the env source (`_passphrase_resolver.py`, `_env_passphrase_source.py`), the `build_token_cache`/`inspect_token_cache` factory (`_cache_factory.py`), and stderr warning IO (`_console_io.py`). |
 | `_cloudaz/` | CloudAz client internals: request builders, pagination, response helpers. |
 | `_cloudaz/_search/` | Policy-search core: `SearchCriteria`/`SearchField`/`SearchFieldType` models (`criteria.py`), the SCIM `--where` transpiler (`where.py`, `transpile_where`), the `--field` parser (`field_expr.py`, `parse_field_expr`), and DATE parsing (`dates.py`). Pure transforms; see [ADR 0004](adr/0004-policy-search-expression-grammar.md). |
 | `_pdp/` | PDP client internals: token-url resolution, evaluation request/response models. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,6 +83,13 @@ pre-commit install
 
 Docker is still required to run the E2E suite (`tests.py --e2e`).
 
+## Dependencies
+
+Token-cache encryption at rest is part of the core library, so `cryptography`
+and `argon2-cffi` are now core runtime dependencies (declared under
+`[project.dependencies]` in `pyproject.toml`). `keyring` stays in the optional
+`[cli]` extra — it is only used by the CLI.
+
 ## E2E Tests
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,6 +155,32 @@ nextlabs auth logout              # preferred
 rm "$(echo "${NEXTLABS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}")/nextlabs-sdk/tokens.json"
 ```
 
+## `Token cache error` after changing `NEXTLABS_MASTER_PASSWORD`
+
+**Symptom:** commands fail with `Token cache error` (a `TokenCacheError`)
+once the token cache is encrypted — typically after the passphrase in
+`NEXTLABS_MASTER_PASSWORD` changed, was lost, or the cache file was
+copied from another machine.
+
+**Cause:** the encrypted `NLBX` cache can only be decrypted with the same
+passphrase that wrote it. A wrong, missing, or rotated passphrase — or a
+truncated/tampered file — fails authentication, and every such failure is
+normalized to one generic `TokenCacheError` (it never reveals which check
+failed). The cache is encrypt-only on write, so an old plaintext file is
+migrated organically the first time the CLI writes it.
+
+**Fix:** delete the cache and log in again with the passphrase you intend
+to keep:
+
+```bash
+rm "$(echo "${NEXTLABS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}")/nextlabs-sdk/tokens.json"
+NEXTLABS_MASTER_PASSWORD="<your-passphrase>" nextlabs auth login
+```
+
+To go back to a plaintext cache, unset `NEXTLABS_MASTER_PASSWORD` (the
+CLI prints a one-time stderr warning; set `NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`
+to silence it).
+
 ## PDP returns no `Permit`/`Deny` decision (status code is non-OK)
 
 **Symptom:** `nextlabs pdp eval ...` returns a result whose

--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -29,7 +29,13 @@
 | **ID token** | The OIDC `id_token` used as the Authorization bearer; falls back to access token with a warning. | JWT, bearer |
 | **Refresh token** | The OIDC refresh token used to renew an expired **ID token** without re-prompting. | renewal token |
 | **CachedToken** | The persisted token record (id_token, refresh_token, expirations) stored by a **TokenCache**. | token blob |
-| **TokenCache** | The pluggable token-store interface (`FileTokenCache`, `NullTokenCache`). | token storage |
+| **TokenCache** | The pluggable token-store interface (`FileTokenCache`, `EncryptedFileTokenCache`, `NullTokenCache`). | token storage |
+| **NLBX envelope** | The fixed-layout, single-slot container `EncryptedFileTokenCache` writes: `magic·version·wrap-type·suite-id·salt·wrapped-DEK` header (bound as AAD) followed by the AES-256-GCM ciphertext. | header, blob |
+| **DEK** | Data Encryption Key — a random 256-bit key that encrypts the cache payload under AES-256-GCM; itself wrapped by the **KEK**. | data key |
+| **KEK** | Key Encryption Key — the key derived from the master passphrase (Argon2id) that wraps the **DEK**. | wrap key, master key |
+| **suite-id** | The byte in the **NLBX** header identifying the crypto suite (KDF + cipher) so the format can evolve without ambiguity. | algorithm id, cipher id |
+| **encrypt-when-possible** | The safe-by-default policy: encrypt the cache when a passphrase source resolves, otherwise keep a plaintext cache with a one-time warning — never abort. | best-effort encryption |
+| **Organic migration** | A legacy plaintext cache is read once as-is and rewritten as an **NLBX** envelope on the next write; a read never mutates the file. | lazy migration |
 | **PDP auth source** | The choice of which token endpoint to use for **PDP** login: `cloudaz` (`/cas/token` on the auth base URL) or `pdp` (`/dpc/oauth` on the PDP URL). | auth flavor |
 | **Active account** | The currently selected user/tenant identity used by the CLI to scope token cache lookups. | current user, profile |
 | **PDP client ID** | The OAuth client identifier used specifically when authenticating to the **PDP**, separate from the **CloudAz** client ID. | DPC client id |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "httpx>=0.27,<1.0",
     "pydantic>=2.0,<3.0",
     "defusedxml>=0.7,<1.0",
-    "cryptography>=42,<46",
+    "cryptography>=42,<50",
     "argon2-cffi>=23,<25",
 ]
 # ── Uncomment / fill in before publishing to PyPI ──

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "httpx>=0.27,<1.0",
     "pydantic>=2.0,<3.0",
     "defusedxml>=0.7,<1.0",
+    "cryptography>=42,<46",
+    "argon2-cffi>=23,<25",
 ]
 # ── Uncomment / fill in before publishing to PyPI ──
 license = {text = "MIT"}
@@ -36,6 +38,7 @@ cli = [
     "typer>=0.12,<1.0",
     "rich>=13.0,<14.0",
     "scim2-filter-parser>=0.5,<1.0",
+    "keyring>=24,<26",
 ]
 yaml = [
     "PyYAML>=6.0",

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,5 @@
 black==24.4.2
+cryptography==49.0.0
 Faker==40.15.0
 isort==5.13.2
 mockito==2.0.4

--- a/src/nextlabs_sdk/__init__.py
+++ b/src/nextlabs_sdk/__init__.py
@@ -12,6 +12,7 @@ __all__: list[str] = [
     # Auth
     "CachedToken",
     "CloudAzAuth",
+    "EncryptedFileTokenCache",
     "FileTokenCache",
     "NullTokenCache",
     "PdpAuth",
@@ -32,6 +33,9 @@ from nextlabs_sdk._auth._pdp_auth import PdpAuth as PdpAuth
 from nextlabs_sdk._auth._static_token_auth import StaticTokenAuth as StaticTokenAuth
 from nextlabs_sdk._auth._token_cache import (
     CachedToken as CachedToken,
+)
+from nextlabs_sdk._auth._token_cache import (
+    EncryptedFileTokenCache as EncryptedFileTokenCache,
 )
 from nextlabs_sdk._auth._token_cache import (
     FileTokenCache as FileTokenCache,

--- a/src/nextlabs_sdk/_auth/_token_cache/__init__.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/__init__.py
@@ -1,4 +1,7 @@
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken as CachedToken
+from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
+    EncryptedFileTokenCache as EncryptedFileTokenCache,
+)
 from nextlabs_sdk._auth._token_cache._file_token_cache import (
     FileTokenCache as FileTokenCache,
 )

--- a/src/nextlabs_sdk/_auth/_token_cache/_atomic_write.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_atomic_write.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_bytes(
+    path: Path,
+    payload: bytes,
+    *,
+    dir_mode: int = 0o700,
+    file_mode: int = 0o600,
+) -> None:
+    """Write ``payload`` to ``path`` atomically with restrictive permissions."""
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    os.chmod(directory, dir_mode)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".tokens-", suffix=".tmp", dir=str(directory)
+    )
+    try:
+        _commit(fd, tmp_name, payload, path, file_mode)
+    except Exception:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
+
+
+def _commit(
+    fd: int,
+    tmp_name: str,
+    payload: bytes,
+    path: Path,
+    file_mode: int,
+) -> None:
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(payload)
+    os.chmod(tmp_name, file_mode)
+    os.replace(tmp_name, path)

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
@@ -14,6 +15,7 @@ from nextlabs_sdk._auth._token_cache._file_token_cache import (
     _default_path,
 )
 from nextlabs_sdk._auth._token_cache._passphrase_resolver import PassphraseResolver
+from nextlabs_sdk._auth._token_cache._secret_box import SecretBox, read_header
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 
 _DISABLE_ENCRYPTION_ENV = "NEXTLABS_DISABLE_TOKEN_ENCRYPTION"
@@ -46,6 +48,38 @@ def build_token_cache(
 
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
+
+
+@dataclass(frozen=True)
+class CacheStatus:
+    """Observed state of the token cache file, reported without unlocking."""
+
+    path: Path
+    state: str
+    source: str
+    suite_id: int | None
+
+
+def inspect_token_cache(
+    *,
+    path: Path | str | None = None,
+    env: Mapping[str, str] = os.environ,
+) -> CacheStatus:
+    """Report the cache file's state without deriving any key or prompting.
+
+    Resolves only the passphrase *source label* (never the material) and
+    parses the envelope header bytes, so an encrypted cache is inspected
+    without running Argon2 or unlocking it.
+    """
+    cache_path = _default_path() if path is None else Path(path)
+    _material, source = PassphraseResolver().resolve(env)
+    if not cache_path.exists():
+        return CacheStatus(cache_path, "absent", source, None)
+    blob = cache_path.read_bytes()
+    if not SecretBox.is_encrypted(blob):
+        return CacheStatus(cache_path, "plaintext", source, None)
+    header = read_header(blob)
+    return CacheStatus(cache_path, "encrypted", source, header.suite_id)
 
 
 def _warn_plaintext_once(env: Mapping[str, str]) -> None:

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+from nextlabs_sdk._auth._token_cache._console_io import ConsoleIO
+from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
+    EncryptedFileTokenCache,
+)
+from nextlabs_sdk._auth._token_cache._file_token_cache import (
+    FileTokenCache,
+    _default_path,
+)
+from nextlabs_sdk._auth._token_cache._passphrase_resolver import PassphraseResolver
+from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
+
+_DISABLE_ENCRYPTION_ENV = "NEXTLABS_DISABLE_TOKEN_ENCRYPTION"
+_PLAINTEXT_WARNING = (
+    "warning: token cache is stored UNENCRYPTED; set NEXTLABS_MASTER_PASSWORD "
+    "to encrypt it, or NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1 to silence this warning"
+)
+
+_WARNED = False
+
+
+def build_token_cache(
+    *,
+    path: Path | str | None = None,
+    env: Mapping[str, str] = os.environ,
+    console: ConsoleIO | None = None,
+) -> TokenCache:
+    """Build a token cache, encrypting when a passphrase source is present.
+
+    With no source available the cache falls back to plaintext and emits a
+    single process-wide warning to stderr; it never aborts. Setting
+    ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`` silences the warning.
+    """
+    console = console or ConsoleIO()
+    material, _label = PassphraseResolver().resolve(env)
+    cache_path = _default_path() if path is None else Path(path)
+
+    if material is not None:
+        return EncryptedFileTokenCache(path=cache_path, kek_source=material)
+
+    _warn_plaintext_once(env)
+    return FileTokenCache(path=cache_path)
+
+
+def _warn_plaintext_once(env: Mapping[str, str]) -> None:
+    if env.get(_DISABLE_ENCRYPTION_ENV) == "1" or _WARNED:
+        return
+    print(_PLAINTEXT_WARNING, file=sys.stderr)
+    globals()["_WARNED"] = True

--- a/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+
+class ConsoleIO:
+    """Console abstraction over the controlling terminal (POSIX ``/dev/tty``)."""
+
+    def isatty(self) -> bool:
+        return sys.stdin.isatty()
+
+    def prompt_secret(self, prompt: str) -> str:
+        import getpass
+
+        with open("/dev/tty", "r+", encoding="utf-8") as tty:
+            return getpass.getpass(prompt, stream=tty)
+
+    def confirm(self, prompt: str) -> bool:
+        with open("/dev/tty", "r+", encoding="utf-8") as tty:
+            tty.write(prompt)
+            tty.flush()
+            return tty.readline().strip().lower() in {"y", "yes"}

--- a/src/nextlabs_sdk/_auth/_token_cache/_encrypted_file_token_cache.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_encrypted_file_token_cache.py
@@ -1,37 +1,34 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-
 
 from nextlabs_sdk._auth._token_cache._atomic_write import atomic_write_bytes
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._auth._token_cache._secret_box import (
+    PassphraseKek,
+    RawKek,
+    SecretBox,
+)
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 
 _FILE_MODE = 0o600
 _DIR_MODE = 0o700
-_CACHE_FILENAME = "tokens.json"
-_PACKAGE_DIR = "nextlabs-sdk"
 
 
-def _default_path() -> Path:
-    override = os.environ.get("NEXTLABS_CACHE_DIR")
-    if override:
-        return Path(override) / _CACHE_FILENAME
+class EncryptedFileTokenCache(TokenCache):
+    """Token cache that reads plaintext or ``NLBX`` and always writes encrypted.
 
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    if xdg:
-        return Path(xdg) / _PACKAGE_DIR / _CACHE_FILENAME
+    Reading a legacy plaintext file leaves it untouched; the next ``save``
+    rewrites it as an ``NLBX`` envelope. The unwrapped data-encryption key is
+    cached in-process so the Argon2 key derivation runs at most once per
+    process across all loads and saves.
+    """
 
-    return Path.home() / ".cache" / _PACKAGE_DIR / _CACHE_FILENAME
-
-
-class FileTokenCache(TokenCache):
-    """JSON-backed token cache with atomic writes and ``0600`` permissions."""
-
-    def __init__(self, *, path: Path | str | None = None) -> None:
-        self._path = _default_path() if path is None else Path(path)
+    def __init__(self, *, path: Path | str, kek_source: PassphraseKek | RawKek) -> None:
+        self._path = Path(path)
+        self._kek_source = kek_source
+        self._box: SecretBox | None = None
 
     @property
     def path(self) -> Path:
@@ -63,19 +60,27 @@ class FileTokenCache(TokenCache):
     def _read_all(self) -> dict[str, object]:
         if not self._path.exists():
             return {}
+        blob = self._path.read_bytes()
+        if not blob:
+            return {}
+        if SecretBox.is_encrypted(blob):
+            if self._box is None:
+                self._box = SecretBox.unlock(blob, self._kek_source)
+            loaded = json.loads(self._box.decrypt(blob))
+            return loaded if isinstance(loaded, dict) else {}
         try:
-            with self._path.open("r", encoding="utf-8") as fh:
-                loaded = json.load(fh)
-        except (OSError, json.JSONDecodeError):
+            loaded = json.loads(blob.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
             return {}
-        if not isinstance(loaded, dict):
-            return {}
-        return loaded
+        return loaded if isinstance(loaded, dict) else {}
 
     def _write_all(self, entries: dict[str, object]) -> None:
+        if self._box is None:
+            self._box = SecretBox.seal_new(self._kek_source)
+        blob = self._box.encrypt(json.dumps(entries).encode("utf-8"))
         atomic_write_bytes(
             self._path,
-            json.dumps(entries).encode("utf-8"),
+            blob,
             dir_mode=_DIR_MODE,
             file_mode=_FILE_MODE,
         )

--- a/src/nextlabs_sdk/_auth/_token_cache/_env_passphrase_source.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_env_passphrase_source.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+
+_MASTER_PASSWORD_ENV = "NEXTLABS_MASTER_PASSWORD"
+
+
+class EnvVarPassphraseSource:
+    """Passphrase source backed by the ``NEXTLABS_MASTER_PASSWORD`` env var."""
+
+    source_label = "env"
+
+    def resolve(self, env: Mapping[str, str]) -> PassphraseKek | None:
+        secret = env.get(_MASTER_PASSWORD_ENV)
+        if not secret:
+            return None
+        return PassphraseKek(passphrase=secret.encode("utf-8"))

--- a/src/nextlabs_sdk/_auth/_token_cache/_passphrase_resolver.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_passphrase_resolver.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
+    EnvVarPassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+
+
+class PassphraseResolver:
+    """Resolves the first available passphrase source in fixed order.
+
+    This slice wires only the environment source; keyring and TTY sources
+    are inserted ahead of the plaintext fallback by later slices.
+    """
+
+    def __init__(
+        self,
+        sources: Sequence[EnvVarPassphraseSource] = (EnvVarPassphraseSource(),),
+    ) -> None:
+        self._sources = sources
+
+    def resolve(self, env: Mapping[str, str]) -> tuple[PassphraseKek | None, str]:
+        for source in self._sources:
+            material = source.resolve(env)
+            if material is not None:
+                return material, source.source_label
+        return None, "none"

--- a/src/nextlabs_sdk/_auth/_token_cache/_secret_box.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_secret_box.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from argon2 import low_level
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from nextlabs_sdk.exceptions import TokenCacheError
+
+_MAGIC = b"NLBX"
+_VERSION = 1
+
+_WRAP_ARGON2 = 0
+_WRAP_RAW = 1
+
+_MAGIC_LEN = 4
+_SALT_LEN = 16
+_DEK_LEN = 32
+_GCM_TAG_LEN = 16
+_WRAPPED_DEK_LEN = _DEK_LEN + _GCM_TAG_LEN
+_NONCE_LEN = 12
+
+_SALT_OFFSET = 7
+_WRAPPED_DEK_OFFSET = _SALT_OFFSET + _SALT_LEN
+_HEADER_PREFIX_LEN = _WRAPPED_DEK_OFFSET + _WRAPPED_DEK_LEN
+
+_ZERO_SALT = b"\x00" * _SALT_LEN
+_WRAP_NONCE = b"\x00" * _NONCE_LEN
+
+_ARGON2_TIME_COST = 3
+_ARGON2_MEMORY_COST = 65536
+_ARGON2_PARALLELISM = 4
+
+
+@dataclass(frozen=True)
+class _Argon2Suite:
+    time_cost: int
+    memory_cost: int
+    parallelism: int
+    hash_len: int
+    salt_len: int
+
+
+_SUITES = MappingProxyType(
+    {
+        1: _Argon2Suite(
+            time_cost=_ARGON2_TIME_COST,
+            memory_cost=_ARGON2_MEMORY_COST,
+            parallelism=_ARGON2_PARALLELISM,
+            hash_len=_DEK_LEN,
+            salt_len=_SALT_LEN,
+        ),
+    }
+)
+
+
+@dataclass(frozen=True)
+class PassphraseKek:
+    passphrase: bytes
+    suite_id: int = 1
+
+
+@dataclass(frozen=True)
+class RawKek:
+    key: bytes
+
+
+@dataclass(frozen=True)
+class Header:
+    version: int
+    wrap_type: int
+    suite_id: int
+
+
+def _derive_kek(passphrase: bytes, salt: bytes, suite: _Argon2Suite) -> bytes:
+    return low_level.hash_secret_raw(
+        passphrase,
+        salt,
+        time_cost=suite.time_cost,
+        memory_cost=suite.memory_cost,
+        parallelism=suite.parallelism,
+        hash_len=_DEK_LEN,
+        type=low_level.Type.ID,
+    )
+
+
+class SecretBox:
+    """Seals and opens the fixed-layout ``NLBX`` single-slot envelope.
+
+    Holds an in-process data-encryption key (DEK) so that the key
+    derivation runs once per cache file and is reused for every
+    :meth:`encrypt`/:meth:`decrypt` call within a single invocation.
+    """
+
+    def __init__(self, dek: bytes, header_prefix: bytes) -> None:
+        self._dek = dek
+        self._header_prefix = header_prefix
+
+    @classmethod
+    def seal_new(cls, kek_source: PassphraseKek | RawKek) -> SecretBox:
+        dek = os.urandom(_DEK_LEN)
+        wrap_type, suite_id, salt, kek = _resolve_kek_for_seal(kek_source)
+        header_pre_wrap = _pack_pre_wrap(wrap_type, suite_id, salt)
+        wrapped_dek = AESGCM(kek).encrypt(_WRAP_NONCE, dek, header_pre_wrap)
+        return cls(dek, header_pre_wrap + wrapped_dek)
+
+    @classmethod
+    def unlock(cls, blob: bytes, kek_source: PassphraseKek | RawKek) -> SecretBox:
+        header = read_header(blob)
+        expected_wrap = _WRAP_RAW if isinstance(kek_source, RawKek) else _WRAP_ARGON2
+        if header.wrap_type != expected_wrap:
+            raise TokenCacheError()
+
+        header_pre_wrap = blob[:_WRAPPED_DEK_OFFSET]
+        salt = blob[_SALT_OFFSET:_WRAPPED_DEK_OFFSET]
+        wrapped_dek = blob[_WRAPPED_DEK_OFFSET:_HEADER_PREFIX_LEN]
+        kek = _resolve_kek_for_unlock(kek_source, header.suite_id, salt)
+        try:
+            dek = AESGCM(kek).decrypt(_WRAP_NONCE, wrapped_dek, header_pre_wrap)
+        except InvalidTag:
+            raise TokenCacheError()
+        return cls(dek, blob[:_HEADER_PREFIX_LEN])
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        nonce = os.urandom(_NONCE_LEN)
+        ciphertext = AESGCM(self._dek).encrypt(nonce, plaintext, self._header_prefix)
+        return self._header_prefix + nonce + ciphertext
+
+    def decrypt(self, blob: bytes) -> bytes:
+        nonce = blob[_HEADER_PREFIX_LEN : _HEADER_PREFIX_LEN + _NONCE_LEN]
+        ciphertext = blob[_HEADER_PREFIX_LEN + _NONCE_LEN :]
+        try:
+            return AESGCM(self._dek).decrypt(nonce, ciphertext, self._header_prefix)
+        except InvalidTag:
+            raise TokenCacheError()
+
+    @classmethod
+    def is_encrypted(cls, blob: bytes) -> bool:
+        return blob[:_MAGIC_LEN] == _MAGIC
+
+
+def read_header(blob: bytes) -> Header:
+    """Parse the envelope header without deriving any key."""
+    if len(blob) < _HEADER_PREFIX_LEN or blob[:_MAGIC_LEN] != _MAGIC:
+        raise TokenCacheError()
+    version = blob[4]
+    wrap_type = blob[5]
+    suite_id = blob[6]
+    if version != _VERSION or wrap_type not in {_WRAP_ARGON2, _WRAP_RAW}:
+        raise TokenCacheError()
+    return Header(version=version, wrap_type=wrap_type, suite_id=suite_id)
+
+
+def _pack_pre_wrap(wrap_type: int, suite_id: int, salt: bytes) -> bytes:
+    return _MAGIC + bytes((_VERSION, wrap_type, suite_id)) + salt
+
+
+def _resolve_kek_for_seal(
+    kek_source: PassphraseKek | RawKek,
+) -> tuple[int, int, bytes, bytes]:
+    if isinstance(kek_source, RawKek):
+        return _WRAP_RAW, 0, _ZERO_SALT, kek_source.key
+    suite = _SUITES[kek_source.suite_id]
+    salt = os.urandom(suite.salt_len)
+    kek = _derive_kek(kek_source.passphrase, salt, suite)
+    return _WRAP_ARGON2, kek_source.suite_id, salt, kek
+
+
+def _resolve_kek_for_unlock(
+    kek_source: PassphraseKek | RawKek,
+    suite_id: int,
+    salt: bytes,
+) -> bytes:
+    if isinstance(kek_source, RawKek):
+        return kek_source.key
+    suite = _SUITES.get(suite_id)
+    if suite is None:
+        raise TokenCacheError()
+    return _derive_kek(kek_source.passphrase, salt, suite)

--- a/src/nextlabs_sdk/_cli/_account_menu.py
+++ b/src/nextlabs_sdk/_cli/_account_menu.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import click
 import typer
 
-from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk._cli._cache_key import cache_key_for as cache_key_for
 from nextlabs_sdk._cli._cache_key import parse_cache_key as _parse_cache_key
 
@@ -34,7 +34,7 @@ def parse_cache_key(key: str) -> AccountIdentifier | None:
     )
 
 
-def known_accounts(cache: FileTokenCache) -> list[AccountIdentifier]:
+def known_accounts(cache: TokenCache) -> list[AccountIdentifier]:
     """Return all parseable accounts from the token cache, in insertion order."""
     parsed: list[AccountIdentifier] = []
     for key in cache.keys():

--- a/src/nextlabs_sdk/_cli/_account_resolver.py
+++ b/src/nextlabs_sdk/_cli/_account_resolver.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from nextlabs_sdk._auth._active_account._active_account_store import (
     ActiveAccountStore,
 )
-from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._auth._token_cache._cache_factory import (
+    build_token_cache as _factory,
+)
+from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._context import CliContext
@@ -28,10 +31,14 @@ def build_active_store(ctx: CliContext) -> ActiveAccountStore:
     return ActiveAccountStore()
 
 
-def build_file_cache(ctx: CliContext) -> FileTokenCache:
-    if ctx.cache_dir:
-        return FileTokenCache(path=Path(ctx.cache_dir) / "tokens.json")
-    return FileTokenCache()
+def build_token_cache(ctx: CliContext) -> TokenCache:
+    env: dict[str, str] = {}
+    if ctx.master_password:
+        env["NEXTLABS_MASTER_PASSWORD"] = ctx.master_password
+    if ctx.disable_token_encryption:
+        env["NEXTLABS_DISABLE_TOKEN_ENCRYPTION"] = "1"
+    path = Path(ctx.cache_dir) / "tokens.json" if ctx.cache_dir else None
+    return _factory(path=path, env=env)
 
 
 def build_prefs_store(ctx: CliContext) -> AccountPreferencesStore:

--- a/src/nextlabs_sdk/_cli/_app.py
+++ b/src/nextlabs_sdk/_cli/_app.py
@@ -129,6 +129,20 @@ def main(
         envvar="NEXTLABS_CACHE_DIR",
         help="Override the token cache directory.",
     ),
+    master_password: str | None = typer.Option(
+        None,
+        envvar="NEXTLABS_MASTER_PASSWORD",
+        hide_input=True,
+        help="Master password for the encrypted token cache.",
+    ),
+    disable_token_encryption: bool = typer.Option(
+        False,
+        envvar="NEXTLABS_DISABLE_TOKEN_ENCRYPTION",
+        help=(
+            "Silence the unencrypted-cache warning when no passphrase "
+            "source is configured."
+        ),
+    ),
     verbose: int = typer.Option(
         0,
         "-v",
@@ -161,4 +175,6 @@ def main(
         verbose=verbose,
         pdp_auth=pdp_auth,
         pdp_client_id=pdp_client_id,
+        master_password=master_password,
+        disable_token_encryption=disable_token_encryption,
     )

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -22,7 +22,7 @@ from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
     build_active_store,
-    build_file_cache,
+    build_token_cache,
     build_prefs_store,
     effective_verify_ssl,
 )
@@ -91,7 +91,7 @@ def _apply_menu_defaults(
 ) -> tuple[str | None, str | None]:
     if base_url and username:
         return base_url, username
-    accounts = known_accounts(build_file_cache(cli_ctx))
+    accounts = known_accounts(build_token_cache(cli_ctx))
     if not accounts:
         return base_url, username
     selection = select_account(accounts)
@@ -165,7 +165,7 @@ def _account_status_and_refreshable(
     cli_ctx: CliContext,
     account: AccountIdentifier,
 ) -> tuple[str, str]:
-    entry = build_file_cache(cli_ctx).load(cache_key_for(account))
+    entry = build_token_cache(cli_ctx).load(cache_key_for(account))
     return account_status_and_refreshable(entry)
 
 
@@ -331,7 +331,7 @@ def logout(ctx: typer.Context) -> None:
     """Remove the cached token; defaults to the active account."""
     cli_ctx: CliContext = ctx.obj
     target = _resolve_active_target(cli_ctx)
-    cache = build_file_cache(cli_ctx)
+    cache = build_token_cache(cli_ctx)
     cache.delete(cache_key_for(target))
     build_prefs_store(cli_ctx).delete(_prefs_key(target))
     if _is_active(cli_ctx, target):
@@ -389,7 +389,7 @@ def status(
         _status_all(cli_ctx)
         return
     target = _resolve_active_target(cli_ctx)
-    cache = build_file_cache(cli_ctx)
+    cache = build_token_cache(cli_ctx)
     entry = cache.load(cache_key_for(target))
     if entry is None:
         typer.echo("No cached token.")
@@ -400,7 +400,7 @@ def status(
 
 
 def _status_all(cli_ctx: CliContext) -> None:
-    accounts = known_accounts(build_file_cache(cli_ctx))
+    accounts = known_accounts(build_token_cache(cli_ctx))
     if not accounts:
         typer.echo(_NO_ACCOUNTS_MESSAGE)
         raise _EXIT_FAILURE
@@ -412,7 +412,7 @@ def _status_all(cli_ctx: CliContext) -> None:
 def accounts(ctx: typer.Context) -> None:
     """List every cached account, marking the active one."""
     cli_ctx: CliContext = ctx.obj
-    entries = known_accounts(build_file_cache(cli_ctx))
+    entries = known_accounts(build_token_cache(cli_ctx))
     if not entries:
         typer.echo(_NO_ACCOUNTS_MESSAGE)
         raise _EXIT_FAILURE
@@ -427,7 +427,7 @@ def use(
 ) -> None:
     """Switch the active cached account."""
     cli_ctx: CliContext = ctx.obj
-    entries = known_accounts(build_file_cache(cli_ctx))
+    entries = known_accounts(build_token_cache(cli_ctx))
     if not entries:
         typer.echo(_NO_ACCOUNTS_MESSAGE)
         raise _EXIT_FAILURE

--- a/src/nextlabs_sdk/_cli/_client_factory.py
+++ b/src/nextlabs_sdk/_cli/_client_factory.py
@@ -8,11 +8,11 @@ import typer
 
 from nextlabs_sdk._auth._refresh_token_policy import RefreshDecision, decide
 from nextlabs_sdk._auth._static_token_auth import StaticTokenAuth
-from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
-    build_file_cache,
     build_prefs_store,
+    build_token_cache,
     effective_verify_ssl,
     load_account_prefs,
     resolve_account,
@@ -64,7 +64,7 @@ def _pdp_url_required(flavor: PdpAuthSource) -> str:
 
 
 def _cached_credentials_usable(
-    cache: FileTokenCache,
+    cache: TokenCache,
     account: ResolvedAccount,
     *,
     now: float | None = None,
@@ -141,7 +141,7 @@ def make_cloudaz_client(ctx: CliContext) -> CloudAzClient:
         return _build_static_token_client(ctx)
 
     account = _resolve_or_raise(ctx)
-    cache = build_file_cache(ctx)
+    cache = build_token_cache(ctx)
 
     password = ctx.password or None
     if password is None and not _cached_credentials_usable(cache, account):
@@ -207,7 +207,7 @@ def _load_pdp_overrides(
     if account is None or account.kind != "pdp":
         return _PdpOverrides()
     prefs = load_account_prefs(build_prefs_store(ctx), account)
-    entry = build_file_cache(ctx).load(cache_key_for(account))
+    entry = build_token_cache(ctx).load(cache_key_for(account))
     flavor = _coerce_flavor(prefs.pdp_auth_source if prefs else None)
     return _PdpOverrides(
         client_secret=entry.client_secret if entry else None,

--- a/src/nextlabs_sdk/_cli/_context.py
+++ b/src/nextlabs_sdk/_cli/_context.py
@@ -24,3 +24,5 @@ class CliContext:
     verbose: int = 0
     pdp_auth: PdpAuthSource | None = None
     pdp_client_id: str | None = None
+    master_password: str | None = None
+    disable_token_encryption: bool = False

--- a/src/nextlabs_sdk/_cli/_error_handler.py
+++ b/src/nextlabs_sdk/_cli/_error_handler.py
@@ -19,6 +19,7 @@ from nextlabs_sdk.exceptions import (
     PdpStatusError,
     RefreshTokenExpiredError,
     RequestTimeoutError,
+    TokenCacheError,
     TransportError,
 )
 
@@ -30,6 +31,7 @@ _BODY_PREVIEW_LIMIT = 2000
 
 _ErrorPrefixPair = tuple[type[NextLabsError], str]
 _ERROR_PREFIXES: tuple[_ErrorPrefixPair, ...] = (
+    (TokenCacheError, "Token cache error"),
     (RefreshTokenExpiredError, "Re-login required"),
     (AuthenticationError, "Authentication failed"),
     (NotFoundError, "Not found"),

--- a/src/nextlabs_sdk/_cli/_pdp_login.py
+++ b/src/nextlabs_sdk/_cli/_pdp_login.py
@@ -16,7 +16,7 @@ from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
     build_active_store,
-    build_file_cache,
+    build_token_cache,
     build_prefs_store,
     effective_verify_ssl,
 )
@@ -351,7 +351,7 @@ class _PersistedLogin:
 
 
 def _persist_login(cli_ctx: CliContext, record: _PersistedLogin) -> None:
-    cache = build_file_cache(cli_ctx)
+    cache = build_token_cache(cli_ctx)
     prefs = build_prefs_store(cli_ctx)
     active = build_active_store(cli_ctx)
     account = record.account

--- a/src/nextlabs_sdk/exceptions.py
+++ b/src/nextlabs_sdk/exceptions.py
@@ -37,6 +37,24 @@ class AuthenticationError(NextLabsError):
     """HTTP 401 or token acquisition failure."""
 
 
+class TokenCacheError(NextLabsError):
+    """Token cache file could not be read, decrypted, or verified.
+
+    Raised generically for every cache failure mode (wrong passphrase,
+    tampered ciphertext, tampered or unrecognised header) so that no
+    information distinguishes the cause. Recover by deleting the cache
+    file and logging in again.
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "Token cache is unreadable; delete the cache file and log in again."
+        ),
+    ) -> None:
+        super().__init__(message)
+
+
 class RefreshTokenExpiredError(AuthenticationError):
     """Refresh token is no longer usable.
 

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,10 +1,22 @@
-from mockito import mock, when
+from mockito import mock, spy2, verify, when
 
 from nextlabs_sdk._auth._token_cache import _cache_factory as cache_factory
+from nextlabs_sdk._auth._token_cache import _secret_box as sb
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
     EncryptedFileTokenCache,
 )
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+
+
+def _tok(access_token: str = "id", expires_at: float = 1000.0) -> CachedToken:
+    return CachedToken(
+        access_token=access_token,
+        refresh_token="rt",
+        expires_at=expires_at,
+        token_type="bearer",
+        scope=None,
+    )
 
 
 class TestBuildTokenCache:
@@ -41,3 +53,34 @@ class TestBuildTokenCache:
             console=console,
         )
         assert capsys.readouterr().err == ""
+
+
+class TestInspectTokenCache:
+    def test_inspect_reports_without_unlocking(self, tmp_path):
+        path = tmp_path / "tokens.json"
+        cache_factory.build_token_cache(
+            path=path, env={"NEXTLABS_MASTER_PASSWORD": "pw"}
+        ).save("a", _tok())
+        spy2(sb._derive_kek)
+        status = cache_factory.inspect_token_cache(
+            path=path, env={"NEXTLABS_MASTER_PASSWORD": "pw"}
+        )
+        assert status.state == "encrypted"
+        assert status.source == "env"
+        assert status.suite_id == 1
+        verify(sb, times=0)._derive_kek(...)
+
+    def test_inspect_reports_absent(self, tmp_path):
+        status = cache_factory.inspect_token_cache(
+            path=tmp_path / "tokens.json", env={}
+        )
+        assert status.state == "absent"
+        assert status.source == "none"
+        assert status.suite_id is None
+
+    def test_inspect_reports_plaintext(self, tmp_path):
+        path = tmp_path / "tokens.json"
+        cache_factory.build_token_cache(path=path, env={}).save("a", _tok())
+        status = cache_factory.inspect_token_cache(path=path, env={})
+        assert status.state == "plaintext"
+        assert status.suite_id is None

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,0 +1,43 @@
+from mockito import mock, when
+
+from nextlabs_sdk._auth._token_cache import _cache_factory as cache_factory
+from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
+    EncryptedFileTokenCache,
+)
+from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+
+
+class TestBuildTokenCache:
+    def test_source_present_returns_encrypted(self, tmp_path):
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json",
+            env={"NEXTLABS_MASTER_PASSWORD": "pw"},
+        )
+        assert isinstance(cache, EncryptedFileTokenCache)
+
+    def test_no_source_non_tty_plaintext_warns_once(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        console = mock()
+        when(console).isatty().thenReturn(False)
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console
+        )
+        cache2 = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console
+        )
+        assert isinstance(cache, FileTokenCache)
+        assert isinstance(cache2, FileTokenCache)
+        assert capsys.readouterr().err.count("UNENCRYPTED") == 1
+
+    def test_disable_env_silences_warning(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        console = mock()
+        when(console).isatty().thenReturn(False)
+        cache_factory.build_token_cache(
+            path=tmp_path / "t.json",
+            env={"NEXTLABS_DISABLE_TOKEN_ENCRYPTION": "1"},
+            console=console,
+        )
+        assert capsys.readouterr().err == ""

--- a/tests/test_cli_account_resolver.py
+++ b/tests/test_cli_account_resolver.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import pytest
 
 from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli._account_resolver import (
     build_active_store,
-    build_file_cache,
+    build_token_cache,
     resolve_account,
 )
 from nextlabs_sdk._cli._context import CliContext
@@ -132,8 +133,9 @@ def test_cache_dir_from_ctx_is_honoured(tmp_path: Path) -> None:
     assert resolved.username == "pointer-user"
 
 
-def test_build_file_cache_respects_cache_dir(tmp_path: Path) -> None:
-    cache = build_file_cache(_ctx(cache_dir=str(tmp_path)))
+def test_build_token_cache_respects_cache_dir(tmp_path: Path) -> None:
+    cache = build_token_cache(_ctx(cache_dir=str(tmp_path)))
+    assert isinstance(cache, FileTokenCache)
     assert cache.path == tmp_path / "tokens.json"
 
 

--- a/tests/test_cli_client_factory_bypass.py
+++ b/tests/test_cli_client_factory_bypass.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from mockito import spy2, verify
+
+from nextlabs_sdk._cli import _account_resolver as ar
+from nextlabs_sdk._cli._client_factory import make_cloudaz_client
+from nextlabs_sdk._cli._context import CliContext
+from nextlabs_sdk._cli._output_format import OutputFormat
+
+
+def _ctx() -> CliContext:
+    return CliContext(
+        base_url="https://x",
+        username=None,
+        password=None,
+        client_id="ControlCenterOIDCClient",
+        client_secret=None,
+        pdp_url=None,
+        output_format=OutputFormat.TABLE,
+        verify=None,
+        timeout=30.0,
+        token="abc",
+    )
+
+
+def test_token_bypasses_cache_factory() -> None:
+    spy2(ar.build_token_cache)
+    make_cloudaz_client(_ctx())
+    verify(ar, times=0).build_token_cache(...)

--- a/tests/test_encrypted_file_token_cache.py
+++ b/tests/test_encrypted_file_token_cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from mockito import spy2, verify
+
+from nextlabs_sdk._auth._token_cache import _secret_box as sb
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
+    EncryptedFileTokenCache,
+)
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+
+
+def _kek() -> PassphraseKek:
+    return PassphraseKek(passphrase=b"hunter2")
+
+
+def _tok(access_token: str = "id", expires_at: float = 1000.0) -> CachedToken:
+    return CachedToken(
+        access_token=access_token,
+        refresh_token="rt",
+        expires_at=expires_at,
+        token_type="bearer",
+        scope=None,
+    )
+
+
+def test_encrypted_round_trip_and_magic(tmp_path: Path):
+    path = tmp_path / "tokens.json"
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+    tok = _tok()
+    cache.save("acct", tok)
+
+    assert path.read_bytes().startswith(b"NLBX")
+    fresh = EncryptedFileTokenCache(path=path, kek_source=_kek())
+    assert fresh.load("acct") == tok
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_legacy_plaintext_loads_then_save_encrypts(tmp_path: Path):
+    path = tmp_path / "tokens.json"
+    tok = _tok()
+    path.write_text(json.dumps({"acct": tok.to_dict()}), encoding="utf-8")
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    assert cache.load("acct") == tok
+    assert not path.read_bytes().startswith(b"NLBX")
+
+    cache.save("acct2", _tok())
+    assert path.read_bytes().startswith(b"NLBX")
+
+
+def test_argon2_runs_once_per_process(tmp_path: Path):
+    spy2(sb._derive_kek)
+    path = tmp_path / "tokens.json"
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    cache.save("a", _tok())
+    cache.save("b", _tok())
+    cache.load("a")
+
+    verify(sb, times=1)._derive_kek(...)

--- a/tests/test_encrypted_file_token_cache.py
+++ b/tests/test_encrypted_file_token_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 from pathlib import Path
 
@@ -37,7 +38,9 @@ def test_encrypted_round_trip_and_magic(tmp_path: Path):
     assert path.read_bytes().startswith(b"NLBX")
     fresh = EncryptedFileTokenCache(path=path, kek_source=_kek())
     assert fresh.load("acct") == tok
-    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    # POSIX-mode bits are not enforceable on Windows; chmod is a no-op there.
+    if os.name == "posix":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_legacy_plaintext_loads_then_save_encrypts(tmp_path: Path):

--- a/tests/test_passphrase_sources.py
+++ b/tests/test_passphrase_sources.py
@@ -1,0 +1,25 @@
+from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
+    EnvVarPassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._passphrase_resolver import PassphraseResolver
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+
+
+class TestEnvVarPassphraseSource:
+    def test_env_source_present_returns_passphrase(self):
+        source = EnvVarPassphraseSource()
+        result = source.resolve({"NEXTLABS_MASTER_PASSWORD": "pw"})
+        assert result == PassphraseKek(passphrase=b"pw")
+
+    def test_env_source_absent_returns_none(self):
+        assert EnvVarPassphraseSource().resolve({}) is None
+
+
+class TestPassphraseResolver:
+    def test_resolver_order_env_then_none(self):
+        resolver = PassphraseResolver()
+        assert resolver.resolve({"NEXTLABS_MASTER_PASSWORD": "pw"}) == (
+            PassphraseKek(passphrase=b"pw"),
+            "env",
+        )
+        assert resolver.resolve({}) == (None, "none")

--- a/tests/test_secret_box.py
+++ b/tests/test_secret_box.py
@@ -1,0 +1,52 @@
+import pytest
+
+from nextlabs_sdk._auth._token_cache._secret_box import (
+    PassphraseKek,
+    RawKek,
+    SecretBox,
+)
+from nextlabs_sdk.exceptions import TokenCacheError
+
+
+def test_argon2_round_trip():
+    kek = PassphraseKek(passphrase=b"hunter2")
+    box = SecretBox.seal_new(kek)
+    blob = box.encrypt(b'{"k":"v"}')
+    assert blob.startswith(b"NLBX")
+    reopened = SecretBox.unlock(blob, PassphraseKek(passphrase=b"hunter2"))
+    assert reopened.decrypt(blob) == b'{"k":"v"}'
+
+
+def test_raw_wrap_round_trip():
+    key = b"\x11" * 32
+    box = SecretBox.seal_new(RawKek(key=key))
+    blob = box.encrypt(b"payload")
+    assert SecretBox.unlock(blob, RawKek(key=key)).decrypt(blob) == b"payload"
+
+
+def test_wrong_passphrase_rejects():
+    blob = SecretBox.seal_new(PassphraseKek(passphrase=b"right")).encrypt(b"x")
+    with pytest.raises(TokenCacheError):
+        SecretBox.unlock(blob, PassphraseKek(passphrase=b"wrong"))
+
+
+def test_tampered_ciphertext_rejects():
+    box = SecretBox.seal_new(PassphraseKek(passphrase=b"pw"))
+    blob = box.encrypt(b"some-token-data")
+    tampered = blob[:-1] + bytes([blob[-1] ^ 1])
+    reopened = SecretBox.unlock(blob, PassphraseKek(passphrase=b"pw"))
+    with pytest.raises(TokenCacheError):
+        reopened.decrypt(tampered)
+
+
+def test_tampered_header_rejects():
+    kek = PassphraseKek(passphrase=b"pw")
+    blob = SecretBox.seal_new(kek).encrypt(b"data")
+
+    suite_tampered = blob[:6] + bytes([blob[6] ^ 1]) + blob[7:]
+    with pytest.raises(TokenCacheError):
+        SecretBox.unlock(suite_tampered, PassphraseKek(passphrase=b"pw"))
+
+    salt_tampered = blob[:7] + bytes([blob[7] ^ 1]) + blob[8:]
+    with pytest.raises(TokenCacheError):
+        SecretBox.unlock(salt_tampered, PassphraseKek(passphrase=b"pw"))

--- a/tests/test_token_cache_public_api.py
+++ b/tests/test_token_cache_public_api.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+
+def test_encrypted_cache_publicly_importable():
+    import nextlabs_sdk
+    from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
+        EncryptedFileTokenCache,
+    )
+
+    assert nextlabs_sdk.EncryptedFileTokenCache is EncryptedFileTokenCache
+    assert "EncryptedFileTokenCache" in nextlabs_sdk.__all__
+
+
+def test_import_does_not_pull_keyring():
+    code = (
+        "import nextlabs_sdk, sys; "
+        "assert 'keyring' not in sys.modules, "
+        "sorted(m for m in sys.modules if 'keyring' in m)"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
Closes #131.

Encrypts the CLI token cache at rest (ADR 0003) using the single-slot `NLBX` envelope. Implements the env-passphrase path only; OS keyring (#132) and TTY prompt (#133) are out of scope.

## What changed
- **SecretBox** (`_secret_box.py`) — IO-free `NLBX` envelope crypto: random 256-bit DEK encrypts the JSON via AES-256-GCM; DEK wrapped by an Argon2id-derived KEK. Full header is AAD. All decrypt failures normalize to a single generic `TokenCacheError` — no oracle leakage.
- **EncryptedFileTokenCache** — drop-in `TokenCache`; organic migration (reads plaintext or `NLBX`, always writes encrypted, never mutates on read). Preserves `0600`/`0700` modes.
- **Factory** — `build_token_cache(...)` replaces every `build_file_cache(...)` call site; `inspect_token_cache(...)` reports path/state/source/suite without unlocking or running Argon2. Encrypt-when-possible: env passphrase present ⇒ encrypt; non-TTY with no source ⇒ plaintext fallback + one-time stderr warning (silenced by `NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`).
- **CLI wiring** — `NEXTLABS_MASTER_PASSWORD` / `NEXTLABS_DISABLE_TOKEN_ENCRYPTION` reach the factory via `CliContext`; `TokenCacheError` mapped in the error handler. `NEXTLABS_TOKEN` still bypasses the cache entirely.
- **Deps** — `cryptography` + `argon2-cffi` → core; `keyring` → `[cli]`. `import nextlabs_sdk` without `[cli]` does not import keyring.
- **Public surface** — exports `EncryptedFileTokenCache`.
- **Docs** — README env-var table + encryption-at-rest note, architecture module map, development deps, troubleshooting recovery note, glossary terms.

## Verification
- 31 token-cache + CLI tests pass (AC6 call-site migration / inspect-without-unlock; AC7 `NEXTLABS_TOKEN` bypass).
- `python ./tools/checks.py --short` — 4/4 (black, flake8, mypy, pyright).
- `grep -rn build_file_cache src/` — empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
