### PR TITLE
feat(policy-diff): expand added/removed obligation content in semantic diff

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -22,6 +22,7 @@ _KIND_ADD: Literal["add"] = "add"
 _KIND_REMOVE: Literal["remove"] = "remove"
 _KIND_CHANGE: Literal["change"] = "change"
 _UNKNOWN_LABEL: str = "?"
+_OBLIGATION_HEADER_FIELDS: frozenset[str] = frozenset(("id", "name"))
 
 _NOISE_FIELDS: frozenset[str] = frozenset(
     (
@@ -248,6 +249,9 @@ def _diff_obligation_field(
                     new=None,
                 )
             )
+            _expand_obligation(
+                old_obl, path=path + (label,), kind=_KIND_REMOVE, changes=changes
+            )
         else:
             changes.append(
                 FieldChange(
@@ -257,6 +261,49 @@ def _diff_obligation_field(
                     new=ObligationSummary(name=label),
                 )
             )
+            _expand_obligation(
+                new_obl, path=path + (label,), kind=_KIND_ADD, changes=changes
+            )
+
+
+def _expand_obligation(
+    obligation: Mapping[str, object] | None,
+    *,
+    path: tuple[str, ...],
+    kind: Literal["add", "remove"],
+    changes: list[FieldChange],
+) -> None:
+    """Emit a field-line change per leaf of an added/removed obligation payload.
+
+    The obligation's header fields (its ``name`` and the always-null ``id``)
+    are skipped because the name is already shown on the summary header; every
+    remaining field, including each nested ``params`` entry, is flattened to a
+    leaf change so the renderer prints it as a ``+``/``-`` field-line nested
+    under that header.
+    """
+    if obligation is None:
+        return
+    for key, child in obligation.items():
+        if key in _OBLIGATION_HEADER_FIELDS:
+            continue
+        _expand_obligation_value(child, path=path + (key,), kind=kind, changes=changes)
+
+
+def _expand_obligation_value(
+    value: object,  # noqa: WPS110
+    *,
+    path: tuple[str, ...],
+    kind: Literal["add", "remove"],
+    changes: list[FieldChange],
+) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            _expand_obligation_value(
+                child, path=path + (key,), kind=kind, changes=changes
+            )
+        return
+    old, new = (value, None) if kind == _KIND_REMOVE else (None, value)
+    changes.append(FieldChange(path=path, kind=kind, old=old, new=new))
 
 
 def _obligation_label(obligation: Mapping[str, object] | None) -> str:

--- a/tests/_policy_diff_helpers.py
+++ b/tests/_policy_diff_helpers.py
@@ -113,15 +113,16 @@ def obligation(name: str, params: dict[str, str]) -> dict[str, Any]:
 
 
 def revision_with_obligations(
-    number: int, obligations: list[dict[str, Any]]
+    number: int, obligations: list[dict[str, Any]], *, deny: bool = False
 ) -> PolicyRevision:
+    field = "denyObligations" if deny else "allowObligations"
     policy = Policy.model_validate(
         {
             "id": 82,
             "name": "P",
             "status": "DRAFT",
             "effectType": "ALLOW",
-            "allowObligations": obligations,
+            field: obligations,
         }
     )
     return PolicyRevision(

--- a/tests/test_cli_policy_diff_report.py
+++ b/tests/test_cli_policy_diff_report.py
@@ -269,3 +269,106 @@ def test_both_shared_name_obligations_report_changed_params(
     output = strip_ansi(result.output)
     assert "ssn_hash" in output
     assert "dob_hash" in output
+
+
+def test_added_obligation_renders_expanded_content(stub: tuple[Any, Any]) -> None:
+    """Given two revisions where an obligation is added, when running diff, then
+    its params and policyModelId render as nested field-lines under the added
+    summary header, not just the name."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(revision_with_obligations(2, []))
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(
+            3, [obligation("data_masking", {"col": "ssn", "region": "eu"})]
+        )
+    )
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "allowObligations: data_masking" in output
+    assert "params.col" in output and "ssn" in output
+    assert "region" in output and "eu" in output
+    assert "policyModelId" in output
+
+
+def test_removed_obligation_renders_expanded_content(stub: tuple[Any, Any]) -> None:
+    """Given two revisions where an obligation is removed, when running diff,
+    then its params render as nested remove field-lines under the removed
+    summary header."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_obligations(2, [obligation("data_masking", {"col": "ssn"})])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(revision_with_obligations(3, []))
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "allowObligations: data_masking" in output
+    assert "params.col" in output and "ssn" in output
+
+
+def test_added_obligations_render_each_param_shape(stub: tuple[Any, Any]) -> None:
+    """Given two revisions adding a data_masking and an enforce_table_list
+    obligation, when running diff, then the distinct param fields of each shape
+    are rendered."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(revision_with_obligations(2, []))
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(
+            3,
+            [
+                obligation("data_masking", {"mask_fields": "ssn,dob"}),
+                obligation("enforce_table_list", {"tables": "orders,users"}),
+            ],
+        )
+    )
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "params.mask_fields" in output and "ssn,dob" in output
+    assert "params.tables" in output and "orders,users" in output
+
+
+def test_added_deny_obligation_expands_like_allow(stub: tuple[Any, Any]) -> None:
+    """Given two revisions where a denyObligations entry is added, when running
+    diff, then its content expands identically to an allowObligations add."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_obligations(2, [], deny=True)
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(
+            3, [obligation("data_masking", {"col": "ssn"})], deny=True
+        )
+    )
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "denyObligations: data_masking" in output
+    assert "params.col" in output and "ssn" in output
+
+
+def test_unified_added_obligation_keeps_json_body_unchanged(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions where an obligation is added, when running diff with
+    --format unified, then the obligation is rendered in the JSON body and the
+    semantic dotted field-line style does not leak into the unified output."""
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(revision_with_obligations(2, []))
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(3, [obligation("data_masking", {"col": "ssn"})])
+    )
+    result = runner.invoke(
+        app, [*GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    assert result.exit_code == 0
+    output = strip_ansi(result.output)
+    assert "@@" in output
+    assert '"name": "data_masking"' in output
+    assert "allowObligations.data_masking" not in output

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -242,3 +242,143 @@ def test_cross_policy_show_all_reveals_identity_fields():
     result = diff_payloads(old, new, cross_policy=True, show_all=True)
 
     assert any(c.path == ("name",) for c in result.changes)
+
+
+from nextlabs_sdk._cli._diff._identity import ObligationSummary
+
+
+def test_added_obligation_expands_payload_field_lines():
+    """Given a payload that adds an obligation carrying params and policyModelId.
+
+    When diffing without show_all.
+    Then a summary-header add is emitted plus per-field add lines for the
+    obligation's policyModelId and each params entry, nested under the
+    obligation's name.
+    """
+    # given
+    old = {"name": "P", "allowObligations": []}
+    new = {
+        "name": "P",
+        "allowObligations": [
+            {
+                "id": None,
+                "policyModelId": 7,
+                "name": "data_masking",
+                "params": {"col": "ssn"},
+            }
+        ],
+    }
+    # when
+    result = diff_payloads(old, new)
+    obl = [c for c in result.changes if c.path and c.path[0] == "allowObligations"]
+    # then
+    assert any(
+        c.kind == "add"
+        and c.path == ("allowObligations",)
+        and isinstance(c.new, ObligationSummary)
+        for c in obl
+    )
+    assert any(
+        c.kind == "add"
+        and c.path == ("allowObligations", "data_masking", "policyModelId")
+        and c.new == 7
+        for c in obl
+    )
+    assert any(
+        c.kind == "add"
+        and c.path == ("allowObligations", "data_masking", "params", "col")
+        and c.new == "ssn"
+        for c in obl
+    )
+
+
+def test_removed_obligation_expands_payload_field_lines():
+    """Given a payload that removes an obligation carrying params.
+
+    When diffing without show_all.
+    Then a summary-header remove is emitted plus per-field remove lines carrying
+    the removed obligation's params under its name.
+    """
+    # given
+    old = {
+        "name": "P",
+        "allowObligations": [
+            {
+                "id": None,
+                "policyModelId": 0,
+                "name": "data_masking",
+                "params": {"col": "ssn"},
+            }
+        ],
+    }
+    new = {"name": "P", "allowObligations": []}
+    # when
+    result = diff_payloads(old, new)
+    obl = [c for c in result.changes if c.path and c.path[0] == "allowObligations"]
+    # then
+    assert any(
+        c.kind == "remove"
+        and c.path == ("allowObligations",)
+        and isinstance(c.old, ObligationSummary)
+        for c in obl
+    )
+    assert any(
+        c.kind == "remove"
+        and c.path == ("allowObligations", "data_masking", "params", "col")
+        and c.old == "ssn"
+        for c in obl
+    )
+
+
+def test_noise_field_inside_added_obligation_is_hidden_by_default():
+    """Given an added obligation whose payload carries a deployment-noise field.
+
+    When diffing without show_all.
+    Then the noise field surfaces in no visible change and is counted as hidden.
+    """
+    # given
+    old = {"name": "P", "allowObligations": []}
+    new = {
+        "name": "P",
+        "allowObligations": [
+            {
+                "id": None,
+                "policyModelId": 0,
+                "name": "data_masking",
+                "params": {"col": "ssn"},
+                "lastUpdatedDate": 123,
+            }
+        ],
+    }
+    # when
+    result = diff_payloads(old, new)
+    # then
+    assert not any(c.path and c.path[-1] == "lastUpdatedDate" for c in result.changes)
+    assert result.hidden_noise_count == 1
+
+
+def test_noise_field_inside_added_obligation_is_revealed_with_show_all():
+    """Given an added obligation whose payload carries a deployment-noise field.
+
+    When diffing with show_all.
+    Then the noise field's value is no longer suppressed.
+    """
+    # given
+    old = {"name": "P", "allowObligations": []}
+    new = {
+        "name": "P",
+        "allowObligations": [
+            {
+                "id": None,
+                "policyModelId": 0,
+                "name": "data_masking",
+                "params": {"col": "ssn"},
+                "lastUpdatedDate": 123,
+            }
+        ],
+    }
+    # when
+    result = diff_payloads(old, new, show_all=True)
+    # then
+    assert result.hidden_noise_count == 0
+    assert any("lastUpdatedDate" in repr(c.new) for c in result.changes)

--- a/tests/test_policy_diff_identity.py
+++ b/tests/test_policy_diff_identity.py
@@ -287,17 +287,19 @@ def test_added_and_removed_obligations_are_reported():
     """Given one obligation replaced by a differently-named obligation.
 
     When diffing the two payloads.
-    Then one add and one remove are produced, each carrying the name.
+    Then one add and one remove summary header are produced, each carrying the
+    name (the expanded content lines nest beneath them).
     """
     old = {"denyObligations": [_obl("log", {"level": "info"})]}
     new = {"denyObligations": [_obl("alert", {"channel": "ops"})]}
 
     changes = _obligation_changes(diff_payloads(old, new), "denyObligations")
-    kinds = sorted(change.kind for change in changes)
+    headers = [change for change in changes if change.path == ("denyObligations",)]
+    kinds = sorted(change.kind for change in headers)
 
     assert kinds == ["add", "remove"]
-    added = next(change for change in changes if change.kind == "add")
-    removed = next(change for change in changes if change.kind == "remove")
+    added = next(change for change in headers if change.kind == "add")
+    removed = next(change for change in headers if change.kind == "remove")
     assert added.new == ObligationSummary(name="alert")
     assert removed.old == ObligationSummary(name="log")
 
@@ -306,7 +308,8 @@ def test_extra_obligation_in_colliding_group_is_reported_as_added():
     """Given a colliding-name group that gains an extra obligation.
 
     When diffing the two payloads.
-    Then the unpaired obligation is reported as added, not a change.
+    Then the unpaired obligation's summary header is reported as added, not a
+    change.
     """
     old = {"allowObligations": [_obl("data_masking", {"col": "a"})]}
     new = {
@@ -317,9 +320,10 @@ def test_extra_obligation_in_colliding_group_is_reported_as_added():
     }
 
     changes = _obligation_changes(diff_payloads(old, new), "allowObligations")
+    headers = [change for change in changes if change.path == ("allowObligations",)]
 
-    assert [change.kind for change in changes] == ["add"]
-    assert changes[0].new == ObligationSummary(name="data_masking")
+    assert [change.kind for change in headers] == ["add"]
+    assert headers[0].new == ObligationSummary(name="data_masking")
 
 
 def test_tag_identity_key_prefers_key_then_label():


### PR DESCRIPTION
Closes #265

## Summary
- In the semantic `policies diff` view, an added or removed obligation now carries its full payload through the engine: its `policyModelId` and each `params.*` entry render as `+`/`-` field-lines nested under the existing summary header, instead of discarding everything but the name.
- Verified with new engine-level tests (payload retained on add/remove, noise gating) and CLI render tests (add/remove expansion, both param shapes, deny parity, unified unchanged); full unit suite green at 95.95% coverage.
- Trade-off: obligation `id` (always null) and `name` (already on the header) are excluded from the expanded lines; noise-field gating inside obligations is covered at the engine level since the Pydantic `PolicyObligation` model drops unknown keys before they reach the renderer.

## Tests added (red → green)
- `test_added_obligation_expands_payload_field_lines`
- `test_removed_obligation_expands_payload_field_lines`
- `test_noise_field_inside_added_obligation_is_hidden_by_default`
- `test_noise_field_inside_added_obligation_is_revealed_with_show_all`
- `test_added_obligation_renders_expanded_content`
- `test_removed_obligation_renders_expanded_content`
- `test_added_obligations_render_each_param_shape`
- `test_added_deny_obligation_expands_like_allow`
- `test_unified_added_obligation_keeps_json_body_unchanged`

## Notable assumptions
- Enhancement #2 (the `[old → new]` count marker) is out of scope for this slice — its acceptance criteria live in a sibling slice; only obligation content expansion (enhancement #1) is implemented here.
- Two existing identity tests were rewritten to assert on the summary-header change rather than the full change-kind list, since the slice intentionally adds nested field-line changes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the semantic `policies diff` engine so that when an obligation is added or removed, its full payload (every `params.*` entry and `policyModelId`) is emitted as `+`/`-` field-lines nested under the existing summary header, rather than discarding all content but the name.

- Adds `_expand_obligation` / `_expand_obligation_value` helpers that recursively flatten an obligation's non-header fields into individual `FieldChange` entries; noise-field gating for obligation-internal fields is handled by the same end-of-pass filter already in `diff_payloads`.
- Updates two existing identity tests to assert only on the summary-header changes (since the slice now also produces nested field-line changes) and adds nine new engine + CLI render tests covering add/remove expansion, both param shapes, deny parity, and unified-format isolation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is well-scoped and the logic is straightforward; the two style issues (a noqa suppression and a mid-file import) do not affect runtime behavior.

The expansion logic correctly recurses through obligation payloads, flattening nested Mappings into leaf FieldChanges, and the existing end-of-pass noise filter in diff_payloads naturally suppresses obligation-internal noise fields without any extra wiring. The new tests cover add, remove, both param shapes, deny parity, and unified-format isolation. The only findings are a noqa suppression that contradicts the project's stated rule and a mid-file import in the test file.

src/nextlabs_sdk/_cli/_diff/_engine.py (noqa suppression on the new helper) and tests/test_policy_diff_engine.py (mid-file import)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_diff/_engine.py | Adds _expand_obligation and _expand_obligation_value to emit leaf FieldChanges for added/removed obligation payloads; the new _expand_obligation_value carries a # noqa: WPS110 suppression that violates the project's no-noqa rule. |
| tests/test_policy_diff_engine.py | Nine new engine-level tests added; the required ObligationSummary import is placed mid-file rather than at the top with the existing imports. |
| tests/test_cli_policy_diff_report.py | Five new CLI render tests covering add/remove expansion, param shapes, deny parity, and unified-format isolation; straightforward and well-structured. |
| tests/_policy_diff_helpers.py | Adds deny=False keyword arg to revision_with_obligations to allow testing denyObligations; effectType stays ALLOW which is correct since the helper targets the diff engine, not effectType logic. |
| tests/test_policy_diff_identity.py | Two existing tests narrowed to check only summary-header changes; the rewrites correctly adapt to the new nested field-line behavior without weakening the intended assertions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_diff_obligation_field(old_obl, new_obl)"] --> B{Pairing result}
    B -->|both present| C["_diff_dicts(old_obl, new_obl)\nshow_all=False"]
    B -->|old only — removed| D["Emit ObligationSummary\nFieldChange kind=remove"]
    B -->|new only — added| E["Emit ObligationSummary\nFieldChange kind=add"]
    D --> F["_expand_obligation(old_obl, kind=remove) NEW"]
    E --> G["_expand_obligation(new_obl, kind=add) NEW"]
    F --> H["Skip id / name\nIterate remaining keys"]
    G --> H
    H --> I["_expand_obligation_value(child, ...)"]
    I -->|Mapping| J["Recurse into nested dict\ne.g. params.*"]
    I -->|Leaf| K["Emit FieldChange\npath=(..., obl_name, key)\nold/new = leaf value"]
    J --> I
    K --> L["diff_payloads noise filter\npath[-1] in _NOISE_FIELDS → hidden"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["_diff_obligation_field(old_obl, new_obl)"] --> B{Pairing result}
    B -->|both present| C["_diff_dicts(old_obl, new_obl)\nshow_all=False"]
    B -->|old only — removed| D["Emit ObligationSummary\nFieldChange kind=remove"]
    B -->|new only — added| E["Emit ObligationSummary\nFieldChange kind=add"]
    D --> F["_expand_obligation(old_obl, kind=remove) NEW"]
    E --> G["_expand_obligation(new_obl, kind=add) NEW"]
    F --> H["Skip id / name\nIterate remaining keys"]
    G --> H
    H --> I["_expand_obligation_value(child, ...)"]
    I -->|Mapping| J["Recurse into nested dict\ne.g. params.*"]
    I -->|Leaf| K["Emit FieldChange\npath=(..., obl_name, key)\nold/new = leaf value"]
    J --> I
    K --> L["diff_payloads noise filter\npath[-1] in _NOISE_FIELDS → hidden"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fnextlabs_sdk%2F_cli%2F_diff%2F_engine.py%3A292-305%0AThe%20%60%23%20noqa%3A%20WPS110%60%20suppression%20violates%20the%20project's%20explicit%20%22No%20%60noqa%60%20suppressions%22%20rule%20in%20CLAUDE.md.%20The%20parameter%20name%20%60value%60%20is%20what%20triggers%20WPS110%20%E2%80%94%20renaming%20it%20to%20something%20more%20specific%20%28e.g.%20%60field_value%60%29%20removes%20the%20need%20for%20the%20suppression%20entirely%2C%20consistent%20with%20how%20the%20codebase%20otherwise%20handles%20this%20rule.%0A%0A%60%60%60suggestion%0Adef%20_expand_obligation_value%28%0A%20%20%20%20field_value%3A%20object%2C%0A%20%20%20%20*%2C%0A%20%20%20%20path%3A%20tuple%5Bstr%2C%20...%5D%2C%0A%20%20%20%20kind%3A%20Literal%5B%22add%22%2C%20%22remove%22%5D%2C%0A%20%20%20%20changes%3A%20list%5BFieldChange%5D%2C%0A%29%20-%3E%20None%3A%0A%20%20%20%20if%20isinstance%28field_value%2C%20Mapping%29%3A%0A%20%20%20%20%20%20%20%20for%20key%2C%20child%20in%20field_value.items%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20_expand_obligation_value%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20child%2C%20path%3Dpath%20%2B%20%28key%2C%29%2C%20kind%3Dkind%2C%20changes%3Dchanges%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20return%0A%20%20%20%20old%2C%20new%20%3D%20%28field_value%2C%20None%29%20if%20kind%20%3D%3D%20_KIND_REMOVE%20else%20%28None%2C%20field_value%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Ftest_policy_diff_engine.py%3A247-250%0AThis%20import%20is%20inserted%20mid-file%20%28after%20the%20last%20existing%20test%20function%29%20rather%20than%20at%20the%20top%20with%20the%20other%20module-level%20imports.%20PEP%208%20and%20the%20project%20style%20both%20require%20all%20imports%20to%20be%20grouped%20at%20the%20top%20of%20the%20file%3B%20a%20mid-file%20import%20is%20invisible%20to%20readers%20scanning%20the%20header%20and%20can%20confuse%20static-analysis%20tools.%0A%0A%60%60%60suggestion%0Adef%20test_added_obligation_expands_payload_field_lines%28%29%3A%0A%60%60%60%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(policy-diff): expand added/removed ..."](https://github.com/stevenengland/nextlabs_rest_api/commit/23d3d47a1242d805dcc7390f84ecace443146fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40810195)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->