### PR TITLE
feat(token-cache): interactive TTY passphrase source and plaintext confirmation gate

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -10,19 +10,37 @@ from nextlabs_sdk._auth._token_cache._console_io import ConsoleIO
 from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
     EncryptedFileTokenCache,
 )
+from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
+    EnvVarPassphraseSource,
+)
 from nextlabs_sdk._auth._token_cache._file_token_cache import (
     FileTokenCache,
     _default_path,
 )
-from nextlabs_sdk._auth._token_cache._passphrase_resolver import PassphraseResolver
+from nextlabs_sdk._auth._token_cache._interactive_passphrase_source import (
+    InteractivePassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._keyring_passphrase_source import (
+    KeyringPassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._passphrase_resolver import (
+    PassphraseResolver,
+)
 from nextlabs_sdk._auth._token_cache._secret_box import SecretBox, read_header
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
+from nextlabs_sdk.exceptions import TokenCacheError
 
 _DISABLE_ENCRYPTION_ENV = "NEXTLABS_DISABLE_TOKEN_ENCRYPTION"
 _PLAINTEXT_WARNING = (
     "warning: token cache is stored UNENCRYPTED; set NEXTLABS_MASTER_PASSWORD "
     "to encrypt it, or NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1 to silence this warning"
 )
+_CONFIRM_WARNING = (
+    "warning: no passphrase source is available, so the token cache would be "
+    "stored UNENCRYPTED. Set NEXTLABS_MASTER_PASSWORD or configure an OS keyring "
+    "to encrypt it later."
+)
+_CONFIRM_PROMPT = "Store the token cache unencrypted anyway? [y/N]: "
 
 _WARNED = False
 
@@ -35,19 +53,40 @@ def build_token_cache(
 ) -> TokenCache:
     """Build a token cache, encrypting when a passphrase source is present.
 
-    With no source available the cache falls back to plaintext and emits a
-    single process-wide warning to stderr; it never aborts. Setting
-    ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`` silences the warning.
+    Sources are consulted in order: ``NEXTLABS_MASTER_PASSWORD``, the OS
+    keyring, then an interactive TTY passphrase prompt. With no source and a
+    TTY present the caller is warned and asked to confirm plaintext storage;
+    declining raises :class:`TokenCacheError` without writing anything. With no
+    source and no TTY the cache falls back to plaintext and emits a single
+    process-wide warning to stderr; it never aborts. Setting
+    ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`` silences the non-interactive warning.
     """
     console = console or ConsoleIO()
-    material, _label = PassphraseResolver().resolve(env)
+    resolver = PassphraseResolver(
+        sources=(
+            EnvVarPassphraseSource(),
+            KeyringPassphraseSource(),
+            InteractivePassphraseSource(console),
+        )
+    )
+    material, _label = resolver.resolve(env)
     cache_path = _default_path() if path is None else Path(path)
 
     if material is not None:
         return EncryptedFileTokenCache(path=cache_path, kek_source=material)
 
+    if console.isatty():
+        return _confirm_plaintext_or_abort(console, cache_path)
+
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
+
+
+def _confirm_plaintext_or_abort(console: ConsoleIO, cache_path: Path) -> TokenCache:
+    print(_CONFIRM_WARNING, file=sys.stderr)
+    if console.confirm(_CONFIRM_PROMPT):
+        return FileTokenCache(path=cache_path)
+    raise TokenCacheError()
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_auth/_token_cache/_interactive_passphrase_source.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_interactive_passphrase_source.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+from nextlabs_sdk._auth._token_cache._console_io import ConsoleIO
+from nextlabs_sdk._auth._token_cache._secret_box import PassphraseKek
+
+_PROMPT = "Token cache passphrase (leave empty to skip encryption): "
+
+
+class InteractivePassphraseSource:
+    """Passphrase source that prompts for a secret on the controlling terminal.
+
+    On a TTY the typed passphrase becomes Argon2id material for the
+    key-encryption key. A non-interactive input stream reports unavailable
+    without reading, so the resolver falls through to the next source instead of
+    blocking on a prompt that can never be answered. An empty entry is also
+    treated as unavailable, deferring to the plaintext confirmation gate.
+    """
+
+    source_label = "tty"
+
+    def __init__(self, console: ConsoleIO) -> None:
+        self._console = console
+
+    def resolve(self, env: Mapping[str, str]) -> PassphraseKek | None:
+        if not self._console.isatty():
+            return None
+        passphrase = self._console.prompt_secret(_PROMPT)
+        if not passphrase:
+            return None
+        return PassphraseKek(passphrase=passphrase.encode("utf-8"))
+
+    def would_resolve(self, env: Mapping[str, str]) -> bool:
+        return self._console.isatty()

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,8 +1,9 @@
 import base64
 
 import keyring
-
-from mockito import mock, spy2, verify, when
+import pytest
+from keyring.errors import NoKeyringError
+from mockito import ANY, mock, spy2, verify, when
 
 from nextlabs_sdk._auth._token_cache import _cache_factory as cache_factory
 from nextlabs_sdk._auth._token_cache import _keyring_passphrase_source as kps
@@ -12,6 +13,13 @@ from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
     EncryptedFileTokenCache,
 )
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk.exceptions import TokenCacheError
+
+
+def _keyring_unavailable() -> None:
+    when(keyring).set_password(
+        kps._SERVICE, kps._PROBE_ACCOUNT, kps._PROBE_VALUE
+    ).thenRaise(NoKeyringError())
 
 
 def _tok(access_token: str = "id", expires_at: float = 1000.0) -> CachedToken:
@@ -130,3 +138,72 @@ class TestInspectTokenCache:
         assert status.state == "absent"
         assert status.source == "keyring"
         verify(keyring, times=0).set_password(kps._SERVICE, kps._KEK_ACCOUNT, ...)
+
+
+class TestInteractiveTokenCache:
+    def test_tty_passphrase_unlocks_and_roundtrips_with_tty_label(
+        self, tmp_path, monkeypatch
+    ):
+        # given no env secret, an unavailable keyring, and a TTY passphrase
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("hunter2")
+        path = tmp_path / "t.json"
+        # when a cache is built and a token round-trips
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        cache.save("a", _tok())
+        loaded = cache.load("a")
+        # then the entered passphrase encrypts and unlocks the cache
+        assert isinstance(cache, EncryptedFileTokenCache)
+        assert loaded == _tok()
+
+    def test_no_source_tty_confirm_yes_returns_plaintext_with_guidance(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # given no source, a TTY, an empty passphrase, and a yes confirmation
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        when(console).confirm(ANY).thenReturn(True)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console
+        )
+        # then a plaintext cache is returned after warning how to encrypt later
+        assert isinstance(cache, FileTokenCache)
+        assert "NEXTLABS_MASTER_PASSWORD" in capsys.readouterr().err
+
+    def test_no_source_tty_confirm_no_aborts_without_writing(
+        self, tmp_path, monkeypatch
+    ):
+        # given no source, a TTY, an empty passphrase, and a declined confirmation
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        when(console).confirm(ANY).thenReturn(False)
+        path = tmp_path / "t.json"
+        # when the cache is built, then the gate aborts and writes nothing
+        with pytest.raises(TokenCacheError):
+            cache_factory.build_token_cache(path=path, env={}, console=console)
+        assert not path.exists()
+
+    def test_confirmation_is_read_via_console_confirm(self, tmp_path, monkeypatch):
+        # given a piped stdin must not bypass the gate
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        when(console).confirm(ANY).thenReturn(True)
+        # when the cache is built
+        cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console
+        )
+        # then the decision is read through the controlling terminal, not stdin
+        verify(console, times=1).confirm(ANY)

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -7,6 +7,7 @@ import pytest
 import typer
 
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._auth._token_cache._console_io import ConsoleIO
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _client_factory
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
@@ -233,6 +234,26 @@ def _isatty_true() -> bool:
     return True
 
 
