### PR TITLE
feat(token-cache): add keyring passphrase source with raw KEK

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -72,7 +72,7 @@ def inspect_token_cache(
     without running Argon2 or unlocking it.
     """
     cache_path = _default_path() if path is None else Path(path)
-    _material, source = PassphraseResolver().resolve(env)
+    source = PassphraseResolver().peek(env)
     if not cache_path.exists():
         return CacheStatus(cache_path, "absent", source, None)
     blob = cache_path.read_bytes()

--- a/src/nextlabs_sdk/_auth/_token_cache/_env_passphrase_source.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_env_passphrase_source.py
@@ -17,3 +17,6 @@ class EnvVarPassphraseSource:
         if not secret:
             return None
         return PassphraseKek(passphrase=secret.encode("utf-8"))
+
+    def would_resolve(self, env: Mapping[str, str]) -> bool:
+        return bool(env.get(_MASTER_PASSWORD_ENV))

--- a/src/nextlabs_sdk/_auth/_token_cache/_keyring_passphrase_source.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_keyring_passphrase_source.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import base64
+import contextlib
+import os
+from typing import Mapping
+
+import keyring
+from keyring.errors import KeyringError, KeyringLocked, NoKeyringError
+
+from nextlabs_sdk._auth._token_cache._secret_box import RawKek
+
+_SERVICE = "nextlabs-sdk"
+_KEK_ACCOUNT = "token-cache-kek"
+_PROBE_ACCOUNT = "__probe__"
+_PROBE_VALUE = "nextlabs-sdk-probe"
+_KEK_LEN = 32
+
+
+class KeyringPassphraseSource:
+    """Passphrase source backed by the OS keyring, wrapping the DEK with a raw KEK.
+
+    On first use a random 32-byte key-encryption key is generated and stored in
+    the keyring; later invocations fetch it and wrap the data-encryption key
+    directly, with no key-derivation step. A null backend that accepts writes
+    but returns ``None`` on read is treated as unavailable so the resolver falls
+    through to the next source.
+    """
+
+    source_label = "keyring"
+
+    def resolve(self, env: Mapping[str, str]) -> RawKek | None:
+        if not self.available():
+            return None
+        try:
+            return self._load_or_create()
+        except (NoKeyringError, KeyringLocked):
+            return None
+
+    def available(self) -> bool:
+        try:
+            keyring.set_password(_SERVICE, _PROBE_ACCOUNT, _PROBE_VALUE)
+        except (NoKeyringError, KeyringLocked):
+            return False
+        try:
+            roundtrip = keyring.get_password(_SERVICE, _PROBE_ACCOUNT)
+        except (NoKeyringError, KeyringLocked):
+            roundtrip = None
+        finally:
+            self._delete_probe()
+        return roundtrip == _PROBE_VALUE
+
+    def would_resolve(self, env: Mapping[str, str]) -> bool:
+        return self.available()
+
+    def _load_or_create(self) -> RawKek:
+        stored = keyring.get_password(_SERVICE, _KEK_ACCOUNT)
+        if stored is None:
+            return self._generate_and_store()
+        return RawKek(key=base64.b64decode(stored))
+
+    def _generate_and_store(self) -> RawKek:
+        key = os.urandom(_KEK_LEN)
+        keyring.set_password(
+            _SERVICE, _KEK_ACCOUNT, base64.b64encode(key).decode("ascii")
+        )
+        return RawKek(key=key)
+
+    def _delete_probe(self) -> None:
+        with contextlib.suppress(KeyringError):
+            keyring.delete_password(_SERVICE, _PROBE_ACCOUNT)

--- a/src/nextlabs_sdk/_auth/_token_cache/_passphrase_resolver.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_passphrase_resolver.py
@@ -1,29 +1,60 @@
 from __future__ import annotations
 
-from typing import Mapping, Sequence
+from typing import Mapping, Protocol, Sequence
 
 from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
     EnvVarPassphraseSource,
 )
-from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+from nextlabs_sdk._auth._token_cache._keyring_passphrase_source import (
+    KeyringPassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek, RawKek
+
+
+class PassphraseSource(Protocol):
+    """A resolver-pluggable provider of key-encryption-key material."""
+
+    source_label: str
+
+    def resolve(self, env: Mapping[str, str]) -> PassphraseKek | RawKek | None: ...
+
+    def would_resolve(self, env: Mapping[str, str]) -> bool: ...
 
 
 class PassphraseResolver:
     """Resolves the first available passphrase source in fixed order.
 
-    This slice wires only the environment source; keyring and TTY sources
-    are inserted ahead of the plaintext fallback by later slices.
+    Sources are consulted in order: the environment variable, then the OS
+    keyring. The TTY prompt source is inserted ahead of the plaintext fallback
+    by a later slice.
     """
 
     def __init__(
         self,
-        sources: Sequence[EnvVarPassphraseSource] = (EnvVarPassphraseSource(),),
+        sources: Sequence[PassphraseSource] = (
+            EnvVarPassphraseSource(),
+            KeyringPassphraseSource(),
+        ),
     ) -> None:
         self._sources = sources
 
-    def resolve(self, env: Mapping[str, str]) -> tuple[PassphraseKek | None, str]:
+    def resolve(
+        self, env: Mapping[str, str]
+    ) -> tuple[PassphraseKek | RawKek | None, str]:
         for source in self._sources:
             material = source.resolve(env)
             if material is not None:
                 return material, source.source_label
         return None, "none"
+
+    def peek(self, env: Mapping[str, str]) -> str:
+        """Return the label of the source that would resolve, without using it.
+
+        Unlike :meth:`resolve`, this never materialises key material, so callers
+        that only need the selected source's identity (such as cache inspection)
+        do not trigger key generation or persistence as a side effect.
+        """
+        for source in self._sources:
+            if source.would_resolve(env):
+                return source.source_label
+        return "none"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from keyring.errors import NoKeyringError
 from mockito import unstub as mockito_unstub
 
 # ── E2E collection guard ──
@@ -29,6 +30,27 @@ def _isolate_nextlabs_cache(  # pyright: ignore[reportUnusedFunction]
     cache_dir: Path = tmp_path_factory.mktemp("nextlabs-cache")
     monkeypatch.setenv("NEXTLABS_CACHE_DIR", str(cache_dir))
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _disable_real_keyring(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force the keyring to behave as if no backend is installed.
+
+    Otherwise the keyring passphrase source would auto-generate and persist a
+    key into the developer's (or CI runner's) OS keychain on platforms where a
+    backend is installed, encrypting the token cache and making outcomes depend
+    on the host. Tests that exercise the keyring path stub these ``keyring``
+    module functions directly, overriding this default.
+    """
+
+    def _no_backend(*_args: object, **_kwargs: object) -> None:
+        raise NoKeyringError()
+
+    monkeypatch.setattr("keyring.get_password", _no_backend)
+    monkeypatch.setattr("keyring.set_password", _no_backend)
+    monkeypatch.setattr("keyring.delete_password", _no_backend)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,6 +1,11 @@
+import base64
+
+import keyring
+
 from mockito import mock, spy2, verify, when
 
 from nextlabs_sdk._auth._token_cache import _cache_factory as cache_factory
+from nextlabs_sdk._auth._token_cache import _keyring_passphrase_source as kps
 from nextlabs_sdk._auth._token_cache import _secret_box as sb
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
@@ -54,6 +59,29 @@ class TestBuildTokenCache:
         )
         assert capsys.readouterr().err == ""
 
