### PR TITLE
feat(token-cache): remember plaintext-storage choice across CLI runs

### DIFF
--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -26,6 +26,9 @@ from nextlabs_sdk._auth._token_cache._keyring_passphrase_source import (
 from nextlabs_sdk._auth._token_cache._passphrase_resolver import (
     PassphraseResolver,
 )
+from nextlabs_sdk._auth._token_cache._plaintext_ack_store import (
+    PlaintextAckStore,
+)
 from nextlabs_sdk._auth._token_cache._secret_box import SecretBox, read_header
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk.exceptions import TokenCacheError
@@ -59,6 +62,12 @@ _HINT_LOCKOUT = (
     "keyring, or delete {path} to start fresh. See the project's online "
     "documentation for details."
 )
+_REMEMBER_PROMPT = "Remember this choice so I stop asking? [Y/n]: "
+_SAVED_NOTICE = (
+    "Saved. The CLI won't ask again. To re-enable encryption, set "
+    "NEXTLABS_MASTER_PASSWORD or an OS keyring; nextlabs auth status shows the "
+    "cache location and current choice."
+)
 
 _WARNED = False
 
@@ -68,6 +77,7 @@ def build_token_cache(
     path: Path | str | None = None,
     env: Mapping[str, str] = os.environ,
     console: ConsoleIO | None = None,
+    ack_store: PlaintextAckStore | None = None,
 ) -> TokenCache:
     """Build a token cache, encrypting when a passphrase source is present.
 
@@ -78,6 +88,11 @@ def build_token_cache(
     source and no TTY the cache falls back to plaintext and emits a single
     process-wide warning to stderr; it never aborts. Setting
     ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`` silences the non-interactive warning.
+
+    When ``ack_store`` is supplied and reports a remembered plaintext choice,
+    the no-source TTY branch returns a plaintext cache silently. It is consulted
+    only when no source resolves, so configuring a passphrase later upgrades to
+    encryption without resetting the remembered choice.
     """
     console = console or ConsoleIO()
     resolver = PassphraseResolver(
@@ -94,14 +109,17 @@ def build_token_cache(
         return EncryptedFileTokenCache(path=cache_path, kek_source=material)
 
     if console.isatty():
-        return _confirm_plaintext_or_abort(console, cache_path, env)
+        return _confirm_plaintext_or_abort(console, cache_path, env, ack_store)
 
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
 
 
 def _confirm_plaintext_or_abort(
-    console: ConsoleIO, cache_path: Path, env: Mapping[str, str]
+    console: ConsoleIO,
+    cache_path: Path,
+    env: Mapping[str, str],
+    ack_store: PlaintextAckStore | None,
 ) -> TokenCache:
     """Gate plaintext storage behind a confirmation on the controlling terminal.
 
@@ -111,6 +129,11 @@ def _confirm_plaintext_or_abort(
     a lockout: the hint is shown and the build aborts without touching the file,
     so the encrypted tokens are never overwritten with plaintext.
 
+    A remembered plaintext choice short-circuits the hint and confirm gate, but
+    only after the lockout check, so acknowledging plaintext never clobbers an
+    existing encrypted cache. On confirmation the caller is offered a one-time
+    prompt to remember the choice for future runs.
+
     An unusable terminal cannot be prompted, so it degrades to plaintext rather
     than aborting, honouring the "encrypt when possible, never abort" policy.
     """
@@ -119,6 +142,8 @@ def _confirm_plaintext_or_abort(
         hint = _HINT_LOCKOUT.format(path=cache_path)
         console.message(hint)
         raise TokenCacheError(hint)
+    if ack_store is not None and ack_store.is_acknowledged():
+        return FileTokenCache(path=cache_path)
     if status.state == "absent":
         console.message(_HINT_FRESH.format(path=cache_path))
     elif status.state == "plaintext":
@@ -132,8 +157,26 @@ def _confirm_plaintext_or_abort(
         globals()["_WARNED"] = True
         return FileTokenCache(path=cache_path)
     if confirmed:
+        if ack_store is not None:
+            _offer_to_remember(console, ack_store)
         return FileTokenCache(path=cache_path)
     raise TokenCacheError()
+
+
+def _offer_to_remember(console: ConsoleIO, ack_store: PlaintextAckStore) -> None:
+    """Ask whether to persist the plaintext choice, defaulting to yes.
+
+    Accepting records the acknowledgement and prints the saved notice so later
+    no-source builds stay silent. An unusable terminal skips persistence and
+    proceeds plaintext for this run only.
+    """
+    try:
+        remember = console.confirm(_REMEMBER_PROMPT, default=True)
+    except OSError:
+        return
+    if remember:
+        ack_store.remember()
+        console.message(_SAVED_NOTICE)
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -167,16 +167,21 @@ def _offer_to_remember(console: ConsoleIO, ack_store: PlaintextAckStore) -> None
     """Ask whether to persist the plaintext choice, defaulting to yes.
 
     Accepting records the acknowledgement and prints the saved notice so later
-    no-source builds stay silent. An unusable terminal skips persistence and
-    proceeds plaintext for this run only.
+    no-source builds stay silent. An unusable terminal or a failed preferences
+    write skips persistence and proceeds plaintext for this run only, so a
+    best-effort convenience never aborts an otherwise-successful build.
     """
     try:
         remember = console.confirm(_REMEMBER_PROMPT, default=True)
     except OSError:
         return
-    if remember:
+    if not remember:
+        return
+    try:
         ack_store.remember()
-        console.message(_SAVED_NOTICE)
+    except OSError:
+        return
+    console.message(_SAVED_NOTICE)
 
 
 @dataclass(frozen=True)

--- a/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_console_io.py
@@ -41,11 +41,14 @@ class ConsoleIO:
         except OSError:
             return
 
-    def confirm(self, prompt: str) -> bool:
+    def confirm(self, prompt: str, *, default: bool = False) -> bool:
         with (
             open(_TTY_PATH, "w", encoding=_ENCODING) as writer,
             open(_TTY_PATH, "r", encoding=_ENCODING) as reader,
         ):
             writer.write(prompt)
             writer.flush()
-            return reader.readline().strip().lower() in {"y", "yes"}
+            answer = reader.readline().strip().lower()
+        if not answer:
+            return default
+        return answer in {"y", "yes"}

--- a/src/nextlabs_sdk/_auth/_token_cache/_plaintext_ack_store.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_plaintext_ack_store.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PlaintextAckStore(Protocol):
+    """Port for persisting the user's plaintext-storage acknowledgement.
+
+    The token-cache factory consults this port only when no passphrase source
+    resolves. An acknowledged choice lets the factory return a plaintext cache
+    without prompting; :meth:`remember` records that choice so later builds stay
+    silent. Implementations live outside the SDK core (for example, the CLI
+    preferences store) and are injected into ``build_token_cache``.
+    """
+
+    def is_acknowledged(self) -> bool:
+        """Return whether plaintext storage has been remembered."""
+        ...
+
+    def remember(self) -> None:
+        """Persist the plaintext-storage acknowledgement."""
+        ...

--- a/src/nextlabs_sdk/_cli/_account_preferences.py
+++ b/src/nextlabs_sdk/_cli/_account_preferences.py
@@ -60,3 +60,32 @@ class AccountPreferences:
             pdp_url=_optional_str(payload, "pdp_url"),
             pdp_auth_source=_optional_str(payload, "pdp_auth_source"),
         )
+
+
+@dataclass(frozen=True)
+class GlobalCachePreferences:
+    """Process-wide token-cache preferences, shared across all accounts.
+
+    Persisted once under a reserved key rather than per account, so a
+    remembered plaintext-storage choice applies to every CLI command.
+
+    Attributes:
+        plaintext_acknowledged: Whether the user has acknowledged storing the
+            token cache unencrypted and asked not to be prompted again.
+    """
+
+    plaintext_acknowledged: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "plaintext_acknowledged": self.plaintext_acknowledged,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> GlobalCachePreferences:
+        _check_schema_version(payload)
+        acknowledged = payload.get("plaintext_acknowledged")
+        if not isinstance(acknowledged, bool):
+            raise TypeError("plaintext_acknowledged must be a bool")
+        return cls(plaintext_acknowledged=acknowledged)

--- a/src/nextlabs_sdk/_cli/_account_preferences_store.py
+++ b/src/nextlabs_sdk/_cli/_account_preferences_store.py
@@ -5,12 +5,17 @@ import os
 import tempfile
 from pathlib import Path
 
-from nextlabs_sdk._cli._account_preferences import AccountPreferences
+from nextlabs_sdk._cli._account_preferences import (
+    AccountPreferences,
+    GlobalCachePreferences,
+)
 
 _FILE_MODE = 0o600
 _DIR_MODE = 0o700
 _FILENAME = "account_prefs.json"
 _PACKAGE_DIR = "nextlabs-sdk"
+# Reserved global key; real account keys always contain "|" so cannot collide.
+_GLOBAL_CACHE_KEY = "__token_cache__"
 
 
 def _default_path() -> Path:
@@ -63,8 +68,24 @@ class AccountPreferencesStore:
         if entries.pop(key, None) is not None:
             self._write_all(entries)
 
-    def keys(self) -> list[str]:
-        return list(self._read_all().keys())
+    def load_global_cache(self) -> GlobalCachePreferences | None:
+        """Return the reserved global cache preferences, or ``None``.
+
+        A malformed or missing record reads as "not acknowledged" rather than
+        raising, mirroring :meth:`load` for per-account entries.
+        """
+        entry = self._read_all().get(_GLOBAL_CACHE_KEY)
+        if not isinstance(entry, dict):
+            return None
+        try:
+            return GlobalCachePreferences.from_dict(entry)
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def save_global_cache(self, prefs: GlobalCachePreferences) -> None:
+        entries = self._read_all()
+        entries[_GLOBAL_CACHE_KEY] = prefs.to_dict()
+        self._write_all(entries)
 
     def _read_all(self) -> dict[str, object]:
         if not self._path.exists():

--- a/src/nextlabs_sdk/_cli/_account_prefs_plaintext_ack_store.py
+++ b/src/nextlabs_sdk/_cli/_account_prefs_plaintext_ack_store.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from nextlabs_sdk._cli._account_preferences import GlobalCachePreferences
+from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+
+
+class AccountPrefsPlaintextAckStore:
+    """Adapt the CLI preferences store to the SDK ``PlaintextAckStore`` port.
+
+    Reads and writes the reserved global cache preference so every CLI command
+    shares one remembered plaintext-storage choice. A malformed or missing
+    record reads as "not acknowledged".
+    """
+
+    def __init__(self, store: AccountPreferencesStore) -> None:
+        self._store = store
+
+    def is_acknowledged(self) -> bool:
+        prefs = self._store.load_global_cache()
+        return prefs is not None and prefs.plaintext_acknowledged
+
+    def remember(self) -> None:
+        self._store.save_global_cache(
+            GlobalCachePreferences(plaintext_acknowledged=True)
+        )

--- a/src/nextlabs_sdk/_cli/_account_resolver.py
+++ b/src/nextlabs_sdk/_cli/_account_resolver.py
@@ -14,6 +14,9 @@ from nextlabs_sdk._auth._token_cache._cache_factory import (
 )
 from nextlabs_sdk._auth._token_cache._token_cache import TokenCache
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
+from nextlabs_sdk._cli._account_prefs_plaintext_ack_store import (
+    AccountPrefsPlaintextAckStore,
+)
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._context import CliContext
 
@@ -50,7 +53,8 @@ def _cache_env_and_path(ctx: CliContext) -> tuple[dict[str, str], Path | None]:
 
 def build_token_cache(ctx: CliContext) -> TokenCache:
     env, path = _cache_env_and_path(ctx)
-    return _factory(path=path, env=env)
+    ack_store = AccountPrefsPlaintextAckStore(build_prefs_store(ctx))
+    return _factory(path=path, env=env, ack_store=ack_store)
 
 
 def inspect_token_cache(ctx: CliContext) -> CacheStatus:

--- a/tests/test_account_preferences.py
+++ b/tests/test_account_preferences.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from nextlabs_sdk._cli._account_preferences import AccountPreferences
+from nextlabs_sdk._cli._account_preferences import (
+    AccountPreferences,
+    GlobalCachePreferences,
+)
 
 
 def test_to_dict_round_trip_preserves_verify_ssl():
@@ -73,4 +76,28 @@ def test_from_dict_rejects_non_string_pdp_field(field: str):
     with pytest.raises(TypeError, match=field):
         AccountPreferences.from_dict(
             {"schema_version": 1, "verify_ssl": True, field: 42},
+        )
+
+
+def test_global_cache_prefs_round_trip_true():
+    prefs = GlobalCachePreferences(plaintext_acknowledged=True)
+    assert GlobalCachePreferences.from_dict(prefs.to_dict()) == prefs
+
+
+def test_global_cache_prefs_serialises_reserved_shape():
+    payload = GlobalCachePreferences(plaintext_acknowledged=True).to_dict()
+    assert payload == {"schema_version": 1, "plaintext_acknowledged": True}
+
+
+def test_global_cache_prefs_rejects_bad_schema_version():
+    with pytest.raises(TypeError):
+        GlobalCachePreferences.from_dict(
+            {"schema_version": 2, "plaintext_acknowledged": True}
+        )
+
+
+def test_global_cache_prefs_rejects_non_bool_flag():
+    with pytest.raises(TypeError):
+        GlobalCachePreferences.from_dict(
+            {"schema_version": 1, "plaintext_acknowledged": "yes"}
         )

--- a/tests/test_account_preferences_store.py
+++ b/tests/test_account_preferences_store.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
 import stat
 import sys
 from pathlib import Path
 
 import pytest
 
-from nextlabs_sdk._cli._account_preferences import AccountPreferences
+from nextlabs_sdk._cli._account_preferences import (
+    AccountPreferences,
+    GlobalCachePreferences,
+)
 from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 
 _SKIP_ON_WINDOWS = pytest.mark.skipif(
@@ -60,14 +64,7 @@ def test_delete_removes_only_matching_entry(tmp_path: Path) -> None:
 def test_delete_missing_key_is_noop(tmp_path: Path) -> None:
     store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
     store.delete("nope")
-    assert store.keys() == []
-
-
-def test_keys_reports_all_entries(tmp_path: Path) -> None:
-    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
-    store.save("a", _prefs())
-    store.save("b", _prefs())
-    assert sorted(store.keys()) == ["a", "b"]
+    assert store.load("nope") is None
 
 
 @_SKIP_ON_WINDOWS
@@ -161,3 +158,42 @@ def test_default_path(
     store = AccountPreferencesStore()
 
     assert store.path == tmp_path / expected_suffix
+
+
+def test_global_cache_missing_returns_none(tmp_path: Path) -> None:
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    assert store.load_global_cache() is None
+
+
+def test_global_cache_save_then_load_roundtrip(tmp_path: Path) -> None:
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    store.save_global_cache(GlobalCachePreferences(plaintext_acknowledged=True))
+    loaded = store.load_global_cache()
+    assert loaded == GlobalCachePreferences(plaintext_acknowledged=True)
+
+
+def test_global_cache_key_does_not_collide_with_account_entries(
+    tmp_path: Path,
+) -> None:
+    store = AccountPreferencesStore(path=tmp_path / "account_prefs.json")
+    store.save("base|user|client|cloudaz", _prefs(verify_ssl=True))
+    store.save_global_cache(GlobalCachePreferences(plaintext_acknowledged=True))
+
+    assert store.load("base|user|client|cloudaz") == _prefs(verify_ssl=True)
+    assert store.load_global_cache() == GlobalCachePreferences(
+        plaintext_acknowledged=True,
+    )
+
+
+def test_global_cache_reserved_key_stored_under_dunder(tmp_path: Path) -> None:
+    path = tmp_path / "account_prefs.json"
+    store = AccountPreferencesStore(path=path)
+    store.save_global_cache(GlobalCachePreferences(plaintext_acknowledged=True))
+    assert "__token_cache__" in json.loads(path.read_text())
+
+
+def test_global_cache_malformed_reads_as_not_acknowledged(tmp_path: Path) -> None:
+    path = tmp_path / "account_prefs.json"
+    path.write_text('{"__token_cache__": {"schema_version": 1}}')
+    store = AccountPreferencesStore(path=path)
+    assert store.load_global_cache() is None

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -327,6 +327,28 @@ class TestRememberPlaintextChoice:
         verify(ack, times=0).remember()
         verify(console, times=0).message(cache_factory._SAVED_NOTICE)
 
+    def test_remember_write_failure_degrades_silently_without_notice(
+        self, tmp_path, monkeypatch
+    ):
+        # given plaintext confirmed and accepted, but persisting the choice fails
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = self._no_source_tty_console()
+        when(console).confirm(cache_factory._CONFIRM_PROMPT).thenReturn(True)
+        when(console).confirm(cache_factory._REMEMBER_PROMPT, default=True).thenReturn(
+            True
+        )
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(False)
+        when(ack).remember().thenRaise(PermissionError("prefs not writable"))
+        # when the cache is built
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console, ack_store=ack
+        )
+        # then the build still returns plaintext and no saved notice is shown
+        assert isinstance(cache, FileTokenCache)
+        verify(console, times=0).message(cache_factory._SAVED_NOTICE)
+
     def test_source_present_ignores_acknowledgement_and_encrypts(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -260,6 +260,91 @@ class TestInteractiveTokenCache:
         assert capsys.readouterr().err.count("UNENCRYPTED") == 1
 
 
+class TestRememberPlaintextChoice:
+    def _no_source_tty_console(self) -> Any:
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("")
+        when(console).message(ANY).thenReturn(None)
+        return console
+
+    def test_confirm_then_accept_remember_persists_and_prints_saved_notice(
+        self, tmp_path, monkeypatch
+    ):
+        # given no source, a TTY, plaintext confirmed, and the remember prompt accepted
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = self._no_source_tty_console()
+        when(console).confirm(cache_factory._CONFIRM_PROMPT).thenReturn(True)
+        when(console).confirm(cache_factory._REMEMBER_PROMPT, default=True).thenReturn(
+            True
+        )
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(False)
+        when(ack).remember().thenReturn(None)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console, ack_store=ack
+        )
+        # then the choice is persisted and the saved notice is shown
+        assert isinstance(cache, FileTokenCache)
+        verify(ack, times=1).remember()
+        verify(console, times=1).message(cache_factory._SAVED_NOTICE)
+
+    def test_acknowledged_returns_plaintext_silently(self, tmp_path, monkeypatch):
+        # given a prior remembered plaintext choice and no source on a TTY
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = self._no_source_tty_console()
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(True)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console, ack_store=ack
+        )
+        # then a plaintext cache is returned with no hint and no prompt
+        assert isinstance(cache, FileTokenCache)
+        verify(console, times=0).message(ANY)
+        verify(console, times=0).confirm(...)
+
+    def test_declining_remember_does_not_persist(self, tmp_path, monkeypatch):
+        # given no source, a TTY, plaintext confirmed, but the remember prompt declined
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = self._no_source_tty_console()
+        when(console).confirm(cache_factory._CONFIRM_PROMPT).thenReturn(True)
+        when(console).confirm(cache_factory._REMEMBER_PROMPT, default=True).thenReturn(
+            False
+        )
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(False)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json", env={}, console=console, ack_store=ack
+        )
+        # then nothing is persisted and no saved notice is shown
+        assert isinstance(cache, FileTokenCache)
+        verify(ack, times=0).remember()
+        verify(console, times=0).message(cache_factory._SAVED_NOTICE)
+
+    def test_source_present_ignores_acknowledgement_and_encrypts(
+        self, tmp_path, monkeypatch
+    ):
+        # given a remembered plaintext choice but a resolvable passphrase source
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(True)
+        # when the cache is built with an env passphrase present
+        cache = cache_factory.build_token_cache(
+            path=tmp_path / "t.json",
+            env={"NEXTLABS_MASTER_PASSWORD": "pw"},
+            ack_store=ack,
+        )
+        # then the remembered choice is ignored and the cache is encrypted
+        assert isinstance(cache, EncryptedFileTokenCache)
+        verify(ack, times=0).is_acknowledged()
+
+
 class TestStateAwareHints:
     def _no_source_tty_console(self) -> Any:
         console = mock()

--- a/tests/test_cli_account_resolver.py
+++ b/tests/test_cli_account_resolver.py
@@ -9,6 +9,10 @@ from nextlabs_sdk._auth._token_cache._encrypted_file_token_cache import (
     EncryptedFileTokenCache,
 )
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
+from nextlabs_sdk._cli import _account_resolver as account_resolver
+from nextlabs_sdk._cli._account_prefs_plaintext_ack_store import (
+    AccountPrefsPlaintextAckStore,
+)
 from nextlabs_sdk._cli._account_resolver import (
     build_active_store,
     build_token_cache,
@@ -247,3 +251,25 @@ def test_load_account_prefs_prefers_new_four_segment_entry(
 
     assert loaded is not None
     assert loaded.verify_ssl is True
+
+
+def test_build_token_cache_injects_plaintext_ack_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # given a resolver whose factory records the injected ack store
+    seen: dict[str, object] = {}
+
+    def _fake_factory(
+        *,
+        path: object,
+        env: object,
+        ack_store: object,
+    ) -> FileTokenCache:
+        seen["ack_store"] = ack_store
+        return FileTokenCache(path=tmp_path / "tokens.json")
+
+    monkeypatch.setattr(account_resolver, "_factory", _fake_factory)
+    # when the CLI builds a token cache
+    account_resolver.build_token_cache(_ctx(cache_dir=str(tmp_path)))
+    # then a preferences-backed acknowledgement adapter is wired in
+    assert isinstance(seen["ack_store"], AccountPrefsPlaintextAckStore)

--- a/tests/test_cli_client_factory.py
+++ b/tests/test_cli_client_factory.py
@@ -238,7 +238,9 @@ def _no_cache_passphrase(_console: ConsoleIO, _prompt: str) -> str:
     return ""
 
 
-def _accept_plaintext(_console: ConsoleIO, _prompt: str) -> bool:
+def _accept_plaintext(
+    _console: ConsoleIO, _prompt: str, *, default: bool = False
+) -> bool:
     return True
 
 

--- a/tests/test_cli_plaintext_ack_store.py
+++ b/tests/test_cli_plaintext_ack_store.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from mockito import mock, verify, when
+
+from nextlabs_sdk._cli._account_prefs_plaintext_ack_store import (
+    AccountPrefsPlaintextAckStore,
+)
+from nextlabs_sdk._cli._account_preferences import GlobalCachePreferences
+from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
+
+
+def test_is_acknowledged_true_when_flag_persisted() -> None:
+    # given a store holding an acknowledged global cache preference
+    store = mock(AccountPreferencesStore)
+    when(store).load_global_cache().thenReturn(
+        GlobalCachePreferences(plaintext_acknowledged=True)
+    )
+    adapter = AccountPrefsPlaintextAckStore(store)
+    # when the acknowledgement is queried, then it reports true
+    assert adapter.is_acknowledged() is True
+
+
+def test_is_acknowledged_false_when_absent() -> None:
+    # given a store with no global cache preference
+    store = mock(AccountPreferencesStore)
+    when(store).load_global_cache().thenReturn(None)
+    adapter = AccountPrefsPlaintextAckStore(store)
+    # when the acknowledgement is queried, then it reports false
+    assert adapter.is_acknowledged() is False
+
+
+def test_remember_persists_acknowledged_preference() -> None:
+    # given an adapter over a preferences store
+    store = mock(AccountPreferencesStore)
+    when(store).save_global_cache(...).thenReturn(None)
+    adapter = AccountPrefsPlaintextAckStore(store)
+    # when the choice is remembered
+    adapter.remember()
+    # then the acknowledged preference is saved
+    verify(store, times=1).save_global_cache(
+        GlobalCachePreferences(plaintext_acknowledged=True)
+    )


### PR DESCRIPTION
Closes #284

## Summary
- Add a `PlaintextAckStore` port that `build_token_cache` consults in the no-source TTY branch: an acknowledged choice returns a plaintext cache silently, and confirming plaintext now offers a one-time `Remember this choice so I stop asking? [Y/n]` prompt that persists the acknowledgement and prints the saved notice. `ConsoleIO.confirm` gains a `default` so the `[Y/n]` prompt defaults to yes.
- Persist a typed `GlobalCachePreferences` record under the reserved `__token_cache__` key in `account_prefs.json`, wired via an `AccountPrefsPlaintextAckStore` adapter injected into `build_token_cache`, so every CLI command shares the remembered choice. Verified with unit tests and the full suite (2615 passed, 95.98% coverage).
- Trade-off: the acknowledgement is checked *after* the encrypted-cache lockout guard, so a remembered plaintext choice can never overwrite an existing encrypted cache. Resolution precedence is otherwise unchanged — a passphrase source still wins, so configuring one later upgrades to encryption with no reset.

## Tests added (red → green)
- `TestRememberPlaintextChoice::test_confirm_then_accept_remember_persists_and_prints_saved_notice`
- `TestRememberPlaintextChoice::test_acknowledged_returns_plaintext_silently`
- `TestRememberPlaintextChoice::test_declining_remember_does_not_persist`
- `TestRememberPlaintextChoice::test_source_present_ignores_acknowledgement_and_encrypts`
- `test_global_cache_prefs_round_trip_true`, `test_global_cache_prefs_serialises_reserved_shape`, `test_global_cache_prefs_rejects_non_bool_flag`
- `test_global_cache_save_then_load_roundtrip`, `test_global_cache_key_does_not_collide_with_account_entries`, `test_global_cache_malformed_reads_as_not_acknowledged`
- `test_is_acknowledged_true_when_flag_persisted`, `test_remember_persists_acknowledged_preference`
- `test_build_token_cache_injects_plaintext_ack_adapter`

## Notable assumptions
- Removed the unused `AccountPreferencesStore.keys()` method (production-dead, only self-tested) so the class stays under the method-count limit after adding the two reserved-key accessors, avoiding a suppression.
- `_REMEMBER_PROMPT` carries a trailing space (`[Y/n]: `) to match the existing confirm prompt style.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a "remember my choice" flow for the plaintext token-cache acknowledgement: after a user confirms plaintext storage on a TTY, they are offered a one-time prompt to persist that choice so future CLI runs skip the confirmation entirely. The preference is stored under a reserved `__token_cache__` key in `account_prefs.json` via a new `GlobalCachePreferences` model and an `AccountPrefsPlaintextAckStore` adapter that satisfies the new `PlaintextAckStore` port injected into `build_token_cache`.

- `ConsoleIO.confirm` gains a keyword-only `default` parameter; the acknowledged path short-circuits after the encrypted-cache lockout guard, so a remembered plaintext choice can never silently overwrite an existing encrypted cache.
- The `keys()` method on `AccountPreferencesStore` is removed (production-dead) and replaced with `load_global_cache` / `save_global_cache` using a `__token_cache__` key that cannot collide with real account keys (which always contain `|`).
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core token-cache logic and persistence layer are correct, but `_offer_to_remember` leaves a gap: if writing the preference file fails (e.g., a read-only `NEXTLABS_CACHE_DIR`), the exception escapes `build_token_cache` and aborts the command even though the user has already confirmed plaintext and the token cache itself is writable.

Every other I/O operation in this call chain degrades silently on `OSError` — `message()`, `confirm()`, and `_warn_plaintext_once()` all swallow file errors. The `remember()` call is the only one that doesn't, and it sits on the path that runs after the user has interactively confirmed plaintext storage. A read-only preferences directory would turn a successful confirmation into an unexpected command failure.

src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py — `_offer_to_remember` needs an `OSError` guard around `ack_store.remember()`
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py | Adds `ack_store` injection into `build_token_cache` and the `_offer_to_remember` helper; `ack_store.remember()` is missing an `OSError` guard and can propagate a `PermissionError` after the user has already confirmed plaintext. |
| src/nextlabs_sdk/_auth/_token_cache/_console_io.py | Adds keyword-only `default` parameter to `confirm`; implementation is correct — empty answer returns `default`, non-empty checks against `{"y","yes"}`. |
| src/nextlabs_sdk/_auth/_token_cache/_plaintext_ack_store.py | New `PlaintextAckStore` Protocol port — clean, minimal, `runtime_checkable` for duck-typing at the injection site. |
| src/nextlabs_sdk/_cli/_account_preferences.py | Adds `GlobalCachePreferences` dataclass; shares `_SCHEMA_VERSION` and schema-check logic cleanly with `AccountPreferences`. |
| src/nextlabs_sdk/_cli/_account_preferences_store.py | Replaces dead `keys()` method with `load_global_cache` / `save_global_cache`; reserved `__token_cache__` key is justified by the `|`-separator invariant of real account keys. |
| src/nextlabs_sdk/_cli/_account_prefs_plaintext_ack_store.py | Thin adapter connecting `AccountPreferencesStore` to `PlaintextAckStore`; correctly treats missing/malformed record as not acknowledged. |
| src/nextlabs_sdk/_cli/_account_resolver.py | Wires `AccountPrefsPlaintextAckStore` into `build_token_cache`; adapter is always constructed but only consulted on the no-source TTY path. |
| tests/test_cache_factory.py | Four new `TestRememberPlaintextChoice` tests cover the main paths; the OSError-from-`remember()` degradation path is not tested. |
| tests/test_account_preferences.py | Round-trip, serialisation shape, bad schema version, and non-bool flag tests for `GlobalCachePreferences` — thorough. |
| tests/test_account_preferences_store.py | Missing, round-trip, no-collision, reserved-key, and malformed-reads-as-none tests for `load_global_cache` / `save_global_cache`. |
| tests/test_cli_plaintext_ack_store.py | New file covers acknowledged-true, absent, and remember-persists paths for `AccountPrefsPlaintextAckStore`. |
| tests/test_cli_account_resolver.py | Adds injection test confirming the adapter type wired into `_factory`. |
| tests/test_cli_client_factory.py | Updates `_accept_plaintext` stub signature to accept the new `default` keyword argument — correct fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI Command
    participant AR as account_resolver
    participant BTC as build_token_cache
    participant Ack as AccountPrefsPlaintextAckStore
    participant Store as AccountPreferencesStore
    participant Console as ConsoleIO

    CLI->>AR: build_token_cache(ctx)
    AR->>Store: build_prefs_store(ctx)
    AR->>Ack: new(store)
    AR->>BTC: "_factory(path, env, ack_store=Ack)"

    alt passphrase source resolves
        BTC-->>CLI: EncryptedFileTokenCache
    else no source, TTY present
        BTC->>BTC: _confirm_plaintext_or_abort(console, path, env, ack_store)
        BTC->>BTC: inspect_token_cache → status
        alt "status == encrypted (lockout)"
            BTC-->>CLI: raise TokenCacheError
        else "ack_store.is_acknowledged() == True"
            Ack->>Store: load_global_cache()
            Store-->>Ack: "GlobalCachePreferences(acknowledged=True)"
            BTC-->>CLI: FileTokenCache (silent)
        else user must confirm
            BTC->>Console: message(hint)
            BTC->>Console: confirm(_CONFIRM_PROMPT)
            Console-->>BTC: True/False
            alt confirmed
                BTC->>Console: "confirm(_REMEMBER_PROMPT, default=True)"
                Console-->>BTC: True/False
                alt remember accepted
                    BTC->>Ack: remember()
                    Ack->>Store: "save_global_cache(acknowledged=True)"
                    BTC->>Console: message(_SAVED_NOTICE)
                end
                BTC-->>CLI: FileTokenCache
            else declined
                BTC-->>CLI: raise TokenCacheError
            end
        end
    else no source, no TTY
        BTC->>BTC: _warn_plaintext_once
        BTC-->>CLI: FileTokenCache
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI Command
    participant AR as account_resolver
    participant BTC as build_token_cache
    participant Ack as AccountPrefsPlaintextAckStore
    participant Store as AccountPreferencesStore
    participant Console as ConsoleIO

    CLI->>AR: build_token_cache(ctx)
    AR->>Store: build_prefs_store(ctx)
    AR->>Ack: new(store)
    AR->>BTC: "_factory(path, env, ack_store=Ack)"

    alt passphrase source resolves
        BTC-->>CLI: EncryptedFileTokenCache
    else no source, TTY present
        BTC->>BTC: _confirm_plaintext_or_abort(console, path, env, ack_store)
        BTC->>BTC: inspect_token_cache → status
        alt "status == encrypted (lockout)"
            BTC-->>CLI: raise TokenCacheError
        else "ack_store.is_acknowledged() == True"
            Ack->>Store: load_global_cache()
            Store-->>Ack: "GlobalCachePreferences(acknowledged=True)"
            BTC-->>CLI: FileTokenCache (silent)
        else user must confirm
            BTC->>Console: message(hint)
            BTC->>Console: confirm(_CONFIRM_PROMPT)
            Console-->>BTC: True/False
            alt confirmed
                BTC->>Console: "confirm(_REMEMBER_PROMPT, default=True)"
                Console-->>BTC: True/False
                alt remember accepted
                    BTC->>Ack: remember()
                    Ack->>Store: "save_global_cache(acknowledged=True)"
                    BTC->>Console: message(_SAVED_NOTICE)
                end
                BTC-->>CLI: FileTokenCache
            else declined
                BTC-->>CLI: raise TokenCacheError
            end
        end
    else no source, no TTY
        BTC->>BTC: _warn_plaintext_once
        BTC-->>CLI: FileTokenCache
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%3A177-179%0A%60ack_store.remember%28%29%60%20is%20not%20wrapped%20in%20an%20%60OSError%60%20guard%2C%20so%20a%20%60PermissionError%60%20%28or%20any%20other%20%60OSError%60%29%20from%20%60save_global_cache%60%20propagates%20all%20the%20way%20out%20of%20%60build_token_cache%60.%20The%20user%20has%20already%20confirmed%20plaintext%20and%20the%20token-cache%20file%20itself%20is%20writable%3B%20the%20prefs%20write%20failing%20should%20degrade%20silently%2C%20matching%20the%20pattern%20used%20for%20every%20other%20terminal%2Ffile%20operation%20in%20this%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20remember%3A%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20ack_store.remember%28%29%0A%20%20%20%20%20%20%20%20except%20OSError%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20console.message%28_SAVED_NOTICE%29%0A%60%60%60%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(token-cache): remember plaintext-st..."](https://github.com/stevenengland/nextlabs_rest_api/commit/d226178f2dbfbd6f0865a088e21c860cf1022ec2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41020400)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->