### PR TITLE
docs: document token-cache encryption and remembered choice (#286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,14 +479,22 @@ The file is written `0600` inside a `0700` directory; writes are atomic
 (temp file + `os.replace`). The cache key is
 `"{token_url}|{username}|{client_id}"` so multiple profiles coexist.
 
-**Encryption at rest.** When `NEXTLABS_MASTER_PASSWORD` is set, the CLI
-stores the cache as an `EncryptedFileTokenCache` — an `NLBX` envelope
-where a random data key (DEK) encrypts the payload under AES-256-GCM and
-is itself wrapped by a key derived from the passphrase (Argon2id). The
-cache migrates organically: a legacy plaintext `tokens.json` is read
-once and rewritten encrypted on the next write. Without a passphrase the
-CLI keeps a plaintext cache and prints a one-time stderr warning; set
-`NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1` to silence it.
+**Encryption at rest.** The CLI encrypts the cache whenever a passphrase
+source resolves — `NEXTLABS_MASTER_PASSWORD`, then the OS keyring, then
+an interactive TTY prompt — storing it as an `EncryptedFileTokenCache`:
+an `NLBX` envelope where a random data key (DEK) encrypts the payload
+under AES-256-GCM and is itself wrapped by a key derived from the
+resolved source (Argon2id for a passphrase, HKDF-SHA256 for a keyring
+key). The cache migrates organically: a legacy plaintext `tokens.json`
+is read once and rewritten encrypted on the next write.
+
+With no source and no terminal, the CLI keeps a plaintext cache and
+prints a one-time stderr warning; set
+`NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1` to silence it. On a terminal it
+asks for confirmation instead, and can remember that choice so it stops
+asking — see [`docs/encryption.md`](docs/encryption.md) for the
+interactive hints, the lockout case, and how to reset a remembered
+choice.
 
 Refresh tokens are used transparently when available; on refresh failure
 the CLI falls back to the password grant (if `--password` /
@@ -698,4 +706,5 @@ MIT — see [LICENSE](LICENSE).
 ---
 
 [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) ·
-[Changelog](CHANGELOG.md) · [Troubleshooting](docs/troubleshooting.md)
+[Changelog](CHANGELOG.md) · [Troubleshooting](docs/troubleshooting.md) ·
+[Encryption](docs/encryption.md)

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,111 @@
+# Token cache encryption
+
+How the `nextlabs` CLI protects the OIDC token cache (`tokens.json`) at
+rest, what the interactive hints mean, and how to reset a remembered
+choice. See the [README](../README.md#oidc-tokens-caching-and-environment-variables)
+for the cache location and lookup precedence.
+
+## Resolution flow
+
+`build_token_cache` consults passphrase sources in a fixed order every
+time it runs:
+
+1. **`NEXTLABS_MASTER_PASSWORD`** (environment variable) — used verbatim
+   if set.
+2. **OS keyring** — on first use, a random 32-byte key-encryption key
+   (KEK) is generated and stored in the keyring; later runs reuse it. A
+   keyring that is missing, locked, or a null backend is treated as
+   unavailable and resolution falls through to the next source.
+3. **Interactive TTY prompt** — on a controlling terminal, the CLI asks
+   for a passphrase and derives Argon2id key material from it. An empty
+   entry, a non-interactive stream, or an unusable `/dev/tty` is treated
+   as unavailable.
+
+If a source resolves, the cache becomes an `EncryptedFileTokenCache`: an
+`NLBX` envelope where a random data key (DEK) encrypts the payload under
+AES-256-GCM, itself wrapped by the resolved KEK (Argon2id for a
+passphrase, HKDF-SHA256 for a keyring-sourced key).
+
+If no source resolves and a controlling terminal is present, the CLI
+warns and asks for confirmation before storing the cache unencrypted
+(see [Interactive hints](#interactive-hints) below); declining aborts
+without writing anything. With no terminal at all, the cache falls back
+to plaintext with a single stderr warning and never aborts — set
+`NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1` to silence that warning.
+
+## Interactive hints
+
+When no passphrase source resolves and a confirmation prompt is about to
+be shown, the CLI first prints one state-aware hint to the controlling
+terminal (`/dev/tty`), so it survives stdout/stderr redirection:
+
+- **Fresh** — no cache file exists yet:
+
+  > No token cache yet; it will be created at {path}. It can be
+  > encrypted at rest, but no passphrase source is set
+  > (NEXTLABS_MASTER_PASSWORD or an OS keyring). See the project's
+  > online documentation for details.
+
+- **Legacy plaintext** — a cache file exists and is already unencrypted:
+
+  > Your existing token cache at {path} is UNENCRYPTED and may contain
+  > access/refresh tokens in plain text. Set NEXTLABS_MASTER_PASSWORD or
+  > an OS keyring to re-encrypt it on the next write. See the project's
+  > online documentation for details.
+
+- **Lockout** — a cache file exists and is encrypted, but no source can
+  unlock it (see [Lockout abort](#lockout-abort) below).
+
+## Remembered choice
+
+After confirming plaintext storage, the CLI offers a one-time follow-up
+prompt:
+
+> Remember this choice so I stop asking? \[Y/n\]:
+
+Accepting (the default) persists the acknowledgement and prints:
+
+> Saved. The CLI won't ask again. To re-enable encryption, set
+> NEXTLABS_MASTER_PASSWORD or an OS keyring; nextlabs auth status shows
+> the cache location and current choice.
+
+Once remembered, later runs with no passphrase source skip both the
+hint and the confirmation prompt and build a plaintext cache silently.
+The remembered choice is consulted only when no passphrase source
+resolves, so configuring `NEXTLABS_MASTER_PASSWORD` or a keyring later
+upgrades the cache to encryption without needing to reset anything.
+
+The choice is global — shared by every account — and stored under a
+reserved key in the same JSON file as other CLI account preferences
+(`account_prefs.json`), not per account. `nextlabs auth status` reports
+it as `Remembered plaintext choice: yes` / `no`.
+
+## Lockout abort
+
+If a cache file exists and is encrypted, but no configured source can
+unlock it (wrong or missing passphrase, keyring entry cleared, etc.),
+the CLI never falls back to plaintext for that file. It prints:
+
+> Your token cache at {path} is ENCRYPTED but no passphrase source is
+> available to unlock it. Set the original NEXTLABS_MASTER_PASSWORD /
+> keyring, or delete {path} to start fresh. See the project's online
+> documentation for details.
+
+...and aborts the command without touching the file. This check runs
+before the remembered choice is consulted, so a remembered
+acknowledgement can never cause an encrypted cache to be silently
+overwritten with plaintext.
+
+## Resetting the remembered choice
+
+The remembered choice has no dedicated CLI command; reset it by editing
+the preferences file directly:
+
+1. Locate `account_prefs.json` — the same directory as the token cache
+   (`NEXTLABS_CACHE_DIR`, then `$XDG_CACHE_HOME/nextlabs-sdk`, then
+   `~/.cache/nextlabs-sdk`).
+2. Remove the reserved `"__token_cache__"` top-level key (real account
+   entries are keyed by `base_url|username|client_id[|kind]`, which
+   always contains `|`, so it never collides with the reserved key).
+3. Save the file. The next run with no passphrase source available
+   shows the hints and confirmation prompt again.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -35,9 +35,12 @@ to plaintext with a single stderr warning and never aborts — set
 
 ## Interactive hints
 
-When no passphrase source resolves and a confirmation prompt is about to
-be shown, the CLI first prints one state-aware hint to the controlling
-terminal (`/dev/tty`), so it survives stdout/stderr redirection:
+When no passphrase source resolves and a controlling terminal is
+present, the CLI prints one state-aware hint to that terminal
+(`/dev/tty`) — so it survives stdout/stderr redirection — before
+deciding what happens next. Fresh and legacy plaintext fall through to
+a confirmation prompt (below); lockout instead aborts immediately, with
+no prompt shown:
 
 - **Fresh** — no cache file exists yet:
 
@@ -54,7 +57,8 @@ terminal (`/dev/tty`), so it survives stdout/stderr redirection:
   > online documentation for details.
 
 - **Lockout** — a cache file exists and is encrypted, but no source can
-  unlock it (see [Lockout abort](#lockout-abort) below).
+  unlock it. No confirmation prompt follows (see
+  [Lockout abort](#lockout-abort) below).
 
 ## Remembered choice
 


### PR DESCRIPTION
Closes #286

## Summary
- Added `docs/encryption.md`: the passphrase-source resolution order, the
  three interactive hint states (fresh / legacy-plaintext / lockout), the
  remembered plaintext-choice behavior, the lockout abort, and how to
  reset a remembered choice by editing `account_prefs.json`.
- Updated the README "Encryption at rest" paragraph to describe the OS
  keyring source and the interactive/remembered-choice flow (previously
  only mentioned `NEXTLABS_MASTER_PASSWORD`), and cross-linked
  `docs/encryption.md`. Added an "Encryption" link to the footer nav bar.
- Docs-only change; no code touched.

## Tests added (red → green)
- None — both acceptance criteria are `(structural)` (documentation).
  Re-ran the existing suite per the ship-light structural gate: 2618
  passed, 12 skipped, 97 xfailed, 95.99% coverage.

## Notable assumptions
- `docs/encryption.md` section order (resolution flow → hints →
  remembered choice → lockout → reset) was chosen for reading order;
  the issue body didn't mandate one.
- Added the "Encryption" footer-nav link alongside the existing
  Troubleshooting link, matching the existing convention; the AC only
  required a cross-link, not a specific placement.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Docs-only change that documents the token-cache encryption feature: passphrase resolution order, interactive hint states, remembered plaintext choice, lockout abort behavior, and how to reset a saved choice.

- Adds `docs/encryption.md` with a full walkthrough of the three-source resolution flow (`NEXTLABS_MASTER_PASSWORD` → OS keyring → interactive TTY), the three hint states (Fresh / Legacy plaintext / Lockout), the remembered-choice mechanism stored in `account_prefs.json`, and manual reset steps.
- Updates the README \"Encryption at rest\" paragraph to mention the OS keyring source and interactive/remembered-choice flow, and adds an \"Encryption\" cross-link to the footer nav alongside the existing Troubleshooting link.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no code is touched; only documentation is added and updated.

The "Encryption at rest" README update and the new docs/encryption.md are accurate and internally consistent. The one gap is that the "Interactive hints" section intro incorrectly groups the Lockout hint under "when no source resolves and a confirmation prompt is about to be shown" — Lockout is a distinct condition where the CLI aborts instead of prompting, so a reader who hits that path will be misled by the section opening.

The "Interactive hints" section in docs/encryption.md (lines 38–57) needs its intro reworded to not imply a confirmation prompt follows for the Lockout state.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/encryption.md | New documentation file covering passphrase resolution order, interactive hints, remembered plaintext choice, lockout abort, and reset procedure. Content is internally consistent except the "Interactive hints" section intro inaccurately describes the Lockout state. |
| README.md | Expanded "Encryption at rest" paragraph to cover OS keyring source, interactive/remembered-choice flow, and a cross-link to docs/encryption.md; also added an "Encryption" entry to the footer nav. Changes are accurate and consistent with the new docs file. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build_token_cache called] --> B{NEXTLABS_MASTER_PASSWORD set?}
    B -- Yes --> E[Use passphrase → Argon2id KEK]
    B -- No --> C{OS keyring available?}
    C -- Yes --> F[Use keyring KEK → HKDF-SHA256]
    C -- No --> D{Interactive TTY available?}
    D -- Yes, passphrase entered --> G[Use passphrase → Argon2id KEK]
    D -- Empty / unavailable --> H{Existing encrypted cache?}
    H -- Yes, can't unlock --> LOCK[Print Lockout hint → Abort]
    H -- No / plaintext exists --> HINT{Remembered plaintext choice?}
    HINT -- Yes --> PLAIN[Build plaintext cache silently]
    HINT -- No, TTY present --> CONF[Show state hint Fresh/Legacy]
    CONF --> PROM{User confirms plaintext?}
    PROM -- No --> ABORT[Abort, nothing written]
    PROM -- Yes --> REMEMBER{Remember choice?}
    REMEMBER -- Yes --> SAVEPLAIN[Save choice → build plaintext cache]
    REMEMBER -- No --> PLAIN2[Build plaintext cache]
    H -- No terminal at all --> WARN[Stderr warning → plaintext cache]
    E & F & G --> ENC[Build EncryptedFileTokenCache NLBX/AES-256-GCM]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[build_token_cache called] --> B{NEXTLABS_MASTER_PASSWORD set?}
    B -- Yes --> E[Use passphrase → Argon2id KEK]
    B -- No --> C{OS keyring available?}
    C -- Yes --> F[Use keyring KEK → HKDF-SHA256]
    C -- No --> D{Interactive TTY available?}
    D -- Yes, passphrase entered --> G[Use passphrase → Argon2id KEK]
    D -- Empty / unavailable --> H{Existing encrypted cache?}
    H -- Yes, can't unlock --> LOCK[Print Lockout hint → Abort]
    H -- No / plaintext exists --> HINT{Remembered plaintext choice?}
    HINT -- Yes --> PLAIN[Build plaintext cache silently]
    HINT -- No, TTY present --> CONF[Show state hint Fresh/Legacy]
    CONF --> PROM{User confirms plaintext?}
    PROM -- No --> ABORT[Abort, nothing written]
    PROM -- Yes --> REMEMBER{Remember choice?}
    REMEMBER -- Yes --> SAVEPLAIN[Save choice → build plaintext cache]
    REMEMBER -- No --> PLAIN2[Build plaintext cache]
    H -- No terminal at all --> WARN[Stderr warning → plaintext cache]
    E & F & G --> ENC[Build EncryptedFileTokenCache NLBX/AES-256-GCM]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fencryption.md%3A38-57%0A**%22Interactive%20hints%22%20intro%20is%20inaccurate%20for%20the%20Lockout%20case**%0A%0AThe%20section%20opens%20with%20%22When%20no%20passphrase%20source%20resolves%20*and%20a%20confirmation%20prompt%20is%20about%20to%20be%20shown*%22%2C%20but%20Lockout%20is%20listed%20as%20the%20third%20hint%20state%20and%20it%20matches%20neither%20condition%3A%20a%20source%20may%20have%20been%20configured%20%28it%20just%20can't%20decrypt%20the%20existing%20file%29%2C%20and%20the%20CLI%20aborts%20immediately%20without%20showing%20a%20confirmation%20prompt.%20A%20user%20who%20hits%20Lockout%20and%20reads%20this%20intro%20will%20be%20confused%20when%20no%20prompt%20appears.%20Consider%20either%20narrowing%20the%20intro%20to%20cover%20only%20Fresh%2FLegacy%20plaintext%20and%20giving%20Lockout%20its%20own%20note%2C%20or%20rewording%20to%20something%20like%20%22The%20CLI%20prints%20one%20state-aware%20hint%20in%20three%20situations%22%20so%20the%20intro%20doesn't%20imply%20a%20shared%20confirmation-prompt%20outcome.%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document token-cache encryption an..."](https://github.com/stevenengland/nextlabs_rest_api/commit/75d3d4e4cc83c69b2ba878f16092cbce7492b450) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41031527)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->