### PR TITLE
feat(token-cache): state-aware plaintext hints and lockout guard

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -42,6 +42,24 @@ _CONFIRM_WARNING = (
 )
 _CONFIRM_PROMPT = "Store the token cache unencrypted anyway? [y/N]: "
 
+_HINT_FRESH = (
+    "No token cache yet; it will be created at {path}. It can be encrypted at "
+    "rest, but no passphrase source is set (NEXTLABS_MASTER_PASSWORD or an OS "
+    "keyring). See the project's online documentation for details."
+)
+_HINT_LEGACY_PLAINTEXT = (
+    "Your existing token cache at {path} is UNENCRYPTED and may contain "
+    "access/refresh tokens in plain text. Set NEXTLABS_MASTER_PASSWORD or an OS "
+    "keyring to re-encrypt it on the next write. See the project's online "
+    "documentation for details."
+)
+_HINT_LOCKOUT = (
+    "Your token cache at {path} is ENCRYPTED but no passphrase source is "
+    "available to unlock it. Set the original NEXTLABS_MASTER_PASSWORD / "
+    "keyring, or delete {path} to start fresh. See the project's online "
+    "documentation for details."
+)
+
 _WARNED = False
 
 
@@ -76,18 +94,34 @@ def build_token_cache(
         return EncryptedFileTokenCache(path=cache_path, kek_source=material)
 
     if console.isatty():
-        return _confirm_plaintext_or_abort(console, cache_path)
+        return _confirm_plaintext_or_abort(console, cache_path, env)
 
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
 
 
-def _confirm_plaintext_or_abort(console: ConsoleIO, cache_path: Path) -> TokenCache:
+def _confirm_plaintext_or_abort(
+    console: ConsoleIO, cache_path: Path, env: Mapping[str, str]
+) -> TokenCache:
     """Gate plaintext storage behind a confirmation on the controlling terminal.
+
+    Emits a state-aware hint first: a first-time hint for an absent cache and a
+    plaintext-exposure hint for an existing unencrypted one, both falling
+    through to the confirm gate. An encrypted cache that no source can unlock is
+    a lockout: the hint is shown and the build aborts without touching the file,
+    so the encrypted tokens are never overwritten with plaintext.
 
     An unusable terminal cannot be prompted, so it degrades to plaintext rather
     than aborting, honouring the "encrypt when possible, never abort" policy.
     """
+    status = inspect_token_cache(path=cache_path, env=env)
+    if status.state == "encrypted":
+        console.message(_HINT_LOCKOUT.format(path=cache_path))
+        raise TokenCacheError()
+    if status.state == "absent":
+        console.message(_HINT_FRESH.format(path=cache_path))
+    else:
+        console.message(_HINT_LEGACY_PLAINTEXT.format(path=cache_path))
     print(_CONFIRM_WARNING, file=sys.stderr)
     try:
         confirmed = console.confirm(_CONFIRM_PROMPT)

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -116,11 +116,12 @@ def _confirm_plaintext_or_abort(
     """
     status = inspect_token_cache(path=cache_path, env=env)
     if status.state == "encrypted":
-        console.message(_HINT_LOCKOUT.format(path=cache_path))
-        raise TokenCacheError()
+        hint = _HINT_LOCKOUT.format(path=cache_path)
+        console.message(hint)
+        raise TokenCacheError(hint)
     if status.state == "absent":
         console.message(_HINT_FRESH.format(path=cache_path))
-    else:
+    elif status.state == "plaintext":
         console.message(_HINT_LEGACY_PLAINTEXT.format(path=cache_path))
     print(_CONFIRM_WARNING, file=sys.stderr)
     try:

--- a/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import sys
 
+_TTY_PATH = "/dev/tty"
+_ENCODING = "utf-8"
+
 
 class ConsoleIO:
     """Console abstraction over the controlling terminal (POSIX ``/dev/tty``).
@@ -20,13 +23,28 @@ class ConsoleIO:
     def prompt_secret(self, prompt: str) -> str:
         import getpass
 
-        with open("/dev/tty", "w", encoding="utf-8") as tty:
+        with open(_TTY_PATH, "w", encoding=_ENCODING) as tty:
             return getpass.getpass(prompt, stream=tty)
+
+    def message(self, text: str) -> None:
+        """Write one line to the controlling terminal, ignoring an unusable one.
+
+        Unlike stderr diagnostics, hints go to ``/dev/tty`` so they appear next
+        to the prompt and survive stdout/stderr redirection. A terminal that
+        cannot be opened is treated as non-interactive: the hint is dropped
+        rather than raising, mirroring the other prompt handles.
+        """
+        try:
+            with open(_TTY_PATH, "w", encoding=_ENCODING) as writer:
+                writer.write(f"{text}\n")
+                writer.flush()
+        except OSError:
+            return
 
     def confirm(self, prompt: str) -> bool:
         with (
-            open("/dev/tty", "w", encoding="utf-8") as writer,
-            open("/dev/tty", "r", encoding="utf-8") as reader,
+            open(_TTY_PATH, "w", encoding=_ENCODING) as writer,
+            open(_TTY_PATH, "r", encoding=_ENCODING) as reader,
         ):
             writer.write(prompt)
             writer.flush()

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -313,10 +313,12 @@ class TestStateAwareHints:
         console = self._no_source_tty_console()
         when(console).confirm(ANY).thenReturn(True)
         # when the cache is built with no resolvable passphrase source
-        with pytest.raises(TokenCacheError):
+        with pytest.raises(TokenCacheError) as excinfo:
             cache_factory.build_token_cache(path=path, env={}, console=console)
-        # then the lockout hint is shown, the confirm gate is skipped, and the
-        # encrypted file is left untouched
-        verify(console, times=1).message(cache_factory._HINT_LOCKOUT.format(path=path))
+        # then the lockout hint is shown, carried on the exception for callers,
+        # the confirm gate is skipped, and the encrypted file is left untouched
+        expected_hint = cache_factory._HINT_LOCKOUT.format(path=path)
+        assert excinfo.value.message == expected_hint
+        verify(console, times=1).message(expected_hint)
         verify(console, times=0).confirm(ANY)
         assert path.read_bytes() == before

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -1,5 +1,6 @@
 import base64
 import io
+from typing import Any
 
 import keyring
 import pytest
@@ -257,3 +258,65 @@ class TestInteractiveTokenCache:
         cache_factory.build_token_cache(path=tmp_path / "t.json", env={}, console=plain)
         # then the user was warned about unencrypted storage only once
         assert capsys.readouterr().err.count("UNENCRYPTED") == 1
+
+
+class TestStateAwareHints:
+    def _no_source_tty_console(self) -> Any:
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        when(console).message(ANY).thenReturn(None)
+        return console
+
+    def test_fresh_prints_first_time_hint_then_confirms(self, tmp_path, monkeypatch):
+        # given no source, a TTY, and no cache on disk yet
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = self._no_source_tty_console()
+        when(console).confirm(ANY).thenReturn(True)
+        path = tmp_path / "tokens.json"
+        # when the cache is built
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then the fresh hint is shown before the unchanged confirm gate
+        assert isinstance(cache, FileTokenCache)
+        verify(console, times=1).message(cache_factory._HINT_FRESH.format(path=path))
+        verify(console, times=1).confirm(ANY)
+
+    def test_legacy_plaintext_prints_hint_then_confirms(self, tmp_path, monkeypatch):
+        # given no source, a TTY, and an existing unencrypted cache
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        path = tmp_path / "tokens.json"
+        FileTokenCache(path=path).save("a", _tok())
+        console = self._no_source_tty_console()
+        when(console).confirm(ANY).thenReturn(True)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then the legacy-plaintext hint is shown before the unchanged confirm gate
+        assert isinstance(cache, FileTokenCache)
+        verify(console, times=1).message(
+            cache_factory._HINT_LEGACY_PLAINTEXT.format(path=path)
+        )
+        verify(console, times=1).confirm(ANY)
+
+    def test_lockout_prints_hint_and_aborts_without_touching_file(
+        self, tmp_path, monkeypatch
+    ):
+        # given an encrypted cache that no available source can unlock
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        path = tmp_path / "tokens.json"
+        cache_factory.build_token_cache(
+            path=path, env={"NEXTLABS_MASTER_PASSWORD": "pw"}
+        ).save("a", _tok())
+        before = path.read_bytes()
+        console = self._no_source_tty_console()
+        when(console).confirm(ANY).thenReturn(True)
+        # when the cache is built with no resolvable passphrase source
+        with pytest.raises(TokenCacheError):
+            cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then the lockout hint is shown, the confirm gate is skipped, and the
+        # encrypted file is left untouched
+        verify(console, times=1).message(cache_factory._HINT_LOCKOUT.format(path=path))
+        verify(console, times=0).confirm(ANY)
+        assert path.read_bytes() == before

--- a/tests/test_console_io.py
+++ b/tests/test_console_io.py
@@ -1,0 +1,26 @@
+import builtins
+import io
+
+from mockito import ANY, mock, when
+
+from nextlabs_sdk._auth._token_cache._console_io import ConsoleIO
+
+
+class TestConsoleIOMessage:
+    def test_writes_single_line_to_dev_tty(self):
+        # given a writable controlling terminal
+        writer = io.StringIO()
+        handle = mock()
+        when(handle).__enter__().thenReturn(writer)
+        when(handle).__exit__(ANY, ANY, ANY).thenReturn(False)
+        when(builtins).open("/dev/tty", "w", encoding="utf-8").thenReturn(handle)
+        # when a message is emitted
+        ConsoleIO().message("heads up")
+        # then exactly one newline-terminated line lands on the terminal
+        assert writer.getvalue() == "heads up\n"
+
+    def test_oserror_opening_tty_is_non_interactive(self):
+        # given a controlling terminal that cannot be opened
+        when(builtins).open("/dev/tty", "w", encoding="utf-8").thenRaise(OSError())
+        # when a message is emitted then it neither aborts nor crashes
+        ConsoleIO().message("heads up")


### PR DESCRIPTION
Closes #283

## Summary
- Add a state-aware guidance layer to the token-cache factory's no-source TTY branch: a first-time hint for an absent cache and a plaintext-exposure hint for an existing unencrypted one both fall through to the unchanged `Store the token cache unencrypted anyway? [y/N]` confirm, while an encrypted cache that no passphrase source can unlock is a lockout that prints its message and aborts (`TokenCacheError`) without touching the file.
- Add `ConsoleIO.message()`, writing one line to `/dev/tty` so hints appear with the prompt and survive stdout/stderr redirection; an `OSError` opening the terminal is treated as non-interactive (no abort, no crash).
- Verified with red→green unit tests plus the full suite (2599 passed, 95.99% coverage); Black, Flake8, MyPy, and Pyright all pass.

## Tests added (red → green)
- `TestConsoleIOMessage::test_writes_single_line_to_dev_tty`
- `TestConsoleIOMessage::test_oserror_opening_tty_is_non_interactive`
- `TestStateAwareHints::test_fresh_prints_first_time_hint_then_confirms`
- `TestStateAwareHints::test_legacy_plaintext_prints_hint_then_confirms`
- `TestStateAwareHints::test_lockout_prints_hint_and_aborts_without_touching_file`

## Notable assumptions
- Reused `inspect_token_cache` for no-source-TTY state detection instead of inlining a fresh/plaintext/encrypted check, accepting one extra file read plus a source re-peek to keep the state logic in a single place.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Introduces a state-aware hint layer in the token-cache factory's no-source TTY branch and a new `ConsoleIO.message()` method that writes directly to `/dev/tty`. The three cache states (absent, plaintext, encrypted) now each get a tailored hint before the existing confirm prompt, with the encrypted/lockout case aborting immediately via `TokenCacheError` to prevent overwriting the encrypted file with plaintext.

- **`_console_io.py`**: Adds `message()`, which writes one newline-terminated line to `/dev/tty` and silently swallows `OSError`, consistent with the existing prompt/confirm methods; also extracts `_TTY_PATH` and `_ENCODING` constants used by all three methods.
- **`_cache_factory.py`**: `_confirm_plaintext_or_abort` gains an `env` parameter and calls `inspect_token_cache` to dispatch the correct hint; the lockout path is a hard abort without touching the file.
- **Tests**: Five new red→green unit tests cover all three state branches plus `ConsoleIO.message` write and error-handling paths.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The lockout guard correctly aborts before any write, leaving the encrypted file untouched; the rest of the change is additive hint text with no impact on existing paths.

The core logic — state detection, lockout abort, hint dispatch — is correct and covered by targeted unit tests. Two small improvement opportunities exist: the `else` catch-all in state dispatch could silently mishandle any future `inspect_token_cache` state, and the lockout exception carries no message for programmatic callers. Neither causes wrong behavior today.

src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py — specifically the state dispatch in `_confirm_plaintext_or_abort` and the bare `TokenCacheError()` raise in the lockout branch.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py | Adds state-aware hints to the no-source TTY branch; lockout guard is logically correct but the `else` catch-all for state dispatch is fragile and the lockout `TokenCacheError` carries no diagnostic message. |
| src/nextlabs_sdk/_auth/_token_cache/_console_io.py | Adds `message()` writing one newline-terminated line to `/dev/tty`, silently swallowing `OSError`; constants extracted for path/encoding; all existing methods updated to use them — clean. |
| tests/test_cache_factory.py | Three new red→green tests covering fresh, legacy-plaintext, and lockout paths; verify both the hint content and whether `confirm` is called or skipped — well-structured with mockito. |
| tests/test_console_io.py | New test file; two tests cover the happy-path write and the `OSError` silent-drop; correctly mocks `builtins.open` via mockito. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build_token_cache] --> B{material resolved?}
    B -- yes --> C[EncryptedFileTokenCache]
    B -- no --> D{console.isatty?}
    D -- no --> E[_warn_plaintext_once\nFileTokenCache]
    D -- yes --> F[_confirm_plaintext_or_abort]
    F --> G[inspect_token_cache]
    G --> H{status.state}
    H -- encrypted --> I[message HINT_LOCKOUT\nraise TokenCacheError]
    H -- absent --> J[message HINT_FRESH]
    H -- plaintext --> K[message HINT_LEGACY_PLAINTEXT]
    J --> L[print _CONFIRM_WARNING to stderr]
    K --> L
    L --> M{console.confirm?}
    M -- OSError --> N[globals _WARNED=True\nFileTokenCache]
    M -- yes --> O[FileTokenCache]
    M -- no --> P[raise TokenCacheError]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[build_token_cache] --> B{material resolved?}
    B -- yes --> C[EncryptedFileTokenCache]
    B -- no --> D{console.isatty?}
    D -- no --> E[_warn_plaintext_once\nFileTokenCache]
    D -- yes --> F[_confirm_plaintext_or_abort]
    F --> G[inspect_token_cache]
    G --> H{status.state}
    H -- encrypted --> I[message HINT_LOCKOUT\nraise TokenCacheError]
    H -- absent --> J[message HINT_FRESH]
    H -- plaintext --> K[message HINT_LEGACY_PLAINTEXT]
    J --> L[print _CONFIRM_WARNING to stderr]
    K --> L
    L --> M{console.confirm?}
    M -- OSError --> N[globals _WARNED=True\nFileTokenCache]
    M -- yes --> O[FileTokenCache]
    M -- no --> P[raise TokenCacheError]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%3A121-124%0AThe%20%60else%60%20branch%20implicitly%20covers%20every%20state%20that%20isn't%20%22absent%22%20%28after%20%22encrypted%22%20is%20handled%20above%29.%20Because%20%60CacheStatus.state%60%20is%20a%20plain%20%60str%60%2C%20any%20new%20state%20added%20to%20%60inspect_token_cache%60%20in%20the%20future%20%E2%80%94%20e.g.%2C%20%60%22corrupted%22%60%20%E2%80%94%20would%20silently%20receive%20the%20legacy-plaintext%20hint%20and%20fall%20through%20to%20the%20confirm%20gate%2C%20which%20would%20be%20wrong.%20Using%20%60elif%60%20makes%20the%20intent%20explicit%20and%20lets%20an%20unexpected%20state%20propagate%20as%20an%20unhandled%20case%20rather%20than%20disguising%20itself%20as%20plaintext.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20status.state%20%3D%3D%20%22absent%22%3A%0A%20%20%20%20%20%20%20%20console.message%28_HINT_FRESH.format%28path%3Dcache_path%29%29%0A%20%20%20%20elif%20status.state%20%3D%3D%20%22plaintext%22%3A%0A%20%20%20%20%20%20%20%20console.message%28_HINT_LEGACY_PLAINTEXT.format%28path%3Dcache_path%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%3A118-120%0AThe%20lockout%20%60TokenCacheError%60%20is%20raised%20without%20a%20message.%20The%20TTY%20hint%20explains%20the%20situation%20to%20the%20interactive%20user%2C%20but%20any%20caller%20that%20catches%20%60TokenCacheError%60%20and%20logs%20or%20re-raises%20it%20gets%20a%20bare%20exception%20with%20no%20diagnostic%20text.%20The%20hint%20string%20is%20already%20formatted%20at%20this%20point%2C%20so%20threading%20it%20into%20the%20exception%20costs%20nothing%20and%20makes%20the%20lockout%20reason%20visible%20programmatically.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20status.state%20%3D%3D%20%22encrypted%22%3A%0A%20%20%20%20%20%20%20%20hint%20%3D%20_HINT_LOCKOUT.format%28path%3Dcache_path%29%0A%20%20%20%20%20%20%20%20console.message%28hint%29%0A%20%20%20%20%20%20%20%20raise%20TokenCacheError%28hint%29%0A%60%60%60%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(token-cache): state-aware plaintext..."](https://github.com/stevenengland/nextlabs_rest_api/commit/308b0acd189adcb57e339ca186777f10a579575a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41015970)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->