### PR TITLE
fix(cli): add __main__ guard so debugger can attach to entrypoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,38 +1,23 @@
 {
     "version": "0.2.0",
     "configurations": [
-        // ── Uncomment and adapt the configurations you need ──
-
-        // Run as module (most common for src-layout packages):
-        // {
-        //     "name": "Run module",
-        //     "type": "debugpy",
-        //     "request": "launch",
-        //     "module": "nextlabs_sdk",
-        //     "cwd": "${workspaceFolder}",
-        //     "console": "integratedTerminal"
-        // },
-
-        // Run module with arguments (e.g., CLI subcommand):
-        // {
-        //     "name": "Run with args",
-        //     "type": "debugpy",
-        //     "request": "launch",
-        //     "module": "nextlabs_sdk",
-        //     "args": ["--help"],
-        //     "cwd": "${workspaceFolder}",
-        //     "console": "integratedTerminal",
-        // },
-
-        // Run a specific test file:
-        // {
-        //     "name": "Debug test",
-        //     "type": "debugpy",
-        //     "request": "launch",
-        //     "module": "pytest",
-        //     "args": ["tests/test_placeholder.py", "-s", "--no-cov"],
-        //     "cwd": "${workspaceFolder}",
-        //     "console": "integratedTerminal"
-        // }
+        {
+            "name": "nextlabs (prompt args)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "nextlabs_sdk._cli._entrypoint",
+            "args": "${input:nextlabsArgs}",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ],
+    "inputs": [
+        {
+            "id": "nextlabsArgs",
+            "type": "promptString",
+            "description": "nextlabs args & flags (e.g. policies get 123456  or  -o json policies diff)",
+            "default": "--help"
+        }
     ]
 }

--- a/src/nextlabs_sdk/_cli/_entrypoint.py
+++ b/src/nextlabs_sdk/_cli/_entrypoint.py
@@ -40,3 +40,7 @@ def main() -> None:
 
     app_module = importlib.import_module("nextlabs_sdk._cli._app")
     app_module.app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`python -m nextlabs_sdk._cli._entrypoint` only executes top-level code (function definitions). `main()` was never called, so the process exited immediately — breakpoints were never hit and raised exceptions were never surfaced.

## Fix

- Added the standard `if __name__ == '__main__': main()` guard to `_entrypoint.py`
- Updated `.vscode/launch.json`: module-based launch now works, added `justMyCode: false` so debugpy doesn't skip breakpoints in `src/` editable installs

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the standard `if __name__ == "__main__": main()` guard to `_entrypoint.py` so the module can be launched directly via `python -m` for debugging. The accompanying `.vscode/launch.json` is updated with an active debugpy configuration that targets the module and enables `justMyCode: false` for editable installs.

- `_entrypoint.py`: four-line addition of the idiomatic `__main__` guard — correct and has no runtime impact on the normal console-script path.
- `.vscode/launch.json`: all commented-out placeholder configs are replaced with one working configuration; a `promptString` input lets the developer supply CLI args interactively at debug time.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are confined to a developer tooling file and a four-line idiomatic Python guard with no production impact.

The entrypoint change is a textbook `__main__` guard and introduces no risk. The launch.json `args` field uses a bare string instead of an array, which may silently break multi-token CLI invocations during debug sessions.

.vscode/launch.json — the `args` string vs. array question is worth a quick sanity-check before the config is shared with other contributors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_entrypoint.py | Adds standard `if __name__ == "__main__": main()` guard so `python -m nextlabs_sdk._cli._entrypoint` correctly invokes `main()`. Change is idiomatic and correct. |
| .vscode/launch.json | Replaces all commented-out example configs with one active debugpy configuration. The `args` field is set to a bare string `"${input:nextlabsArgs}"` rather than an array, which may cause multi-word inputs to be passed as a single argument. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["python -m nextlabs_sdk._cli._entrypoint"] --> B{"__name__ == '__main__'?"}
    B -- "Yes (direct run / debugger)" --> C["main()"]
    B -- "No (imported as module)" --> D["Module loaded, nothing called"]
    C --> E{"CLI deps installed?"}
    E -- "Missing" --> F["Print error + sys.exit(1)"]
    E -- "OK" --> G["importlib.import_module('nextlabs_sdk._cli._app')"]
    G --> H["app_module.app()  ← Typer app"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["python -m nextlabs_sdk._cli._entrypoint"] --> B{"__name__ == '__main__'?"}
    B -- "Yes (direct run / debugger)" --> C["main()"]
    B -- "No (imported as module)" --> D["Module loaded, nothing called"]
    C --> E{"CLI deps installed?"}
    E -- "Missing" --> F["Print error + sys.exit(1)"]
    E -- "OK" --> G["importlib.import_module('nextlabs_sdk._cli._app')"]
    G --> H["app_module.app()  ← Typer app"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.vscode%2Flaunch.json%3A9%0AThe%20%60args%60%20field%20is%20set%20to%20a%20bare%20string%20%60%22%24%7Binput%3AnextlabsArgs%7D%22%60%20instead%20of%20an%20array.%20VS%20Code's%20JSON%20schema%20for%20debugpy%20launch%20configs%20types%20%60args%60%20as%20%60string%5B%5D%60%2C%20so%20a%20raw%20string%20may%20be%20coerced%20to%20a%20single%20element%20%E2%80%94%20meaning%20input%20like%20%60policies%20get%20123456%60%20would%20arrive%20at%20the%20CLI%20as%20one%20argument%20%60%22policies%20get%20123456%22%60%20rather%20than%20three%20separate%20tokens%2C%20causing%20an%20argument-parsing%20failure.%20Wrapping%20it%20in%20an%20array%20keeps%20the%20intended%20multi-word%20split%20behavior%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%22args%22%3A%20%5B%22%24%7Binput%3AnextlabsArgs%7D%22%5D%2C%0A%60%60%60%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): add \_\_main\_\_ guard so debugger..."](https://github.com/stevenengland/nextlabs_rest_api/commit/d00a46ac53b5142b51697dee079b542c52e19212) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40777985)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->