### PR TITLE
test(token-cache): verify organic legacy→encrypted migration (#134)

### DIFF
--- a/tests/test_encrypted_file_token_cache.py
+++ b/tests/test_encrypted_file_token_cache.py
@@ -5,7 +5,8 @@ import os
 import stat
 from pathlib import Path
 
-from mockito import spy2, verify
+import pytest
+from mockito import spy2, verify, when
 
 from nextlabs_sdk._auth._token_cache import _secret_box as sb
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
@@ -66,3 +67,81 @@ def test_argon2_runs_once_per_process(tmp_path: Path):
     cache.load("a")
 
     verify(sb, times=1)._derive_kek(...)
+
+
+def test_loading_legacy_file_does_not_rewrite_it(tmp_path: Path):
+    # Given a legacy plaintext cache file
+    path = tmp_path / "tokens.json"
+    tok = _tok()
+    path.write_text(json.dumps({"acct": tok.to_dict()}), encoding="utf-8")
+    original_bytes = path.read_bytes()
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    # When the token is loaded
+    loaded = cache.load("acct")
+
+    # Then the same token is returned and the file is left byte-for-byte intact
+    assert loaded == tok
+    assert path.read_bytes() == original_bytes
+
+
+def test_first_save_migrates_and_preserves_existing_tokens(tmp_path: Path):
+    # Given a legacy plaintext file holding one account
+    path = tmp_path / "tokens.json"
+    legacy = _tok(access_token="legacy")
+    path.write_text(json.dumps({"acct": legacy.to_dict()}), encoding="utf-8")
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    # When a second account is saved
+    added = _tok(access_token="added")
+    cache.save("acct2", added)
+
+    # Then the file is encrypted and decrypts to both the old and new tokens
+    assert path.read_bytes().startswith(b"NLBX")
+    fresh = EncryptedFileTokenCache(path=path, kek_source=_kek())
+    assert fresh.load("acct") == legacy
+    assert fresh.load("acct2") == added
+
+
+def test_failed_write_leaves_plaintext_intact_and_rerun_completes(tmp_path: Path):
+    # Given a legacy plaintext file
+    path = tmp_path / "tokens.json"
+    legacy = _tok(access_token="legacy")
+    path.write_text(json.dumps({"acct": legacy.to_dict()}), encoding="utf-8")
+    original_bytes = path.read_bytes()
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    # When the atomic rename fails mid-write
+    when(os).replace(...).thenRaise(OSError("disk full"))
+    with pytest.raises(OSError):
+        cache.save("acct2", _tok(access_token="added"))
+
+    # Then the previous plaintext file is untouched and still readable
+    assert path.read_bytes() == original_bytes
+    assert EncryptedFileTokenCache(path=path, kek_source=_kek()).load("acct") == legacy
+
+    # And re-running the save after recovery completes the migration
+    when(os).replace(...).thenCallOriginalImplementation()
+    cache.save("acct2", _tok(access_token="added"))
+    assert path.read_bytes().startswith(b"NLBX")
+    fresh = EncryptedFileTokenCache(path=path, kek_source=_kek())
+    assert fresh.load("acct") == legacy
+
+
+def test_dir_and_file_modes_preserved_across_migration(tmp_path: Path):
+    if os.name != "posix":
+        pytest.skip("POSIX-mode bits are not enforceable on Windows")
+
+    # Given a legacy plaintext file inside the cache directory
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    path = cache_dir / "tokens.json"
+    path.write_text(json.dumps({"acct": _tok().to_dict()}), encoding="utf-8")
+    cache = EncryptedFileTokenCache(path=path, kek_source=_kek())
+
+    # When the first save migrates the file to encrypted form
+    cache.save("acct2", _tok())
+
+    # Then the directory is 0700 and the file is 0600
+    assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/tests/test_encrypted_file_token_cache.py
+++ b/tests/test_encrypted_file_token_cache.py
@@ -120,12 +120,15 @@ def test_failed_write_leaves_plaintext_intact_and_rerun_completes(tmp_path: Path
     assert path.read_bytes() == original_bytes
     assert EncryptedFileTokenCache(path=path, kek_source=_kek()).load("acct") == legacy
 
-    # And re-running the save after recovery completes the migration
+    # And re-running the save after recovery completes the migration,
+    # persisting both the existing and the newly-added token
+    added = _tok(access_token="added")
     when(os).replace(...).thenCallOriginalImplementation()
-    cache.save("acct2", _tok(access_token="added"))
+    cache.save("acct2", added)
     assert path.read_bytes().startswith(b"NLBX")
     fresh = EncryptedFileTokenCache(path=path, kek_source=_kek())
     assert fresh.load("acct") == legacy
+    assert fresh.load("acct2") == added
 
 
 def test_dir_and_file_modes_preserved_across_migration(tmp_path: Path):


### PR DESCRIPTION
Closes #134

## Summary
- Add verification tests for the organic legacy→encrypted token-cache migration (no production code change required; the behavior shipped in #131 / ADR 0003 was already correct).
- Tested via `tools/tests.py` (7 passed) and `tools/checks.py` (black/flake8/mypy/pyright all green).
- Trade-off: none — this is a dedicated verification slice.

## Tests added (red → green)
- `test_loading_legacy_file_does_not_rewrite_it`
- `test_first_save_migrates_and_preserves_existing_tokens`
- `test_failed_write_leaves_plaintext_intact_and_rerun_completes`
- `test_dir_and_file_modes_preserved_across_migration`

## Notable assumptions
- `blocked_by: 131` in the slice front-matter is stale: #131 is closed/merged, so the blocker is resolved and the slice proceeded.
- The four acceptance criteria were untagged in the issue body; all four assert observable load/save/failure/mode behavior, so they were tagged `(behavior)` in the issue.
- The repository uses a flat `tests/` layout, so the tests live in `tests/test_encrypted_file_token_cache.py` rather than the issue's hinted nested `tests/_auth/_token_cache/...` path.
- The mid-flight-failure test mocks the `os.replace` filesystem boundary (the atomic-rename step); all other assertions go through the public `load`/`save` interface.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds four acceptance-criteria tests verifying the organic legacy→encrypted token-cache migration introduced in #131 — no production code is changed. The tests exercise the full read/write lifecycle of `EncryptedFileTokenCache` against a pre-existing plaintext file, covering load-only idempotency, migration-on-first-save with token preservation, mid-write failure atomicity and recovery, and POSIX mode-bit enforcement.

- `test_loading_legacy_file_does_not_rewrite_it` and `test_first_save_migrates_and_preserves_existing_tokens` add stronger byte-level and multi-token assertions on top of the already-existing `test_legacy_plaintext_loads_then_save_encrypts` test.
- `test_failed_write_leaves_plaintext_intact_and_rerun_completes` mocks `os.replace` via mockito at the exact atomic-rename boundary; the `conftest.py` `_unstub` autouse fixture correctly tears down all stubs after each test.
- `test_dir_and_file_modes_preserved_across_migration` is gated with `pytest.skip` on non-POSIX platforms, consistent with the approach in `test_encrypted_round_trip_and_magic`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Pure test addition with no production code changes; safe to merge once the missing assertion is addressed.

The four new tests cover real and meaningful scenarios; all production-code paths they exercise were already correct. The one gap is in the recovery test: after the successful re-run, the test verifies the legacy token but never asserts that the newly-added acct2 token is present, leaving that half of the recovery guarantee unconfirmed.

tests/test_encrypted_file_token_cache.py — specifically the assertion set at the end of test_failed_write_leaves_plaintext_intact_and_rerun_completes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_encrypted_file_token_cache.py | Adds four migration verification tests for the legacy→encrypted token-cache path; all tests are well-structured and use the project's mockito conventions, with one missing assertion in the recovery test (acct2 token not verified after successful re-run). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant C as EncryptedFileTokenCache
    participant FS as Filesystem (tmp_path)
    participant AW as atomic_write_bytes

    Note over T,FS: test_loading_legacy_file_does_not_rewrite_it
    T->>FS: write plaintext JSON
    T->>C: load("acct")
    C->>FS: read_bytes()
    FS-->>C: plaintext blob (no NLBX)
    C-->>T: CachedToken
    T->>FS: read_bytes() again
    FS-->>T: identical plaintext (file untouched)

    Note over T,FS: test_first_save_migrates_and_preserves_existing_tokens
    T->>FS: write plaintext JSON (legacy token)
    T->>C: save("acct2", added)
    C->>FS: read_bytes() → plaintext dict
    C->>AW: atomic_write_bytes(encrypted blob)
    AW->>FS: os.replace(tmp → tokens.json)
    T->>C: fresh.load("acct") + fresh.load("acct2")
    C-->>T: both tokens present

    Note over T,FS: test_failed_write_leaves_plaintext_intact_and_rerun_completes
    T->>FS: write plaintext JSON (legacy token)
    T-->>C: mock os.replace → OSError
    T->>C: save("acct2", added) → raises OSError
    AW->>FS: os.unlink(tmp) cleanup
    T->>FS: read_bytes() → still original plaintext
    T-->>C: mock os.replace → thenCallOriginalImplementation
    T->>C: save("acct2", added) → succeeds
    AW->>FS: os.replace(tmp → tokens.json)
    T->>FS: read_bytes() → starts with NLBX
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant C as EncryptedFileTokenCache
    participant FS as Filesystem (tmp_path)
    participant AW as atomic_write_bytes

    Note over T,FS: test_loading_legacy_file_does_not_rewrite_it
    T->>FS: write plaintext JSON
    T->>C: load("acct")
    C->>FS: read_bytes()
    FS-->>C: plaintext blob (no NLBX)
    C-->>T: CachedToken
    T->>FS: read_bytes() again
    FS-->>T: identical plaintext (file untouched)

    Note over T,FS: test_first_save_migrates_and_preserves_existing_tokens
    T->>FS: write plaintext JSON (legacy token)
    T->>C: save("acct2", added)
    C->>FS: read_bytes() → plaintext dict
    C->>AW: atomic_write_bytes(encrypted blob)
    AW->>FS: os.replace(tmp → tokens.json)
    T->>C: fresh.load("acct") + fresh.load("acct2")
    C-->>T: both tokens present

    Note over T,FS: test_failed_write_leaves_plaintext_intact_and_rerun_completes
    T->>FS: write plaintext JSON (legacy token)
    T-->>C: mock os.replace → OSError
    T->>C: save("acct2", added) → raises OSError
    AW->>FS: os.unlink(tmp) cleanup
    T->>FS: read_bytes() → still original plaintext
    T-->>C: mock os.replace → thenCallOriginalImplementation
    T->>C: save("acct2", added) → succeeds
    AW->>FS: os.replace(tmp → tokens.json)
    T->>FS: read_bytes() → starts with NLBX
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Ftest_encrypted_file_token_cache.py%3A123-128%0A**Missing%20assertion%20on%20newly-added%20token%20after%20recovery**%0A%0AAfter%20the%20successful%20re-run%2C%20the%20test%20only%20checks%20%60fresh.load%28%22acct%22%29%20%3D%3D%20legacy%60%20but%20never%20asserts%20that%20%60fresh.load%28%22acct2%22%29%60%20equals%20the%20token%20passed%20to%20the%20second%20%60cache.save%60%20call.%20Without%20that%20assertion%2C%20the%20test%20doesn't%20verify%20that%20the%20recovered%20migration%20actually%20persisted%20the%20newly-added%20token%20%E2%80%94%20an%20%60OSError%60-swallowing%20regression%20in%20%60save%60%20could%20keep%20the%20file%20stale%20while%20the%20existing%20assertion%20still%20passes.%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=261&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(token-cache): verify organic legacy..."](https://github.com/stevenengland/nextlabs_rest_api/commit/32b0dcd0e5b8a478c19fa9adb872aa9edbc8ac98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40733324)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->