### PR TITLE
feat(cli): surface remembered plaintext choice in auth status

### DIFF
--- a/src/nextlabs_sdk/_cli/_auth_cmd.py
+++ b/src/nextlabs_sdk/_cli/_auth_cmd.py
@@ -19,6 +19,9 @@ from nextlabs_sdk._cli._account_menu import (
     known_accounts,
     select_account,
 )
+from nextlabs_sdk._cli._account_prefs_plaintext_ack_store import (
+    AccountPrefsPlaintextAckStore,
+)
 from nextlabs_sdk._cli._account_preferences import AccountPreferences
 from nextlabs_sdk._cli._account_resolver import (
     ResolvedAccount,
@@ -402,6 +405,12 @@ def _render_cache_line(cli_ctx: CliContext) -> None:
     )
 
 
+def _render_remembered_choice_line(cli_ctx: CliContext) -> None:
+    ack_store = AccountPrefsPlaintextAckStore(build_prefs_store(cli_ctx))
+    remembered = "yes" if ack_store.is_acknowledged() else "no"
+    typer.echo(f"Remembered plaintext choice: {remembered}")
+
+
 @auth_app.command(name="status")
 @cli_error_handler
 def status(
@@ -411,6 +420,7 @@ def status(
     """Show whether a valid cached token exists."""
     cli_ctx: CliContext = ctx.obj
     _render_cache_line(cli_ctx)
+    _render_remembered_choice_line(cli_ctx)
     if show_all:
         _status_all(cli_ctx)
         return

--- a/tests/test_cli_auth_status_cache.py
+++ b/tests/test_cli_auth_status_cache.py
@@ -14,6 +14,8 @@ from nextlabs_sdk._auth._token_cache._cache_factory import CacheStatus
 from nextlabs_sdk._auth._token_cache._cached_token import CachedToken
 from nextlabs_sdk._auth._token_cache._file_token_cache import FileTokenCache
 from nextlabs_sdk._cli import _auth_cmd
+from nextlabs_sdk._cli._account_preferences import GlobalCachePreferences
+from nextlabs_sdk._cli._account_preferences_store import AccountPreferencesStore
 from nextlabs_sdk._cli._app import app
 from nextlabs_sdk.exceptions import TokenCacheError
 
@@ -192,3 +194,42 @@ def test_status_all_prints_cache_line(
     assert result.exit_code == 0, result.output
     assert "Cache:" in result.output
     assert "plaintext" in result.output
+
+
+def _remember_plaintext_choice(tmp_path: object) -> None:
+    AccountPreferencesStore(path=f"{tmp_path}/account_prefs.json").save_global_cache(
+        GlobalCachePreferences(plaintext_acknowledged=True),
+    )
+
+
+def test_status_reports_remembered_plaintext_choice(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given a remembered plaintext-storage choice on disk
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+    _remember_plaintext_choice(tmp_path)
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the remembered choice is reported as yes
+    assert result.exit_code == 0, result.output
+    assert "Remembered plaintext choice: yes" in result.output
+
+
+def test_status_reports_no_remembered_plaintext_choice(
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given no remembered plaintext-storage choice on disk
+    _isolate_cache(tmp_path, monkeypatch)
+    _seed_plaintext_token(tmp_path)
+
+    # When status is rendered
+    result = runner.invoke(app, ["auth", "status"])
+
+    # Then the remembered choice is reported as no
+    assert result.exit_code == 0, result.output
+    assert "Remembered plaintext choice: no" in result.output


### PR DESCRIPTION
Closes #285

## Summary
- Extend `nextlabs auth status` with a "Remembered plaintext choice: yes/no" line, read via the existing `AccountPrefsPlaintextAckStore` over the global preferences record (no cache unlock). The cache path and encryption state (absent/plaintext/encrypted) were already surfaced by the existing cache line.
- Verified with two new Given/When/Then CLI tests (red → green) plus the existing `test_cli_auth_status_cache.py` suite (12 passed); black/flake8/mypy/pyright all green.
- Notable trade-off: none.

## Tests added (red → green)
- `test_status_reports_remembered_plaintext_choice`
- `test_status_reports_no_remembered_plaintext_choice`

## Notable assumptions
- The user-facing wording "Remembered plaintext choice: yes/no" is not dictated by the PRD conventions (which only fix login-time copy); chosen to match the PRD vocabulary "remembered choice" / "plaintext acknowledgement".

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Extends `nextlabs auth status` with a "Remembered plaintext choice: yes/no" line sourced from `AccountPrefsPlaintextAckStore` over the global preferences record, requiring no cache unlock. Two new Given/When/Then tests cover the acknowledged and unacknowledged paths, and all twelve existing cache-status tests continue to pass.

- `_render_remembered_choice_line` is added in `_auth_cmd.py` and called unconditionally after the existing `_render_cache_line`; the backing `AccountPreferencesStore` silently swallows missing/malformed records so the function cannot raise under normal conditions.
- The test helper `_remember_plaintext_choice` writes to `{tmp_path}/account_prefs.json`, matching the path resolved from `NEXTLABS_CACHE_DIR` set by `_isolate_cache`, so test isolation is correct.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to reading a single boolean from an already-existing preferences store that is designed to return a safe default on any I/O or parse error.

The new render function delegates entirely to AccountPrefsPlaintextAckStore.is_acknowledged(), which can never raise because the underlying store silently absorbs missing files, OSError, and malformed JSON. The two new tests correctly isolate state via the existing _isolate_cache fixture and verify both the yes and no branches. All pre-existing cache-status assertions remain unaffected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_auth_cmd.py | Adds _render_remembered_choice_line which reads the global plaintext-ack preference via AccountPrefsPlaintextAckStore and prints yes/no; calls it unconditionally in status() after the existing cache line. Implementation is safe: the underlying store silently returns None on missing/malformed data. |
| tests/test_cli_auth_status_cache.py | Adds two new Given/When/Then tests and a _remember_plaintext_choice helper. Both tests correctly verify the yes/no output without disturbing existing assertions. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant CLI as nextlabs auth status
    participant RCL as _render_cache_line
    participant RRL as _render_remembered_choice_line
    participant APS as AccountPrefsPlaintextAckStore
    participant Store as AccountPreferencesStore

    User->>CLI: nextlabs auth status
    CLI->>RCL: _render_cache_line(cli_ctx)
    RCL-->>CLI: prints "Cache: ..." line
    CLI->>RRL: _render_remembered_choice_line(cli_ctx)
    RRL->>APS: AccountPrefsPlaintextAckStore(build_prefs_store(cli_ctx))
    RRL->>APS: is_acknowledged()
    APS->>Store: load_global_cache()
    Store-->>APS: GlobalCachePreferences or None
    APS-->>RRL: True / False
    RRL-->>CLI: prints "Remembered plaintext choice: yes/no"
    CLI-->>User: combined status output
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant CLI as nextlabs auth status
    participant RCL as _render_cache_line
    participant RRL as _render_remembered_choice_line
    participant APS as AccountPrefsPlaintextAckStore
    participant Store as AccountPreferencesStore

    User->>CLI: nextlabs auth status
    CLI->>RCL: _render_cache_line(cli_ctx)
    RCL-->>CLI: prints "Cache: ..." line
    CLI->>RRL: _render_remembered_choice_line(cli_ctx)
    RRL->>APS: AccountPrefsPlaintextAckStore(build_prefs_store(cli_ctx))
    RRL->>APS: is_acknowledged()
    APS->>Store: load_global_cache()
    Store-->>APS: GlobalCachePreferences or None
    APS-->>RRL: True / False
    RRL-->>CLI: prints "Remembered plaintext choice: yes/no"
    CLI-->>User: combined status output
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): surface remembered plaintext ..."](https://github.com/stevenengland/nextlabs_rest_api/commit/ca4f57a95b206edfbb38ea653224ce03a583a5cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41025512)</sub>

<!-- /greptile_comment -->