### PR TITLE
feat(diff): element-count marker on list-typed field headers

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -12,10 +12,11 @@ from nextlabs_sdk._cli._diff._identity import (
     OBLIGATION_FIELDS,
     TAG_FIELDS,
     ObligationSummary,
+    flatten_slot,
     pair_obligations,
 )
 from nextlabs_sdk._cli._diff._identity import TagSummary, pair_tags
-from nextlabs_sdk._cli._diff._models import DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._models import CountMarker, DiffResult, FieldChange
 from nextlabs_sdk._cli._diff._slot import compare_slot
 
 _KIND_ADD: Literal["add"] = "add"
@@ -139,7 +140,40 @@ def diff_payloads(
     return DiffResult(
         changes=tuple(visible_changes),
         hidden_noise_count=hidden_noise_count,
+        count_markers=tuple(_collect_count_markers(old, new)),
     )
+
+
+def _collect_count_markers(
+    old: Mapping[str, object], new: Mapping[str, object]
+) -> list[CountMarker]:
+    """Record old/new element counts for top-level list fields that changed size.
+
+    Obligations, tags and generic arrays count their list elements directly;
+    component slots count their flattened members so a component added within an
+    existing group is recognised even though the group list itself is unchanged.
+    A marker is emitted only when the two counts differ.
+    """
+    markers: list[CountMarker] = []
+    for key in old.keys() | new.keys():
+        old_value = old.get(key)
+        new_value = new.get(key)
+        if not isinstance(old_value, list) and not isinstance(new_value, list):
+            continue
+        old_count, new_count = _element_counts(key, old_value, new_value)
+        if old_count != new_count:
+            markers.append(
+                CountMarker(path=(key,), old_count=old_count, new_count=new_count)
+            )
+    return markers
+
+
+def _element_counts(key: str, old_value: object, new_value: object) -> tuple[int, int]:
+    if key in COMPONENT_SLOT_FIELDS:
+        return len(flatten_slot(old_value)), len(flatten_slot(new_value))
+    old_count = len(old_value) if isinstance(old_value, list) else 0
+    new_count = len(new_value) if isinstance(new_value, list) else 0
+    return old_count, new_count
 
 
 def _strip_identity_fields(payload: Mapping[str, object]) -> dict[str, object]:

--- a/src/nextlabs_sdk/_cli/_diff/_models.py
+++ b/src/nextlabs_sdk/_cli/_diff/_models.py
@@ -17,11 +17,26 @@ class FieldChange:
 
 
 @dataclass(frozen=True)
+class CountMarker:
+    """Old and new element counts for a list-typed field whose length changed.
+
+    Carried alongside the changes so the semantic renderer can annotate the
+    field's header with an ``[old → new]`` marker. Only emitted when the counts
+    actually differ.
+    """
+
+    path: tuple[str, ...]
+    old_count: int
+    new_count: int
+
+
+@dataclass(frozen=True)
 class DiffResult:
     """The structured result of comparing two policy payloads."""
 
     changes: tuple[FieldChange, ...]
     hidden_noise_count: int
+    count_markers: tuple[CountMarker, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
+++ b/src/nextlabs_sdk/_cli/_diff/_render_semantic.py
@@ -10,7 +10,12 @@ from nextlabs_sdk._cli._diff._identity import (
     TagSummary,
 )
 from nextlabs_sdk._cli._diff._inline import highlight_pair
-from nextlabs_sdk._cli._diff._models import DiffHeader, DiffResult, FieldChange
+from nextlabs_sdk._cli._diff._models import (
+    CountMarker,
+    DiffHeader,
+    DiffResult,
+    FieldChange,
+)
 
 _GLYPH_ADD = "[green]+[/green]"
 _GLYPH_REMOVE = "[red]-[/red]"
@@ -187,6 +192,22 @@ def _render_typed_change(con: Console, field: str, change: FieldChange) -> None:
         _render_scalar_change(con, field, change)
 
 
+def _markers_by_section(markers: tuple[CountMarker, ...]) -> dict[str, CountMarker]:
+    """Index single-segment count markers by their field name for header lookup."""
+    indexed: dict[str, CountMarker] = {}
+    for marker in markers:
+        if len(marker.path) == 1:
+            indexed[marker.path[0]] = marker
+    return indexed
+
+
+def _count_suffix(marker: CountMarker | None) -> str:
+    """Render the ``[old → new]`` header suffix for a changed-count field."""
+    if marker is None:
+        return ""
+    return f" \\[{marker.old_count} {_ARROW} {marker.new_count}]"
+
+
 def render_semantic(
     diff: DiffResult,
     header: DiffHeader,
@@ -215,8 +236,9 @@ def render_semantic(
     for change in diff.changes:
         sections.setdefault(change.path[0], []).append(change)
 
+    markers = _markers_by_section(diff.count_markers)
     for section, changes in sections.items():
-        con.print(f"\n[bold]{section}[/bold]")
+        con.print(f"\n[bold]{section}[/bold]{_count_suffix(markers.get(section))}")
         for change in changes:
             field = ".".join(str(segment) for segment in change.path)
             _render_change(con, field, change)

--- a/tests/test_cli_policy_diff_elements.py
+++ b/tests/test_cli_policy_diff_elements.py
@@ -16,8 +16,11 @@ from tests._policy_diff_helpers import (
     entry,
     grouped,
     make_stub,
+    obligation,
     revision,
+    revision_with_obligations,
     revision_with_subject_groups,
+    revision_with_subjects,
     revision_with_tags,
     runner,
 )
@@ -265,3 +268,183 @@ def test_diff_unified_ignores_cosmetic_operator_change_matching_semantic(
     output = strip_ansi(result.output)
     assert "operator" not in output
     assert "grouping" not in output
+
+
+def _revision_with_attributes(number: int, attributes: list[str]) -> Any:
+    policy = Policy.model_validate(
+        {
+            "id": 82,
+            "name": "P",
+            "status": "DRAFT",
+            "effectType": "ALLOW",
+            "attributes": attributes,
+        }
+    )
+    return PolicyRevision(
+        id=10, revision=number, action_type="DE", policy_detail=policy
+    )
+
+
+def test_obligation_count_change_annotates_header_with_marker(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose allow-obligation list shrinks from two to one,
+    when running diff, then the obligation field header carries an [2 → 1]
+    count marker."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_obligations(
+            2, [obligation("a", {"p": "1"}), obligation("b", {"p": "2"})]
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(3, [obligation("a", {"p": "1"})])
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "allowObligations" in output
+    assert "[2 → 1]" in output
+
+
+def test_tag_count_change_annotates_header_with_marker(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose tag list grows from one to two, when running
+    diff, then the tags field header carries an [1 → 2] count marker."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_tags(2, [Tag(id=1, key="a", label="A")])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_tags(
+            3, [Tag(id=1, key="a", label="A"), Tag(id=2, key="b", label="B")]
+        )
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "[1 → 2]" in output
+
+
+def test_equal_count_tag_swap_shows_no_marker(stub: tuple[Any, Any]) -> None:
+    """Given two revisions whose two-tag list swaps one tag for another, when
+    running diff, then no count marker is shown because the count is unchanged."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_tags(
+            2, [Tag(id=1, key="a", label="A"), Tag(id=2, key="b", label="B")]
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_tags(
+            3, [Tag(id=1, key="a", label="A"), Tag(id=3, key="c", label="C")]
+        )
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "[2 → 2]" not in output
+
+
+def test_component_count_change_annotates_header_with_marker(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose subject slot grows from one component to two,
+    when running diff, then the slot header carries an [1 → 2] count marker."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_subjects(2, [component(5, "Engineers")])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_subjects(3, [component(5, "Engineers"), component(6, "Ops")])
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "[1 → 2]" in output
+
+
+def test_equal_count_component_swap_shows_no_marker(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose single-component slot swaps one component for
+    another, when running diff, then no count marker is shown."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_subjects(2, [component(5, "Engineers")])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_subjects(3, [component(7, "Auditors")])
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "[1 → 1]" not in output
+
+
+def test_generic_array_count_change_annotates_header_with_marker(
+    stub: tuple[Any, Any],
+) -> None:
+    """Given two revisions whose generic ``attributes`` array grows from one to
+    three, when running diff, then its header carries an [1 → 3] count marker."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        _revision_with_attributes(2, ["a"])
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        _revision_with_attributes(3, ["a", "b", "c"])
+    )
+    # when
+    result = runner.invoke(app, [*GLOBAL_OPTS, "policies", "diff", "10"])
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "[1 → 3]" in output
+
+
+def test_count_marker_absent_in_unified_format(stub: tuple[Any, Any]) -> None:
+    """Given an obligation count change, when running diff with --format
+    unified, then no semantic count marker leaks into the unified output."""
+    # given
+    _, mock_policies = stub
+    when(mock_policies).list_history(10).thenReturn([entry(2), entry(3)])
+    when(mock_policies).get_revision(10, 2).thenReturn(
+        revision_with_obligations(
+            2, [obligation("a", {"p": "1"}), obligation("b", {"p": "2"})]
+        )
+    )
+    when(mock_policies).get_revision(10, 3).thenReturn(
+        revision_with_obligations(3, [obligation("a", {"p": "1"})])
+    )
+    # when
+    result = runner.invoke(
+        app, [*GLOBAL_OPTS, "policies", "diff", "10", "--format", "unified"]
+    )
+    output = strip_ansi(result.output)
+    # then
+    assert result.exit_code == 0
+    assert "@@" in output
+    assert "[2 → 1]" not in output

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -382,3 +382,66 @@ def test_noise_field_inside_added_obligation_is_revealed_with_show_all():
     # then
     assert result.hidden_noise_count == 0
     assert any("lastUpdatedDate" in repr(c.new) for c in result.changes)
+
+
+def test_count_marker_retained_when_obligation_list_shrinks():
+    """Given two payloads whose allow-obligation list shrinks from one to zero.
+
+    When diffing.
+    Then a count marker records the old and new element counts for that field.
+    """
+    old = {"name": "P", "allowObligations": [{"id": None, "name": "a", "params": {}}]}
+    new = {"name": "P", "allowObligations": []}
+
+    result = diff_payloads(old, new)
+
+    markers = {
+        marker.path: (marker.old_count, marker.new_count)
+        for marker in result.count_markers
+    }
+    assert markers[("allowObligations",)] == (1, 0)
+
+
+def test_no_count_marker_when_list_length_unchanged():
+    """Given two payloads whose tag list swaps one element for another.
+
+    When diffing.
+    Then no count marker is produced for the tag field, because the length held.
+    """
+    old = {"name": "P", "tags": [{"key": "a"}, {"key": "b"}]}
+    new = {"name": "P", "tags": [{"key": "a"}, {"key": "c"}]}
+
+    result = diff_payloads(old, new)
+
+    assert all(marker.path != ("tags",) for marker in result.count_markers)
+
+
+def test_count_marker_for_component_slot_counts_members_not_groups():
+    """Given a component slot whose single group grows from one member to two.
+
+    When diffing.
+    Then the count marker reflects member count, not the number of groups.
+    """
+    old = {
+        "name": "P",
+        "subjectComponents": [
+            {"operator": "AND", "components": [{"id": 5, "name": "E"}]}
+        ],
+    }
+    new = {
+        "name": "P",
+        "subjectComponents": [
+            {
+                "operator": "AND",
+                "components": [{"id": 5, "name": "E"}, {"id": 6, "name": "O"}],
+            }
+        ],
+    }
+
+    result = diff_payloads(old, new)
+
+    markers = {
+        marker.path: (marker.old_count, marker.new_count)
+        for marker in result.count_markers
+    }
+    assert markers[("subjectComponents",)] == (1, 2)


### PR DESCRIPTION
Closes #266

## Summary
- In the semantic `policies diff` view, list-typed field headers now carry an `[old → new]` element-count marker, shown only when the count actually changes (obligations, tags, component slots, generic arrays).
- The diff model gained a `CountMarker` record and `DiffResult.count_markers`; the engine computes counts at diff time (component slots count flattened members, not groups). Verified by new engine + CLI tests and the full diff suite.
- `--format unified` and JSON output are untouched — count markers are render-time semantic metadata and are not serialised.

## Tests added (red → green)
- `test_count_marker_retained_when_obligation_list_shrinks`
- `test_no_count_marker_when_list_length_unchanged`
- `test_count_marker_for_component_slot_counts_members_not_groups`
- `test_obligation_count_change_annotates_header_with_marker`
- `test_tag_count_change_annotates_header_with_marker`
- `test_equal_count_tag_swap_shows_no_marker`
- `test_component_count_change_annotates_header_with_marker`
- `test_equal_count_component_swap_shows_no_marker`
- `test_generic_array_count_change_annotates_header_with_marker`
- `test_count_marker_absent_in_unified_format`

## Notable assumptions
- Component-slot counts use flattened member count, not the number of groups, so a component added inside an existing group still surfaces a marker (matches the per-element `+/-` lines the reader sees).
- The marker renders on the section header (`path[0]`), so only top-level list fields carry it — consistent with the PRD examples.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an `[old → new]` element-count marker to section headers in the semantic diff view for list-typed policy fields (obligations, tags, component slots, generic arrays). The marker is computed at diff time in the engine and carried as metadata on `DiffResult`, keeping it out of unified format and JSON output.

- **Engine changes** (`_engine.py`): New `_collect_count_markers` + `_element_counts` helpers compute per-field element counts on the raw payloads; component-slot counts use `flatten_slot` (unique members) rather than the group list length, consistent with the per-element `+/-` lines the reader sees.
- **Model changes** (`_models.py`): New frozen `CountMarker` dataclass and `count_markers` field on `DiffResult` (default `()`); `diff_result_to_dict` intentionally omits `count_markers`, so JSON output is unchanged.
- **Renderer changes** (`_render_semantic.py`): `_markers_by_section` indexes markers by field name; `_count_suffix` produces `\[old → new]` suffix with Rich-safe bracket escaping; count annotation is injected into section headers only.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive metadata only; unified format and JSON output are untouched, and the new code paths all have direct test coverage.

The count marker computation runs after any identity-field stripping and before changes are returned, keeping it consistent with the diff itself. `flatten_slot` handles absent fields gracefully via `_as_mappings`, so component-slot counts never raise when a slot key is missing from one side. Rich bracket escaping in `_count_suffix` is correct. No existing tests are broken and the ten new tests cover both the positive cases (marker appears, counts correct) and the negative cases (equal-count swap, unified format exclusion). The implementation is self-contained — `count_markers` defaults to `()` on `DiffResult`, so all existing call sites that construct `DiffResult` directly continue to compile without change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_diff/_engine.py | Adds _collect_count_markers and _element_counts; correctly delegates to flatten_slot for component slots and raw len() for other list fields; markers computed on stripped/unstripped payloads consistently with the diff itself. |
| src/nextlabs_sdk/_cli/_diff/_models.py | New CountMarker dataclass and count_markers field on DiffResult (defaulting to ()); diff_result_to_dict correctly omits count_markers, keeping JSON output unchanged. |
| src/nextlabs_sdk/_cli/_diff/_render_semantic.py | Adds _markers_by_section and _count_suffix; Rich bracket escaping in _count_suffix is correct; marker lookup is a safe dict.get with None fallback. |
| tests/test_policy_diff_engine.py | Three new engine-level tests covering obligation shrink, unchanged-length tag swap, and component-slot member vs. group counting; all are well-scoped unit tests. |
| tests/test_cli_policy_diff_elements.py | Seven new CLI-level integration tests covering obligations, tags, components, generic arrays, equal-count swaps, and unified-format exclusion; comprehensive coverage of the new feature's visible behaviour. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[diff_payloads called] --> B{cross_policy and not show_all?}
    B -- yes --> C[_strip_identity_fields on old and new]
    B -- no --> D[use payloads as-is]
    C --> E[_diff_dicts → FieldChange list]
    D --> E
    E --> F[filter noise → visible_changes]
    F --> G[_collect_count_markers on old / new]
    G --> H{for each key in old.keys OR new.keys}
    H --> I{is either value a list?}
    I -- no --> H
    I -- yes --> J{key in COMPONENT_SLOT_FIELDS?}
    J -- yes --> K[flatten_slot → unique member count]
    J -- no --> L[len of list or 0 if absent]
    K --> M{old_count != new_count?}
    L --> M
    M -- yes --> N[emit CountMarker with path and counts]
    M -- no --> H
    N --> H
    H --> O[DiffResult with changes + count_markers]
    O --> P[render_semantic called]
    P --> Q[build sections dict from diff.changes]
    P --> R[_markers_by_section → indexed dict]
    Q --> S[for each section in sections]
    R --> S
    S --> T[markers.get section → CountMarker or None]
    T --> U[_count_suffix produces backslash-escaped Rich markup]
    U --> V[con.print bold section header with suffix]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[diff_payloads called] --> B{cross_policy and not show_all?}
    B -- yes --> C[_strip_identity_fields on old and new]
    B -- no --> D[use payloads as-is]
    C --> E[_diff_dicts → FieldChange list]
    D --> E
    E --> F[filter noise → visible_changes]
    F --> G[_collect_count_markers on old / new]
    G --> H{for each key in old.keys OR new.keys}
    H --> I{is either value a list?}
    I -- no --> H
    I -- yes --> J{key in COMPONENT_SLOT_FIELDS?}
    J -- yes --> K[flatten_slot → unique member count]
    J -- no --> L[len of list or 0 if absent]
    K --> M{old_count != new_count?}
    L --> M
    M -- yes --> N[emit CountMarker with path and counts]
    M -- no --> H
    N --> H
    H --> O[DiffResult with changes + count_markers]
    O --> P[render_semantic called]
    P --> Q[build sections dict from diff.changes]
    P --> R[_markers_by_section → indexed dict]
    Q --> S[for each section in sections]
    R --> S
    S --> T[markers.get section → CountMarker or None]
    T --> U[_count_suffix produces backslash-escaped Rich markup]
    U --> V[con.print bold section header with suffix]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(diff): annotate list-field headers ..."](https://github.com/stevenengland/nextlabs_rest_api/commit/94a69a459dadcbc698119366150dbce7516b403d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40816316)</sub>

<!-- /greptile_comment -->