+    def test_keyring_path_roundtrips_without_argon2(self, tmp_path):
+        # given no env secret and an available keyring holding a stored key
+        when(keyring).set_password(
+            kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+        ).thenReturn(None)
+        when(keyring).get_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(
+            kps._PROBE_VALUE
+        )
+        when(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(None)
+        stored = b"\x33" * kps._KEK_LEN
+        when(keyring).get_password(kps._SERVICE, kps._KEK_ACCOUNT).thenReturn(
+            base64.b64encode(stored).decode("ascii")
+        )
+        spy2(sb._derive_kek)
+        # when a cache is built and a token is saved then loaded back
+        cache = cache_factory.build_token_cache(path=tmp_path / "t.json", env={})
+        cache.save("a", _tok())
+        loaded = cache.load("a")
+        # then the cache is encrypted, round-trips, and no Argon2 derivation runs
+        assert isinstance(cache, EncryptedFileTokenCache)
+        assert loaded == _tok()
+        verify(sb, times=0)._derive_kek(...)
+
 
 class TestInspectTokenCache:
     def test_inspect_reports_without_unlocking(self, tmp_path):
@@ -84,3 +112,21 @@ class TestInspectTokenCache:
         status = cache_factory.inspect_token_cache(path=path, env={})
         assert status.state == "plaintext"
         assert status.suite_id is None
+
+    def test_inspect_reports_keyring_label_without_generating_key(self, tmp_path):
+        # given an available keyring but no stored key yet
+        when(keyring).set_password(
+            kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+        ).thenReturn(None)
+        when(keyring).get_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(
+            kps._PROBE_VALUE
+        )
+        when(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(None)
+        # when the absent cache is inspected
+        status = cache_factory.inspect_token_cache(
+            path=tmp_path / "tokens.json", env={}
+        )
+        # then the keyring label is reported without persisting a fresh key
+        assert status.state == "absent"
+        assert status.source == "keyring"
+        verify(keyring, times=0).set_password(kps._SERVICE, kps._KEK_ACCOUNT, ...)

--- a/tests/test_passphrase_sources.py
+++ b/tests/test_passphrase_sources.py
@@ -1,8 +1,92 @@
+import base64
+
+import keyring
+from keyring.errors import KeyringLocked, NoKeyringError
+from mockito import ANY, captor, verify, when
+
+from nextlabs_sdk._auth._token_cache import _keyring_passphrase_source as kps
 from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
     EnvVarPassphraseSource,
 )
+from nextlabs_sdk._auth._token_cache._keyring_passphrase_source import (
+    KeyringPassphraseSource,
+)
 from nextlabs_sdk._auth._token_cache._passphrase_resolver import PassphraseResolver
-from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek, RawKek
+
+
+def _stub_probe_success() -> None:
+    when(keyring).set_password(
+        kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+    ).thenReturn(None)
+    when(keyring).get_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(
+        kps._PROBE_VALUE
+    )
+    when(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(None)
+
+
+class TestKeyringPassphraseSource:
+    def test_available_self_test_passes_and_cleans_up_sentinel(self):
+        # given a backend whose probe write round-trips back the sentinel
+        _stub_probe_success()
+        # when availability is checked
+        result = KeyringPassphraseSource().available()
+        # then the source is available and the sentinel is deleted afterwards
+        assert result is True
+        verify(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT)
+
+    def test_available_reports_null_backend_as_unavailable_and_cleans_up(self):
+        # given a null backend that accepts writes but returns None on read
+        when(keyring).set_password(
+            kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+        ).thenReturn(None)
+        when(keyring).get_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(None)
+        when(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT).thenReturn(None)
+        # when availability is checked
+        result = KeyringPassphraseSource().available()
+        # then the source is unavailable and the sentinel is still removed
+        assert result is False
+        verify(keyring).delete_password(kps._SERVICE, kps._PROBE_ACCOUNT)
+
+    def test_available_treats_no_keyring_error_as_unavailable(self):
+        # given a backend that raises NoKeyringError on write
+        when(keyring).set_password(
+            kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+        ).thenRaise(NoKeyringError())
+        # when availability is checked
+        # then no exception surfaces and the source is unavailable
+        assert KeyringPassphraseSource().available() is False
+
+    def test_resolve_swallows_keyring_locked_and_returns_none(self):
+        # given a locked backend that raises on the probe write
+        when(keyring).set_password(
+            kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+        ).thenRaise(KeyringLocked())
+        # when the source is resolved
+        # then it yields no material and the keyring error never escapes
+        assert KeyringPassphraseSource().resolve({}) is None
+
+    def test_resolve_generates_stores_then_reuses_key(self):
+        # given an available backend that holds no key yet
+        _stub_probe_success()
+        when(keyring).set_password(kps._SERVICE, kps._KEK_ACCOUNT, ANY).thenReturn(None)
+        when(keyring).get_password(kps._SERVICE, kps._KEK_ACCOUNT).thenReturn(None)
+        source = KeyringPassphraseSource()
+        # when the source is resolved the first time
+        first = source.resolve({})
+        stored = captor()
+        verify(keyring).set_password(kps._SERVICE, kps._KEK_ACCOUNT, stored)
+        # and the backend now returns the freshly stored key on the next read
+        when(keyring).get_password(kps._SERVICE, kps._KEK_ACCOUNT).thenReturn(
+            stored.value
+        )
+        second = source.resolve({})
+        # then a 32-byte key was generated, persisted once, and reused verbatim
+        expected = RawKek(key=base64.b64decode(stored.value))
+        assert len(expected.key) == kps._KEK_LEN
+        assert first == expected
+        assert second == expected
+        verify(keyring, times=1).set_password(kps._SERVICE, kps._KEK_ACCOUNT, ANY)
 
 
 class TestEnvVarPassphraseSource:
@@ -23,3 +107,19 @@ class TestPassphraseResolver:
             "env",
         )
         assert resolver.resolve({}) == (None, "none")
+
+    def test_resolver_returns_keyring_label_for_keyring_source(self):
+        # given no env secret and an available keyring holding a stored key
+        _stub_probe_success()
+        stored = b"\x22" * kps._KEK_LEN
+        when(keyring).get_password(kps._SERVICE, kps._KEK_ACCOUNT).thenReturn(
+            base64.b64encode(stored).decode("ascii")
+        )
+        resolver = PassphraseResolver(
+            sources=(EnvVarPassphraseSource(), KeyringPassphraseSource())
+        )
+        # when the resolver runs with an empty environment
+        material, label = resolver.resolve({})
+        # then the keyring source supplies the material under the keyring label
+        assert material == RawKek(key=stored)
+        assert label == "keyring"


### PR DESCRIPTION
Closes #132

## Summary
- Add `KeyringPassphraseSource`, slotted between the env and TTY sources in `PassphraseResolver`. On first use it generates a random 32-byte KEK, stores it via `keyring` (base64-encoded), and on later runs fetches it to wrap the DEK directly with no key derivation (`RawKek`, no Argon2). `available()` self-tests with a write → read → delete sentinel to reject "null" backends that accept writes but return `None`, and `NoKeyringError`/`KeyringLocked` are swallowed so the resolver falls through.
- Add a side-effect-free `PassphraseResolver.peek` / source `would_resolve`, used by `inspect_token_cache` so a read-only status check reports the `keyring` label without generating and persisting a KEK.
- Verified with the targeted token-cache suites and the full unit suite (2544 passed, 95.8% coverage); black/flake8/mypy/pyright all green.

## Tests added (red → green)
- `test_available_self_test_passes_and_cleans_up_sentinel`
- `test_available_reports_null_backend_as_unavailable_and_cleans_up`
- `test_available_treats_no_keyring_error_as_unavailable`
- `test_resolve_swallows_keyring_locked_and_returns_none`
- `test_resolve_generates_stores_then_reuses_key`
- `test_resolver_returns_keyring_label_for_keyring_source`
- `test_keyring_path_roundtrips_without_argon2`
- `test_inspect_reports_keyring_label_without_generating_key`

## Notable assumptions
- The KEK is stored under service `nextlabs-sdk`, account `token-cache-kek` (neither named by the issue; only the `__probe__` account is specified), base64-encoded because `keyring` stores text.
- Adding `peek`/`would_resolve` keeps `inspect_token_cache` read-only; reusing `resolve` there would silently create a keyring entry during a status check.
