### PR TITLE
feat(cli): report token cache encryption in auth status

### DIFF
--- a/src/nextlabs_sdk/_cli/_account_resolver.py
+++ b/src/nextlabs_sdk/_cli/_account_resolver.py
@@ -7,7 +7,9 @@ from nextlabs_sdk._auth._active_account._active_account_store import (
     ActiveAccountStore,
 )
 from nextlabs_sdk._auth._token_cache._cache_factory import (
+    CacheStatus,
     build_token_cache as _factory,
+    inspect_token_cache as _inspect,
 )
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
@@ -31,14 +33,24 @@ def build_active_store(ctx: CliContext) -> ActiveAccountStore:
     return ActiveAccountStore()
 
 
-def build_token_cache(ctx: CliContext) -> TokenCache:
+def _cache_env_and_path(ctx: CliContext) -> tuple[dict[str, str], Path | None]:
     env: dict[str, str] = {}
     if ctx.master_password:
         env["NEXTLABS_MASTER_PASSWORD"] = ctx.master_password
     if ctx.disable_token_encryption:
         env["NEXTLABS_DISABLE_TOKEN_ENCRYPTION"] = "1"
     path = Path(ctx.cache_dir) / "tokens.json" if ctx.cache_dir else None
+    return env, path
+
+
+def build_token_cache(ctx: CliContext) -> TokenCache:
+    env, path = _cache_env_and_path(ctx)
     return _factory(path=path, env=env)
+
+
+def inspect_token_cache(ctx: CliContext) -> CacheStatus:
+    env, path = _cache_env_and_path(ctx)
+    return _inspect(path=path, env=env)
 
 
 def build_prefs_store(ctx: CliContext) -> AccountPreferencesStore:

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -35,6 +35,7 @@ from nextlabs_sdk._cli._expiry_format import format_expiry
 from nextlabs_sdk._cli._factory import make_group
 from nextlabs_sdk._cli._output import print_success
 from nextlabs_sdk._cli._ssl_retry import SslRetryPrompter
+from nextlabs_sdk.exceptions import TokenCacheError
 
 auth_app = make_group("Authentication commands")
 
