### PR TITLE
fix(token-cache): degrade to plaintext on a non-seekable controlling tty

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -83,8 +83,17 @@ def build_token_cache(
 
 
 def _confirm_plaintext_or_abort(console: ConsoleIO, cache_path: Path) -> TokenCache:
+    """Gate plaintext storage behind a confirmation on the controlling terminal.
+
+    An unusable terminal cannot be prompted, so it degrades to plaintext rather
+    than aborting, honouring the "encrypt when possible, never abort" policy.
+    """
     print(_CONFIRM_WARNING, file=sys.stderr)
-    if console.confirm(_CONFIRM_PROMPT):
+    try:
+        confirmed = console.confirm(_CONFIRM_PROMPT)
+    except OSError:
+        return FileTokenCache(path=cache_path)
+    if confirmed:
         return FileTokenCache(path=cache_path)
     raise TokenCacheError()
 

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -92,6 +92,9 @@ def _confirm_plaintext_or_abort(console: ConsoleIO, cache_path: Path) -> TokenCa
     try:
         confirmed = console.confirm(_CONFIRM_PROMPT)
     except OSError:
+        # The confirmation warning already disclosed plaintext storage; record
+        # it so a later non-interactive build does not repeat the warning.
+        globals()["_WARNED"] = True
         return FileTokenCache(path=cache_path)
     if confirmed:
         return FileTokenCache(path=cache_path)

--- a/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
@@ -4,7 +4,15 @@ import sys
 
 
 class ConsoleIO:
-    """Console abstraction over the controlling terminal (POSIX ``/dev/tty``)."""
+    """Console abstraction over the controlling terminal (POSIX ``/dev/tty``).
+
+    The terminal is accessed through separate read and write handles rather than
+    a single ``"r+"`` handle: the latter is a ``BufferedRandom`` whose flush
+    requires seek support, which a non-seekable ``/dev/tty`` (devcontainers, some
+    CI shells) does not provide. An unusable terminal therefore surfaces as an
+    ``OSError`` (``io.UnsupportedOperation`` included) for callers to treat as
+    non-interactive, instead of aborting the command.
+    """
 
     def isatty(self) -> bool:
         return sys.stdin.isatty()
@@ -12,11 +20,14 @@ class ConsoleIO:
     def prompt_secret(self, prompt: str) -> str:
         import getpass
 
-        with open("/dev/tty", "r+", encoding="utf-8") as tty:
+        with open("/dev/tty", "w", encoding="utf-8") as tty:
             return getpass.getpass(prompt, stream=tty)
 
     def confirm(self, prompt: str) -> bool:
-        with open("/dev/tty", "r+", encoding="utf-8") as tty:
-            tty.write(prompt)
-            tty.flush()
-            return tty.readline().strip().lower() in {"y", "yes"}
+        with (
+            open("/dev/tty", "w", encoding="utf-8") as writer,
+            open("/dev/tty", "r", encoding="utf-8") as reader,
+        ):
+            writer.write(prompt)
+            writer.flush()
+            return reader.readline().strip().lower() in {"y", "yes"}

--- a/src/nextlabs_sdk/_auth/_token_cache/_interactive_passphrase_source.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_interactive_passphrase_source.py
@@ -15,7 +15,10 @@ class InteractivePassphraseSource:
     key-encryption key. A non-interactive input stream reports unavailable
     without reading, so the resolver falls through to the next source instead of
     blocking on a prompt that can never be answered. An empty entry is also
-    treated as unavailable, deferring to the plaintext confirmation gate.
+    treated as unavailable, deferring to the plaintext confirmation gate. An
+    ``isatty()``-true terminal whose I/O raises ``OSError`` (such as a
+    non-seekable ``/dev/tty``) is likewise reported unavailable rather than
+    letting the error escape.
     """
 
     source_label = "tty"
@@ -26,7 +29,10 @@ class InteractivePassphraseSource:
     def resolve(self, env: Mapping[str, str]) -> PassphraseKek | None:
         if not self._console.isatty():
             return None
-        passphrase = self._console.prompt_secret(_PROMPT)
+        try:
+            passphrase = self._console.prompt_secret(_PROMPT)
+        except OSError:
+            return None
         if not passphrase:
             return None
         return PassphraseKek(passphrase=passphrase.encode("utf-8"))

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,4 +1,5 @@
 import base64
+import io
 
 import keyring
 import pytest
@@ -207,3 +208,27 @@ class TestInteractiveTokenCache:
         )
         # then the decision is read through the controlling terminal, not stdin
         verify(console, times=1).confirm(ANY)
+
+    def test_unusable_tty_degrades_to_plaintext_and_loads_legacy(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # given no source, an unavailable keyring, an isatty-true terminal whose
+        # I/O raises io.UnsupportedOperation, and a legacy plaintext tokens.json
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenRaise(
+            io.UnsupportedOperation("File or stream is not seekable.")
+        )
+        when(console).confirm(ANY).thenRaise(
+            io.UnsupportedOperation("File or stream is not seekable.")
+        )
+        path = tmp_path / "tokens.json"
+        FileTokenCache(path=path).save("a", _tok())
+        # when a cache is built on the unusable controlling terminal
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then it degrades to plaintext without aborting and the legacy token loads
+        assert isinstance(cache, FileTokenCache)
+        assert cache.load("a") == _tok()
+        assert "UNENCRYPTED" in capsys.readouterr().err

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -232,3 +232,28 @@ class TestInteractiveTokenCache:
         assert isinstance(cache, FileTokenCache)
         assert cache.load("a") == _tok()
         assert "UNENCRYPTED" in capsys.readouterr().err
+
+    def test_unusable_tty_then_non_tty_warns_about_plaintext_only_once(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # given a process whose first build hits an unusable controlling terminal
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        unusable = mock()
+        when(unusable).isatty().thenReturn(True)
+        when(unusable).prompt_secret(ANY).thenRaise(
+            io.UnsupportedOperation("File or stream is not seekable.")
+        )
+        when(unusable).confirm(ANY).thenRaise(
+            io.UnsupportedOperation("File or stream is not seekable.")
+        )
+        cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=unusable
+        )
+        # and a later build in the same process sees a plain non-interactive console
+        plain = mock()
+        when(plain).isatty().thenReturn(False)
+        # when the second build completes
+        cache_factory.build_token_cache(path=tmp_path / "t.json", env={}, console=plain)
+        # then the user was warned about unencrypted storage only once
+        assert capsys.readouterr().err.count("UNENCRYPTED") == 1

--- a/tests/test_passphrase_sources.py
+++ b/tests/test_passphrase_sources.py
@@ -1,4 +1,5 @@
 import base64
+import io
 
 import keyring
 from keyring.errors import KeyringLocked, NoKeyringError
@@ -157,6 +158,19 @@ class TestInteractivePassphraseSource:
         # when the source is resolved
         # then an empty entry yields no material so the resolver falls through
         assert InteractivePassphraseSource(console).resolve({}) is None
+
+    def test_unusable_tty_reports_unavailable_without_escaping(self):
+        # given an isatty-true console whose secret prompt raises on a
+        # non-seekable controlling terminal
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenRaise(
+            io.UnsupportedOperation("File or stream is not seekable.")
+        )
+        # when the source is resolved
+        result = InteractivePassphraseSource(console).resolve({})
+        # then the terminal is treated as unavailable and the error never escapes
+        assert result is None
 
     def test_resolver_returns_tty_label_for_interactive_source(self):
         # given no env secret and an interactive terminal supplying a passphrase


### PR DESCRIPTION
Closes #270

## Summary
- Open the controlling terminal (`/dev/tty`) with separate read/write handles instead of an `"r+"` `BufferedRandom`, whose flush requires seek support that a non-seekable `/dev/tty` (devcontainers, some CI shells) does not provide.
- Treat an unusable controlling terminal — `isatty()` true but I/O raising `OSError`/`io.UnsupportedOperation` — as non-interactive: `InteractivePassphraseSource.resolve` reports unavailable and `_confirm_plaintext_or_abort` degrades to the plaintext `FileTokenCache`, so legacy plaintext `tokens.json` keeps loading instead of the CLI aborting with `Unexpected error: File or stream is not seekable.`
- Verified with two new regression tests plus the full unit suite (2574 passed, 95.90% coverage); public API, cache format, encrypted path, and usable-TTY behavior are unchanged.

## Tests added (red → green)
- `tests/test_passphrase_sources.py::TestInteractivePassphraseSource::test_unusable_tty_reports_unavailable_without_escaping`
- `tests/test_cache_factory.py::TestInteractiveTokenCache::test_unusable_tty_degrades_to_plaintext_and_loads_legacy`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash (`File or stream is not seekable`) on non-seekable `/dev/tty` (devcontainers, some CI shells) by switching from a single `"r+"` `BufferedRandom` handle to separate `"w"` and `"r"` handles in `ConsoleIO`, and by catching `OSError` in both `InteractivePassphraseSource.resolve` and `_confirm_plaintext_or_abort` to degrade gracefully to a plaintext `FileTokenCache` instead of aborting.

- `_console_io.py`: `confirm` now opens two separate handles (`"w"` + `"r"`); `prompt_secret` drops to `"w"` only since `getpass` opens its own read handle internally.
- `_interactive_passphrase_source.py` and `_cache_factory.py`: `OSError` (including `io.UnsupportedOperation`) from TTY I/O is swallowed and treated as "terminal unavailable", falling through to the existing plaintext path.
- Two regression tests confirm the red-to-green fix for both the passphrase source and the full cache-factory path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly targets the seekability issue and the degradation path works end-to-end as verified by the new tests.

The core change — separate "w"/"r" handles instead of a single "r+" BufferedRandom — cleanly eliminates the seek requirement. The OSError catch sites are minimal and well-placed. The one gap is that the degraded-TTY branch in _confirm_plaintext_or_abort doesn't set _WARNED, so a subsequent non-TTY call in the same process would fire _PLAINTEXT_WARNING on top of the already-printed _CONFIRM_WARNING; in practice this requires an unlikely same-process sequence, but the deduplication inconsistency is real.

_cache_factory.py — specifically the OSError branch in _confirm_plaintext_or_abort and its interaction with the _WARNED flag.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_auth/_token_cache/_console_io.py | Switches to separate "w"/"r" handles, eliminating the seek requirement that caused the crash; getpass only uses the stream for writing the prompt, so "w"-only is correct. |
| src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py | OSError degradation path skips _warn_plaintext_once, so _WARNED is never set; a subsequent non-TTY build_token_cache call in the same process would also print _PLAINTEXT_WARNING, producing two distinct warnings for the same plaintext decision. |
| src/nextlabs_sdk/_auth/_token_cache/_interactive_passphrase_source.py | OSError catch around prompt_secret is minimal and correct; correctly returns None so the resolver falls through. |
| tests/test_cache_factory.py | New regression test covers the full degradation path end-to-end (unusable TTY → plaintext FileTokenCache → legacy token loads); assertion on "UNENCRYPTED" in stderr is correct since _CONFIRM_WARNING is printed before the try block. |
| tests/test_passphrase_sources.py | New unit test for InteractivePassphraseSource correctly simulates the non-seekable TTY scenario and verifies None is returned without propagating the error. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as build_token_cache
    participant IPS as InteractivePassphraseSource
    participant CON as ConsoleIO
    participant CF as _confirm_plaintext_or_abort

    C->>IPS: resolve(env)
    IPS->>CON: isatty()
    CON-->>IPS: True
    IPS->>CON: prompt_secret(prompt)
    alt Non-seekable /dev/tty
        CON-->>IPS: OSError (io.UnsupportedOperation)
        IPS-->>C: None (unavailable)
        C->>CF: _confirm_plaintext_or_abort(console, path)
        CF->>CON: confirm(prompt)
        CON-->>CF: OSError (io.UnsupportedOperation)
        CF-->>C: FileTokenCache (plaintext)
    else Seekable /dev/tty
        CON-->>IPS: passphrase str
        IPS-->>C: PassphraseKek
        C-->>C: EncryptedFileTokenCache
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as build_token_cache
    participant IPS as InteractivePassphraseSource
    participant CON as ConsoleIO
    participant CF as _confirm_plaintext_or_abort

    C->>IPS: resolve(env)
    IPS->>CON: isatty()
    CON-->>IPS: True
    IPS->>CON: prompt_secret(prompt)
    alt Non-seekable /dev/tty
        CON-->>IPS: OSError (io.UnsupportedOperation)
        IPS-->>C: None (unavailable)
        C->>CF: _confirm_plaintext_or_abort(console, path)
        CF->>CON: confirm(prompt)
        CON-->>CF: OSError (io.UnsupportedOperation)
        CF-->>C: FileTokenCache (plaintext)
    else Seekable /dev/tty
        CON-->>IPS: passphrase str
        IPS-->>C: PassphraseKek
        C-->>C: EncryptedFileTokenCache
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%3A92-95%0A**Degraded-TTY%20path%20leaves%20%60_WARNED%60%20unset**%0A%0AWhen%20the%20%60OSError%60%20branch%20returns%20%60FileTokenCache%60%2C%20%60_warn_plaintext_once%60%20is%20never%20called%2C%20so%20%60_WARNED%60%20remains%20%60False%60.%20If%20%60build_token_cache%60%20is%20later%20called%20again%20in%20the%20same%20process%20with%20an%20%60isatty%28%29%60-false%20console%20%28e.g.%20a%20health-check%20loop%20after%20the%20TTY%20situation%20changed%29%2C%20it%20will%20additionally%20print%20%60_PLAINTEXT_WARNING%60%20%E2%80%94%20meaning%20the%20user%20could%20see%20two%20separate%20%22UNENCRYPTED%22%20warnings%20from%20a%20single%20underlying%20cache%20decision.%20The%20non-TTY%20path%20already%20has%20this%20deduplication%3B%20the%20degraded-TTY%20path%20bypasses%20it.%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(token-cache): degrade to plaintext o..."](https://github.com/stevenengland/nextlabs_rest_api/commit/dbf53ebf81f96a6176d4ca0fdc0e35db283a1e11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40800698)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->