+def _no_cache_passphrase(_console: ConsoleIO, _prompt: str) -> str:
+    return ""
+
+
+def _accept_plaintext(_console: ConsoleIO, _prompt: str) -> bool:
+    return True
+
+
+def _decline_cache_encryption(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer the token-cache passphrase gate without touching ``/dev/tty``.
+
+    On a TTY with no passphrase source the cache factory prompts for a
+    passphrase and then a plaintext confirmation; here the user supplies no
+    passphrase and accepts plaintext, so the cache stays a ``FileTokenCache``
+    and the login-password prompt under test runs unchanged.
+    """
+    monkeypatch.setattr(ConsoleIO, "prompt_secret", _no_cache_passphrase)
+    monkeypatch.setattr(ConsoleIO, "confirm", _accept_plaintext)
+
+
 def _seed_token(
     cache_dir: Path,
     *,
@@ -350,6 +371,7 @@ def test_tty_prompt_supplies_password_when_cache_empty(
 ):
     captured = _capture_cloudaz_kwargs(monkeypatch)
     monkeypatch.setattr("sys.stdin.isatty", _isatty_true)
+    _decline_cache_encryption(monkeypatch)
     prompts: list[tuple[str, bool]] = []
 
     def _fake_prompt(text: str, *, hide_input: bool = False, **_: object) -> str:

--- a/tests/test_passphrase_sources.py
+++ b/tests/test_passphrase_sources.py
@@ -2,11 +2,14 @@ import base64
 
 import keyring
 from keyring.errors import KeyringLocked, NoKeyringError
-from mockito import ANY, captor, verify, when
+from mockito import ANY, captor, mock, verify, when
 
 from nextlabs_sdk._auth._token_cache import _keyring_passphrase_source as kps
 from nextlabs_sdk._auth._token_cache._env_passphrase_source import (
     EnvVarPassphraseSource,
+)
+from nextlabs_sdk._auth._token_cache._interactive_passphrase_source import (
+    InteractivePassphraseSource,
 )
 from nextlabs_sdk._auth._token_cache._keyring_passphrase_source import (
     KeyringPassphraseSource,
@@ -123,3 +126,48 @@ class TestPassphraseResolver:
         # then the keyring source supplies the material under the keyring label
         assert material == RawKek(key=stored)
         assert label == "keyring"
+
+
+class TestInteractivePassphraseSource:
+    def test_tty_prompt_returns_passphrase_kek(self):
+        # given an interactive terminal that yields a typed passphrase
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("hunter2")
+        # when the source is resolved
+        result = InteractivePassphraseSource(console).resolve({})
+        # then the typed secret becomes Argon2id passphrase material
+        assert result == PassphraseKek(passphrase=b"hunter2")
+
+    def test_non_tty_reports_unavailable_without_reading(self):
+        # given a non-interactive input stream
+        console = mock()
+        when(console).isatty().thenReturn(False)
+        # when the source is resolved
+        result = InteractivePassphraseSource(console).resolve({})
+        # then it yields no material and never blocks on a read
+        assert result is None
+        verify(console, times=0).prompt_secret(ANY)
+
+    def test_empty_passphrase_reports_unavailable(self):
+        # given an interactive terminal where the user enters nothing
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        # when the source is resolved
+        # then an empty entry yields no material so the resolver falls through
+        assert InteractivePassphraseSource(console).resolve({}) is None
+
+    def test_resolver_returns_tty_label_for_interactive_source(self):
+        # given no env secret and an interactive terminal supplying a passphrase
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("pw")
+        resolver = PassphraseResolver(
+            sources=(EnvVarPassphraseSource(), InteractivePassphraseSource(console))
+        )
+        # when the resolver runs with an empty environment
+        material, label = resolver.resolve({})
+        # then the interactive source supplies the material under the tty label
+        assert material == PassphraseKek(passphrase=b"pw")
+        assert label == "tty"


### PR DESCRIPTION
Closes #133

## Summary
- Add `InteractivePassphraseSource` (`source_label = "tty"`): prompts via `ConsoleIO.prompt_secret`, derives the KEK through Argon2id, and reports unavailable on a non-TTY or empty entry so the resolver falls through.
- Wire the interactive source into `build_token_cache` and add a plaintext confirmation gate: when no env/keyring/TTY source unlocks and a TTY is present, warn to stderr how to enable encryption later and read a decision via `ConsoleIO.confirm` (`/dev/tty`); anything but yes raises `TokenCacheError` without writing the cache.
- Tested with new unit tests (red → green) plus the full suite; trade-off: a TTY with no passphrase source now prompts before falling back to plaintext (per ADR 0003), so one existing CLI test was updated to answer the new gate.

## Tests added (red → green)
- `TestInteractivePassphraseSource::test_tty_prompt_returns_passphrase_kek`
- `TestInteractivePassphraseSource::test_non_tty_reports_unavailable_without_reading`
- `TestInteractivePassphraseSource::test_empty_passphrase_reports_unavailable`
- `TestInteractivePassphraseSource::test_resolver_returns_tty_label_for_interactive_source`
- `TestInteractiveTokenCache::test_tty_passphrase_unlocks_and_roundtrips_with_tty_label`
- `TestInteractiveTokenCache::test_no_source_tty_confirm_yes_returns_plaintext_with_guidance`
- `TestInteractiveTokenCache::test_no_source_tty_confirm_no_aborts_without_writing`
- `TestInteractiveTokenCache::test_confirmation_is_read_via_console_confirm`

## Notable assumptions
- An empty passphrase entry at the interactive prompt is treated as "unavailable", deferring to the plaintext confirmation gate.
- The interactive source is wired only into `build_token_cache`; `inspect_token_cache` stays prompt-free (env/keyring labels only), preserving its read-only, no-prompt contract.
- Tests live in the existing flat `tests/` layout rather than the `tests/_auth/_token_cache/` paths in the issue's file hint, matching the repository's current structure.