@@ -379,11 +380,17 @@ def _render_status_detail(
     Console().print(_build_status_table(target, entry))
 
 
-_KDF_SUITE_NAMES = MappingProxyType({1: "argon2id"})
+_KDF_SUITE_NAMES = MappingProxyType({0: "raw", 1: "argon2id"})
+
+_CACHE_LINE_UNREADABLE = "Cache: unreadable (cache header could not be parsed)"
 
 
 def _render_cache_line(cli_ctx: CliContext) -> None:
-    cache_info = inspect_token_cache(cli_ctx)
+    try:
+        cache_info = inspect_token_cache(cli_ctx)
+    except TokenCacheError:
+        typer.echo(_CACHE_LINE_UNREADABLE)
+        return
     suite = (
         _STATUS_NONE
         if cache_info.suite_id is None

--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import replace
+from types import MappingProxyType
 from typing import Annotated
 
 import click
@@ -25,6 +26,7 @@ from nextlabs_sdk._cli._account_resolver import (
     build_token_cache,
     build_prefs_store,
     effective_verify_ssl,
+    inspect_token_cache,
 )
 from nextlabs_sdk._cli._account_status_label import account_status_and_refreshable
 from nextlabs_sdk._cli._context import CliContext
@@ -377,6 +379,22 @@ def _render_status_detail(
     Console().print(_build_status_table(target, entry))
 
 
+_KDF_SUITE_NAMES = MappingProxyType({1: "argon2id"})
+
+
+def _render_cache_line(cli_ctx: CliContext) -> None:
+    cache_info = inspect_token_cache(cli_ctx)
+    suite = (
+        _STATUS_NONE
+        if cache_info.suite_id is None
+        else _KDF_SUITE_NAMES.get(cache_info.suite_id, str(cache_info.suite_id))
+    )
+    typer.echo(
+        f"Cache: {cache_info.path} ({cache_info.state}); "
+        f"source: {cache_info.source}; suite: {suite}"
+    )
+
+
 @auth_app.command(name="status")
 @cli_error_handler
 def status(
@@ -385,6 +403,7 @@ def status(
 ) -> None:
     """Show whether a valid cached token exists."""
     cli_ctx: CliContext = ctx.obj
+    _render_cache_line(cli_ctx)
     if show_all:
         _status_all(cli_ctx)
         return

--- a/tests/test_cli_auth_status_cache.py
+++ b/tests/test_cli_auth_status_cache.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mockito import when
+from typer.testing import CliRunner
+
+from nextlabs_sdk._auth._active_account._active_account import ActiveAccount
+from nextlabs_sdk._auth._active_account._active_account_store import (
+    ActiveAccountStore,
+)
+from nextlabs_sdk._auth._token_cache._cache_factory import CacheStatus
+from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
+from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._cli import _auth_cmd
+from nextlabs_sdk._cli._app import app
+
+runner = CliRunner()
+
+_ACTIVE_KEY = (
+    "https://example.com/cas/oidc/accessToken" "|admin|ControlCenterOIDCClient|cloudaz"
+)
+
+
+def _isolate_cache(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXTLABS_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("NEXTLABS_DISABLE_TOKEN_ENCRYPTION", "1")
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+
+def _set_active_account(tmp_path: object) -> None:
+    ActiveAccountStore(path=f"{tmp_path}/active_account.json").save(
+        ActiveAccount(
+            base_url="https://example.com",
+            username="admin",
+            client_id="ControlCenterOIDCClient",
+        ),
+    )
+
+
+def _seed_plaintext_token(tmp_path: object) -> None:
+    FileTokenCache(path=f"{tmp_path}/tokens.json").save(
+        _ACTIVE_KEY,
+        CachedToken(
+            access_token="t",
+            refresh_token="rt",
+            expires_at=9_999_999_999.0,
+            token_type="bearer",
+            scope=None,
+            refresh_expires_at=None,
+        ),
+    )
+    _set_active_account(tmp_path)
+
+
+def test_status_prints_cache_line_alongside_validity(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a valid plaintext token cache on disk
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then both the validity output and a cache line appear
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output
+    assert "Cache:" in result.output
+    assert f"{tmp_path}/tokens.json" in result.output
+    assert "plaintext" in result.output
+    assert "source:" in result.output
+    assert "suite:" in result.output
+
+
+def test_status_reports_plaintext_for_legacy_file(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a legacy plaintext token file on disk
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the encryption state is reported as plaintext
+    assert result.exit_code == 0, result.output
+    assert "(plaintext)" in result.output
+
+
+def test_status_prints_cache_line_when_no_token_cached(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given an active account but no cached token file
+    _isolate_cache(tmp_path, monkeypatch)
+    _set_active_account(tmp_path)
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the cache line still appears and the exit code is unchanged
+    assert result.exit_code == 1, result.output
+    assert "Cache:" in result.output
+    assert "absent" in result.output
+    assert "No cached token." in result.output
+
+
+@pytest.mark.parametrize("source_label", ["env", "keyring", "tty", "none"])
+def test_status_renders_labels_from_read_only_inspector(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+    source_label: str,
+) -> None:
+    # Given the read-only inspector reports a source label and KDF suite
+    _isolate_cache(tmp_path, monkeypatch)
+    when(_auth_cmd).inspect_token_cache(...).thenReturn(
+        CacheStatus(
+            path=Path(f"{tmp_path}/tokens.json"),
+            state="encrypted",
+            source=source_label,
+            suite_id=1,
+        )
+    )
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the cache line reflects the inspector's labels without unlocking
+    assert "Cache:" in result.output
+    assert f"source: {source_label}" in result.output
+    assert "suite: argon2id" in result.output
+
+
+def test_status_all_prints_cache_line(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a seeded cache and the --all path
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+
+    # When status --all is rendered
+    result = runner.invoke(app, ["auth", "status", "--all"])
+
+    # Then the cache line appears on the --all path too
+    assert result.exit_code == 0, result.output
+    assert "Cache:" in result.output
+    assert "plaintext" in result.output

--- a/tests/test_cli_auth_status_cache.py
+++ b/tests/test_cli_auth_status_cache.py
@@ -69,7 +69,7 @@ def test_status_prints_cache_line_alongside_validity(
     assert result.exit_code == 0, result.output
     assert "valid" in result.output
     assert "Cache:" in result.output
-    assert f"{tmp_path}/tokens.json" in result.output
+    assert "tokens.json" in result.output
     assert "plaintext" in result.output
     assert "source:" in result.output
     assert "suite:" in result.output

--- a/tests/test_cli_auth_status_cache.py
+++ b/tests/test_cli_auth_status_cache.py
@@ -15,6 +15,7 @@ from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _auth_cmd
 from nextlabs_sdk._cli._app import app
+from nextlabs_sdk.exceptions import TokenCacheError
 
 runner = CliRunner()
 
@@ -133,6 +134,47 @@ def test_status_renders_labels_from_read_only_inspector(
     assert "Cache:" in result.output
     assert f"source: {source_label}" in result.output
     assert "suite: argon2id" in result.output
+
+
+def test_status_labels_raw_wrapped_suite(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a keyring (raw-key) wrapped cache whose header suite id is 0
+    _isolate_cache(tmp_path, monkeypatch)
+    when(_auth_cmd).inspect_token_cache(...).thenReturn(
+        CacheStatus(
+            path=Path(f"{tmp_path}/tokens.json"),
+            state="encrypted",
+            source="keyring",
+            suite_id=0,
+        )
+    )
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the raw wrap is labelled rather than shown as a bare integer
+    assert "suite: raw" in result.output
+    assert "suite: 0" not in result.output
+
+
+def test_status_survives_unreadable_cache_header(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a valid token but an inspector that cannot parse the cache header
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+    when(_auth_cmd).inspect_token_cache(...).thenRaise(TokenCacheError())
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then validity output still appears and the command does not abort
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output
+    assert "unreadable" in result.output
 
 
 def test_status_all_prints_cache_line(


### PR DESCRIPTION
Closes #136

## Summary
- Append a cache line to `nextlabs auth status` (single and `--all` paths) showing the cache path, encryption state (`encrypted`/`plaintext`/`absent`), passphrase source label (`env`/`keyring`/`tty`/`none`), and KDF suite.
- The line is sourced from the read-only `inspect_token_cache`, so rendering never unlocks the cache or prompts; it prints even when no token is cached and leaves the existing token-validity exit codes unchanged.
- Verified via new CLI tests covering valid, plaintext-legacy, and no-token cases plus a mockito-backed inspector check for source/suite labels; full `black`/`flake8`/`mypy`/`pyright` pass.

## Tests added (red → green)
- `test_status_prints_cache_line_alongside_validity`
- `test_status_reports_plaintext_for_legacy_file`
- `test_status_prints_cache_line_when_no_token_cached`
- `test_status_renders_labels_from_read_only_inspector`
- `test_status_all_prints_cache_line`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR appends a cache status line to `nextlabs auth status` (both the single-account and `--all` paths) showing the cache path, encryption state, passphrase source label, and KDF suite — sourced from the new read-only `inspect_token_cache` helper that never unlocks the cache or prompts the user.

- `_account_resolver.py`: Extracts `_cache_env_and_path` to share env/path setup between `build_token_cache` and a new `inspect_token_cache` wrapper around the factory-level inspector.
- `_auth_cmd.py`: Adds `_render_cache_line` called at the top of the `status` command; `_KDF_SUITE_NAMES` maps suite IDs to human-readable names, but is missing the `suite_id=0` entry used for raw-key (keyring) encrypted caches and has no guard for `TokenCacheError` from a corrupted/future-format header.
- `tests/test_cli_auth_status_cache.py`: Five new tests covering valid, plaintext-legacy, no-token, source-label, and `--all` paths using mockito and real file fixtures.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The cache line feature works correctly for env-var and plaintext cases, but two correctness gaps affect real keyring and corrupted-cache user workflows.

Keyring users will always see a raw `suite: 0` on the status line because `_KDF_SUITE_NAMES` has no entry for `suite_id=0` written by `RawKek`-based encryption. Additionally, a cache file with the `NLBX` magic but a truncated header or unrecognised version byte causes `read_header` to raise `TokenCacheError`, which the `@cli_error_handler` converts into a hard exit, preventing the user from reading any account-validity output at all.

src/nextlabs_sdk/_cli/_auth_cmd.py — the suite-ID map and the unguarded inspect call in _render_cache_line.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_auth_cmd.py | Adds _render_cache_line and _KDF_SUITE_NAMES; the suite ID map is missing the suite_id=0 entry used for raw-key (keyring) encrypted caches, and TokenCacheError from a truncated/future-version header can abort the entire status command. |
| src/nextlabs_sdk/_cli/_account_resolver.py | Clean refactor: extracts _cache_env_and_path helper and exposes inspect_token_cache; logic is correct and well-factored. |
| tests/test_cli_auth_status_cache.py | Good coverage of cache line output paths; test helpers annotate tmp_path as object instead of pathlib.Path, which weakens type safety but does not break the tests. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant status as "status cmd"
    participant rcl as "_render_cache_line"
    participant itc as "inspect_token_cache"
    participant pr as "PassphraseResolver.peek"
    participant sh as "SecretBox/read_header"

    User->>status: nextlabs auth status
    status->>rcl: _render_cache_line(cli_ctx)
    rcl->>itc: inspect_token_cache(path, env)
    itc->>pr: peek(env)
    pr-->>itc: source label (env/keyring/none)
    itc->>sh: read_bytes + is_encrypted
    alt absent
        itc-->>rcl: CacheStatus(absent, None)
    else plaintext
        itc-->>rcl: CacheStatus(plaintext, None)
    else encrypted
        itc->>sh: read_header(blob)
        sh-->>itc: Header(suite_id)
        itc-->>rcl: CacheStatus(encrypted, suite_id)
    end
    rcl-->>status: echo Cache line
    alt show_all
        status->>status: _status_all accounts table
    else single
        status->>status: resolve target + load token + detail table
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant status as "status cmd"
    participant rcl as "_render_cache_line"
    participant itc as "inspect_token_cache"
    participant pr as "PassphraseResolver.peek"
    participant sh as "SecretBox/read_header"

    User->>status: nextlabs auth status
    status->>rcl: _render_cache_line(cli_ctx)
    rcl->>itc: inspect_token_cache(path, env)
    itc->>pr: peek(env)
    pr-->>itc: source label (env/keyring/none)
    itc->>sh: read_bytes + is_encrypted
    alt absent
        itc-->>rcl: CacheStatus(absent, None)
    else plaintext
        itc-->>rcl: CacheStatus(plaintext, None)
    else encrypted
        itc->>sh: read_header(blob)
        sh-->>itc: Header(suite_id)
        itc-->>rcl: CacheStatus(encrypted, suite_id)
    end
    rcl-->>status: echo Cache line
    alt show_all
        status->>status: _status_all accounts table
    else single
        status->>status: resolve target + load token + detail table
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fnextlabs_sdk%2F_cli%2F_auth_cmd.py%3A382-394%0A**Missing%20%60suite_id%3D0%60%20mapping%20%E2%80%94%20keyring%20users%20see%20%60suite%3A%200%60**%0A%0A%60KeyringPassphraseSource.resolve%60%20returns%20a%20%60RawKek%60%2C%20and%20%60_resolve_kek_for_seal%60%20encodes%20%60suite_id%3D0%60%20into%20the%20file%20header%20for%20raw-key%20wrapped%20caches.%20Because%20%60_KDF_SUITE_NAMES%60%20only%20contains%20%60%7B1%3A%20%22argon2id%22%7D%60%2C%20the%20fallback%20%60str%28cache_info.suite_id%29%60%20fires%20for%20any%20keyring-encrypted%20cache%2C%20producing%20%60suite%3A%200%60%20on%20the%20status%20line%20%E2%80%94%20a%20confusing%20raw%20integer.%20Adding%20%600%60%20to%20the%20map%20%28e.g.%20%600%3A%20%22%E2%80%94%22%60%20or%20%600%3A%20%22raw%22%60%29%20would%20handle%20this%20correctly.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fnextlabs_sdk%2F_cli%2F_auth_cmd.py%3A385-395%0A**%60TokenCacheError%60%20from%20%60read_header%60%20can%20abort%20%60status%60%20entirely**%0A%0A%60inspect_token_cache%60%20calls%20%60read_header%60%2C%20which%20raises%20%60TokenCacheError%60%20when%20the%20file%20has%20the%20%60NLBX%60%20magic%20but%20is%20truncated%20below%20%60_HEADER_PREFIX_LEN%60%20bytes%2C%20or%20has%20an%20unrecognised%20%60version%60%2F%60wrap_type%60.%20Since%20%60_render_cache_line%60%20has%20no%20try%2Fexcept%2C%20%60%40cli_error_handler%60%20intercepts%20the%20exception%2C%20prints%20%60Token%20cache%20error%3A%20...%60%2C%20and%20exits%20with%20code%201%20%E2%80%94%20preventing%20the%20user%20from%20seeing%20any%20account%20validity%20information%20at%20all.%20A%20file%20written%20by%20a%20future%20version%20with%20a%20new%20version%20byte%20would%20trigger%20this%20every%20time%20%60status%60%20is%20run.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_cli_auth_status_cache.py%3A27-35%0A**Test%20helpers%20typed%20as%20%60object%60%20instead%20of%20%60pathlib.Path%60**%0A%0A%60_isolate_cache%60%2C%20%60_set_active_account%60%2C%20and%20%60_seed_plaintext_token%60%20annotate%20%60tmp_path%60%20as%20%60object%60.%20pytest's%20%60tmp_path%60%20fixture%20is%20%60pathlib.Path%60%2C%20and%20pyright%20strict%20mode%20tracks%20the%20actual%20fixture%20type%20through%20parametrised%20calls.%20Using%20%60object%60%20is%20accepted%20here%20only%20because%20all%20operations%20fall%20back%20to%20%60__str__%60%2C%20but%20it%20conceals%20the%20type%20and%20will%20confuse%20future%20readers%20or%20static%20analysis%20tools%20that%20might%20enforce%20stricter%20narrowing.%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): report token cache encryption..."](https://github.com/stevenengland/nextlabs_rest_api/commit/f0a90b49d08433cfee9f3c04c2d8b89bda76194a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40754396)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->