### PR TITLE
refactor(search): mark payload label constants private (#263)

### DIFF
--- a/src/nextlabs_sdk/_cloudaz/_search/payloads.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/payloads.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
-STRING_LABEL = "String"
-TEXT_LABEL = "Text"
-DATE_LABEL = "Date"
-TEXT_DEFAULT_FIELDS = ("name", "description")
+_STRING_LABEL = "String"
+_TEXT_LABEL = "Text"
+_DATE_LABEL = "Date"
+_TEXT_DEFAULT_FIELDS = ("name", "description")
 
 _TYPE_KEY = "type"
 _VALUE_KEY = "value"
@@ -14,7 +14,7 @@ _FIELDS_KEY = "fields"
 
 def string_payload(value: Any) -> dict[str, Any]:  # noqa: WPS110
     """Encode a ``String`` typed search value (scalar or list)."""
-    return {_TYPE_KEY: STRING_LABEL, _VALUE_KEY: value}
+    return {_TYPE_KEY: _STRING_LABEL, _VALUE_KEY: value}
 
 
 def text_payload(
@@ -23,10 +23,10 @@ def text_payload(
     fields: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Encode a ``Text`` typed search value over the given (or default) fields."""
-    subfields = list(fields) if fields else list(TEXT_DEFAULT_FIELDS)
-    return {_TYPE_KEY: TEXT_LABEL, _FIELDS_KEY: subfields, _VALUE_KEY: value}
+    subfields = list(fields) if fields else list(_TEXT_DEFAULT_FIELDS)
+    return {_TYPE_KEY: _TEXT_LABEL, _FIELDS_KEY: subfields, _VALUE_KEY: value}
 
 
 def date_payload(**entries: Any) -> dict[str, Any]:
     """Encode a ``Date`` typed search value from the given bound/option entries."""
-    return {_TYPE_KEY: DATE_LABEL, **entries}
+    return {_TYPE_KEY: _DATE_LABEL, **entries}


### PR DESCRIPTION
## What

Addresses a #263 review comment (greptile) on `_search/payloads.py`: the four
label constants `STRING_LABEL`, `TEXT_LABEL`, `DATE_LABEL`,
`TEXT_DEFAULT_FIELDS` were exported without a leading underscore, reading as
public API.

## Why worthy

They are implementation-level string constants consumed **only** inside
`payloads.py` (no external references in `src/` or `tests/`). Underscore-prefixing
aligns with the project convention of marking internal symbols explicitly private.

## Change

Rename to `_STRING_LABEL` / `_TEXT_LABEL` / `_DATE_LABEL` / `_TEXT_DEFAULT_FIELDS`
and update the three in-module references. No behavior change.

## Verification

- black / flake8 / mypy / pyright green
- search suites pass: `test_search`, `test_search_field_expr`, `test_search_where`, `test_search_dates` (86 passed)

## Note

`payloads.py` landed via #271 (not in the F4 test-split PR #272), so this fix is
its own branch off `main` to keep both PRs' changelog scopes clean. The sibling
greptile comment (`# noqa: WPS110`) is a separate concern, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Renames four module-level string constants in `payloads.py` from public names (`STRING_LABEL`, `TEXT_LABEL`, `DATE_LABEL`, `TEXT_DEFAULT_FIELDS`) to private ones (`_STRING_LABEL`, `_TEXT_LABEL`, `_DATE_LABEL`, `_TEXT_DEFAULT_FIELDS`) and updates the three in-module call sites. No behaviour change.

- All four renamed constants are confirmed to have zero external references in `src/` or `tests/`, so no consumers are broken.
- The three function call sites (`string_payload`, `text_payload`, `date_payload`) are updated consistently; all static-analysis and test suites pass per the PR description.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely cosmetic rename of four internal constants with no external consumers.

All four renamed constants had zero references outside `payloads.py` in both `src/` and `tests/`, and all three in-module call sites are updated. The change is a complete, self-contained rename with no behaviour impact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cloudaz/_search/payloads.py | Four public constants renamed to private; all three in-module usages updated. No external references exist — the rename is safe and complete. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["payloads.py (module)"] --> B["_STRING_LABEL = 'String'"]
    A --> C["_TEXT_LABEL = 'Text'"]
    A --> D["_DATE_LABEL = 'Date'"]
    A --> E["_TEXT_DEFAULT_FIELDS = ('name', 'description')"]
    B --> F["string_payload()"]
    C --> G["text_payload()"]
    E --> G
    D --> H["date_payload()"]
    F --> I["dict payload returned to caller"]
    G --> I
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["payloads.py (module)"] --> B["_STRING_LABEL = 'String'"]
    A --> C["_TEXT_LABEL = 'Text'"]
    A --> D["_DATE_LABEL = 'Date'"]
    A --> E["_TEXT_DEFAULT_FIELDS = ('name', 'description')"]
    B --> F["string_payload()"]
    C --> G["text_payload()"]
    E --> G
    D --> H["date_payload()"]
    F --> I["dict payload returned to caller"]
    G --> I
    H --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(search): mark payload label con..."](https://github.com/stevenengland/nextlabs_rest_api/commit/55adcf9bd24e260b3371f74ce7cb4dfa29028ee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40795588)</sub>

<!-- /greptile_comment -->