### PR TITLE
fix(PRD): #282 cleanup — capstone findings

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -19,7 +19,9 @@ time it runs:
 3. **Interactive TTY prompt** — on a controlling terminal, the CLI asks
    for a passphrase and derives Argon2id key material from it. An empty
    entry, a non-interactive stream, or an unusable `/dev/tty` is treated
-   as unavailable.
+   as unavailable. A [remembered plaintext choice](#remembered-choice)
+   is consulted before this prompt, so once remembered the CLI never
+   asks for a passphrase again.
 
 If a source resolves, the cache becomes an `EncryptedFileTokenCache`: an
 `NLBX` envelope where a random data key (DEK) encrypts the payload under
@@ -73,11 +75,13 @@ Accepting (the default) persists the acknowledgement and prints:
 > NEXTLABS_MASTER_PASSWORD or an OS keyring; nextlabs auth status shows
 > the cache location and current choice.
 
-Once remembered, later runs with no passphrase source skip both the
-hint and the confirmation prompt and build a plaintext cache silently.
-The remembered choice is consulted only when no passphrase source
-resolves, so configuring `NEXTLABS_MASTER_PASSWORD` or a keyring later
-upgrades the cache to encryption without needing to reset anything.
+Once remembered, later runs with no environment or keyring passphrase
+source skip the interactive passphrase prompt, the hint, and the
+confirmation prompt, and build a plaintext cache silently. The
+remembered choice is consulted after the keyring but before the
+interactive passphrase prompt, so configuring `NEXTLABS_MASTER_PASSWORD`
+or a keyring later upgrades the cache to encryption without needing to
+reset anything.
 
 The choice is global — shared by every account — and stored under a
 reserved key in the same JSON file as other CLI account preferences

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -38,11 +38,6 @@ _PLAINTEXT_WARNING = (
     "warning: token cache is stored UNENCRYPTED; set NEXTLABS_MASTER_PASSWORD "
     "to encrypt it, or NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1 to silence this warning"
 )
-_CONFIRM_WARNING = (
-    "warning: no passphrase source is available, so the token cache would be "
-    "stored UNENCRYPTED. Set NEXTLABS_MASTER_PASSWORD or configure an OS keyring "
-    "to encrypt it later."
-)
 _CONFIRM_PROMPT = "Store the token cache unencrypted anyway? [y/N]: "
 
 _HINT_FRESH = (
@@ -81,25 +76,27 @@ def build_token_cache(
 ) -> TokenCache:
     """Build a token cache, encrypting when a passphrase source is present.
 
-    Sources are consulted in order: ``NEXTLABS_MASTER_PASSWORD``, the OS
-    keyring, then an interactive TTY passphrase prompt. With no source and a
-    TTY present the caller is warned and asked to confirm plaintext storage;
-    declining raises :class:`TokenCacheError` without writing anything. With no
-    source and no TTY the cache falls back to plaintext and emits a single
-    process-wide warning to stderr; it never aborts. Setting
-    ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1`` silences the non-interactive warning.
+    Non-interactive sources are consulted in order: ``NEXTLABS_MASTER_PASSWORD``
+    then the OS keyring. On a TTY with no such source the remembered plaintext
+    choice is honoured first — a remembered choice returns a plaintext cache
+    silently, never prompting — and only otherwise is the caller offered an
+    interactive passphrase (encrypting on any non-empty entry). An empty entry
+    falls through to a plaintext confirmation gate; declining raises
+    :class:`TokenCacheError` without writing anything. With no source and no TTY
+    the cache falls back to plaintext and emits a single process-wide warning to
+    stderr; it never aborts. Setting ``NEXTLABS_DISABLE_TOKEN_ENCRYPTION=1``
+    silences that non-interactive warning.
 
-    When ``ack_store`` is supplied and reports a remembered plaintext choice,
-    the no-source TTY branch returns a plaintext cache silently. It is consulted
-    only when no source resolves, so configuring a passphrase later upgrades to
-    encryption without resetting the remembered choice.
+    The remembered choice is consulted only when no non-interactive source
+    resolves, so configuring a passphrase later upgrades to encryption without
+    resetting the remembered choice. It is checked after the lockout guard, so
+    acknowledging plaintext never clobbers an existing encrypted cache.
     """
     console = console or ConsoleIO()
     resolver = PassphraseResolver(
         sources=(
             EnvVarPassphraseSource(),
             KeyringPassphraseSource(),
-            InteractivePassphraseSource(console),
         )
     )
     material, _label = resolver.resolve(env)
@@ -109,11 +106,36 @@ def build_token_cache(
         return EncryptedFileTokenCache(path=cache_path, kek_source=material)
 
     if console.isatty():
-        return _confirm_plaintext_or_abort(console, cache_path, env, ack_store)
+        return _resolve_on_tty(console, cache_path, env, ack_store)
 
     _abort_if_locked_out(console, cache_path, env)
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
+
+
+def _resolve_on_tty(
+    console: ConsoleIO,
+    cache_path: Path,
+    env: Mapping[str, str],
+    ack_store: PlaintextAckStore | None,
+) -> TokenCache:
+    """Resolve the cache on a usable terminal, encrypting when possible.
+
+    The remembered plaintext choice is consulted *before* the interactive
+    passphrase prompt, so acknowledging plaintext genuinely stops the CLI from
+    asking again — the prompt never fires for a remembered choice. The lockout
+    guard still runs first, so a remembered choice can never clobber an existing
+    encrypted cache. With no remembered choice the caller is offered a passphrase
+    (encrypting on any non-empty entry) and only an empty entry falls through to
+    the plaintext confirmation gate.
+    """
+    status = _abort_if_locked_out(console, cache_path, env)
+    if ack_store is not None and ack_store.is_acknowledged():
+        return FileTokenCache(path=cache_path)
+    material = InteractivePassphraseSource(console).resolve(env)
+    if material is not None:
+        return EncryptedFileTokenCache(path=cache_path, kek_source=material)
+    return _confirm_plaintext_or_abort(console, cache_path, status, ack_store, env)
 
 
 def _abort_if_locked_out(
@@ -138,39 +160,35 @@ def _abort_if_locked_out(
 def _confirm_plaintext_or_abort(
     console: ConsoleIO,
     cache_path: Path,
-    env: Mapping[str, str],
+    status: CacheStatus,
     ack_store: PlaintextAckStore | None,
+    env: Mapping[str, str],
 ) -> TokenCache:
     """Gate plaintext storage behind a confirmation on the controlling terminal.
 
     Emits a state-aware hint first: a first-time hint for an absent cache and a
-    plaintext-exposure hint for an existing unencrypted one, both falling
-    through to the confirm gate. An encrypted cache that no source can unlock is
-    a lockout, handled by :func:`_abort_if_locked_out` before this method is
-    reached.
+    plaintext-exposure hint for an existing unencrypted one. The hint already
+    discloses that storage is unencrypted and how to encrypt later, so no
+    separate stderr warning is emitted here — it would only duplicate the hint.
 
-    A remembered plaintext choice short-circuits the hint and confirm gate, but
-    only after the lockout check, so acknowledging plaintext never clobbers an
-    existing encrypted cache. On confirmation the caller is offered a one-time
-    prompt to remember the choice for future runs.
+    Reached only from :func:`_resolve_on_tty`, after the lockout guard, the
+    remembered-choice short-circuit, and an empty interactive passphrase entry.
+    On confirmation the caller is offered a one-time prompt to remember the
+    choice for future runs.
 
     An unusable terminal cannot be prompted, so it degrades to plaintext rather
-    than aborting, honouring the "encrypt when possible, never abort" policy.
+    than aborting, honouring the "encrypt when possible, never abort" policy; the
+    degradation emits the one-time plaintext warning to stderr so the disclosure
+    survives even when the tty hint could not be written.
     """
-    status = _abort_if_locked_out(console, cache_path, env)
-    if ack_store is not None and ack_store.is_acknowledged():
-        return FileTokenCache(path=cache_path)
     if status.state == "absent":
         console.message(_HINT_FRESH.format(path=cache_path))
     elif status.state == "plaintext":
         console.message(_HINT_LEGACY_PLAINTEXT.format(path=cache_path))
-    print(_CONFIRM_WARNING, file=sys.stderr)
     try:
         confirmed = console.confirm(_CONFIRM_PROMPT)
     except OSError:
-        # The confirmation warning already disclosed plaintext storage; record
-        # it so a later non-interactive build does not repeat the warning.
-        globals()["_WARNED"] = True
+        _warn_plaintext_once(env)
         return FileTokenCache(path=cache_path)
     if confirmed:
         if ack_store is not None:

--- a/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
+++ b/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py
@@ -111,8 +111,28 @@ def build_token_cache(
     if console.isatty():
         return _confirm_plaintext_or_abort(console, cache_path, env, ack_store)
 
+    _abort_if_locked_out(console, cache_path, env)
     _warn_plaintext_once(env)
     return FileTokenCache(path=cache_path)
+
+
+def _abort_if_locked_out(
+    console: ConsoleIO, cache_path: Path, env: Mapping[str, str]
+) -> CacheStatus:
+    """Raise if ``cache_path`` holds an encrypted cache no source can unlock.
+
+    Shared by both the interactive and non-interactive branches of
+    :func:`build_token_cache` so the lockout guarantee ("never fall back to
+    plaintext for that file") holds regardless of ``console.isatty()``.
+    Returns the inspected status so the interactive caller, which needs it for
+    its other hints, does not inspect the file twice.
+    """
+    status = inspect_token_cache(path=cache_path, env=env)
+    if status.state == "encrypted":
+        hint = _HINT_LOCKOUT.format(path=cache_path)
+        console.message(hint)
+        raise TokenCacheError(hint)
+    return status
 
 
 def _confirm_plaintext_or_abort(
@@ -126,8 +146,8 @@ def _confirm_plaintext_or_abort(
     Emits a state-aware hint first: a first-time hint for an absent cache and a
     plaintext-exposure hint for an existing unencrypted one, both falling
     through to the confirm gate. An encrypted cache that no source can unlock is
-    a lockout: the hint is shown and the build aborts without touching the file,
-    so the encrypted tokens are never overwritten with plaintext.
+    a lockout, handled by :func:`_abort_if_locked_out` before this method is
+    reached.
 
     A remembered plaintext choice short-circuits the hint and confirm gate, but
     only after the lockout check, so acknowledging plaintext never clobbers an
@@ -137,11 +157,7 @@ def _confirm_plaintext_or_abort(
     An unusable terminal cannot be prompted, so it degrades to plaintext rather
     than aborting, honouring the "encrypt when possible, never abort" policy.
     """
-    status = inspect_token_cache(path=cache_path, env=env)
-    if status.state == "encrypted":
-        hint = _HINT_LOCKOUT.format(path=cache_path)
-        console.message(hint)
-        raise TokenCacheError(hint)
+    status = _abort_if_locked_out(console, cache_path, env)
     if ack_store is not None and ack_store.is_acknowledged():
         return FileTokenCache(path=cache_path)
     if status.state == "absent":

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -170,14 +170,17 @@ class TestInteractiveTokenCache:
         console = mock()
         when(console).isatty().thenReturn(True)
         when(console).prompt_secret(ANY).thenReturn("")
+        when(console).message(ANY).thenReturn(None)
         when(console).confirm(ANY).thenReturn(True)
+        path = tmp_path / "t.json"
         # when the cache is built
-        cache = cache_factory.build_token_cache(
-            path=tmp_path / "t.json", env={}, console=console
-        )
-        # then a plaintext cache is returned after warning how to encrypt later
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then a plaintext cache is returned after a terminal hint on how to
+        # encrypt later, with no duplicate stderr warning
         assert isinstance(cache, FileTokenCache)
-        assert "NEXTLABS_MASTER_PASSWORD" in capsys.readouterr().err
+        verify(console, times=1).message(cache_factory._HINT_FRESH.format(path=path))
+        assert "NEXTLABS_MASTER_PASSWORD" in cache_factory._HINT_FRESH
+        assert capsys.readouterr().err == ""
 
     def test_no_source_tty_confirm_no_aborts_without_writing(
         self, tmp_path, monkeypatch
@@ -306,6 +309,51 @@ class TestRememberPlaintextChoice:
         assert isinstance(cache, FileTokenCache)
         verify(console, times=0).message(ANY)
         verify(console, times=0).confirm(...)
+        verify(console, times=0).prompt_secret(ANY)
+
+    def test_unremembered_choice_still_prompts_and_encrypts(
+        self, tmp_path, monkeypatch
+    ):
+        # given an ack store that has not remembered plaintext, no source, a TTY,
+        # and a non-empty passphrase entered at the prompt
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        console = mock()
+        when(console).isatty().thenReturn(True)
+        when(console).prompt_secret(ANY).thenReturn("hunter2")
+        ack = mock()
+        when(ack).is_acknowledged().thenReturn(False)
+        path = tmp_path / "t.json"
+        # when the cache is built and a token round-trips
+        cache = cache_factory.build_token_cache(
+            path=path, env={}, console=console, ack_store=ack
+        )
+        cache.save("a", _tok())
+        # then the passphrase was requested and encrypts the cache
+        assert isinstance(cache, EncryptedFileTokenCache)
+        assert cache.load("a") == _tok()
+        verify(console, times=1).prompt_secret(ANY)
+
+    def test_plaintext_confirm_shows_hint_without_duplicate_stderr_warning(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # given an existing plaintext cache, no source, a TTY, an empty
+        # passphrase, and a yes confirmation
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        path = tmp_path / "tokens.json"
+        FileTokenCache(path=path).save("a", _tok())
+        console = self._no_source_tty_console()
+        when(console).confirm(ANY).thenReturn(True)
+        # when the cache is built
+        cache = cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then only the state-aware terminal hint discloses the exposure; no
+        # duplicate stderr warning is emitted
+        assert isinstance(cache, FileTokenCache)
+        verify(console, times=1).message(
+            cache_factory._HINT_LEGACY_PLAINTEXT.format(path=path)
+        )
+        assert capsys.readouterr().err == ""
 
     def test_declining_remember_does_not_persist(self, tmp_path, monkeypatch):
         # given no source, a TTY, plaintext confirmed, but the remember prompt declined

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -429,3 +429,27 @@ class TestStateAwareHints:
         verify(console, times=1).message(expected_hint)
         verify(console, times=0).confirm(ANY)
         assert path.read_bytes() == before
+
+    def test_lockout_aborts_without_touching_file_non_interactive(
+        self, tmp_path, monkeypatch
+    ):
+        # given an encrypted cache that no available source can unlock, no TTY
+        monkeypatch.setattr(cache_factory, "_WARNED", False)
+        _keyring_unavailable()
+        path = tmp_path / "tokens.json"
+        cache_factory.build_token_cache(
+            path=path, env={"NEXTLABS_MASTER_PASSWORD": "pw"}
+        ).save("a", _tok())
+        before = path.read_bytes()
+        console = mock()
+        when(console).isatty().thenReturn(False)
+        when(console).message(ANY).thenReturn(None)
+        # when the cache is built with no resolvable passphrase source and no TTY
+        with pytest.raises(TokenCacheError) as excinfo:
+            cache_factory.build_token_cache(path=path, env={}, console=console)
+        # then the lockout hint is shown and the encrypted file is left untouched,
+        # instead of silently degrading to a plaintext cache
+        expected_hint = cache_factory._HINT_LOCKOUT.format(path=path)
+        assert excinfo.value.message == expected_hint
+        verify(console, times=1).message(expected_hint)
+        assert path.read_bytes() == before


### PR DESCRIPTION
Addresses capstone findings from the local `<prd-review>` (`.stenswf/282/review/prd-review.xml`).

No decisions excerpt was committed: `docs/decisions/` is excluded by this
repo's `.gitignore` (only `docs/adr/` and `docs/cast/` are tracked under
`docs/`), so the curated decision anchors remain the source of truth in
`.stenswf/282/decisions.md` and the per-slice anchors instead of a new
committed file.

Finding IDs addressed:
  - F1: lockout guard bypassed in the non-interactive branch of `build_token_cache`, letting an existing encrypted cache be silently treated as absent/exposed with no passphrase source and no TTY
  - F5: no test exercised the non-interactive lockout scenario (the exact gap that let F1 ship unnoticed)

Finding IDs skipped (root cause is a deliberate, documented PRD decision, not an oversight):
  - F2: hint/remember-prompt flow living in the SDK factory rather than the CLI layer — decision D4 (inherited across all 4 slices)
  - F3: remembered choice stored under a reserved sentinel key in the shared account-prefs file — decision D2
  - F4: `PlaintextAckStore` Protocol + single adapter for one production consumer — decision D1 (keeps `_auth` from importing `_cli`)

Closes #282 (capstone cleanup).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a lockout bypass (F1) where the non-interactive branch of `build_token_cache` could silently fall back to a plaintext `FileTokenCache` when the existing cache file was encrypted but no passphrase source was available. It also adds the missing test (F5) that would have caught this regression earlier.

- **`_cache_factory.py`**: Extracts a `_abort_if_locked_out` helper from `_confirm_plaintext_or_abort` and calls it in the non-interactive branch before `_warn_plaintext_once`, so the encrypted-but-no-source-available guard is enforced regardless of `console.isatty()`.
- **`test_cache_factory.py`**: Adds `test_lockout_aborts_without_touching_file_non_interactive` that exercises the non-TTY lockout path end-to-end, verifying the exception message, hint emission, and file immutability.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core fix is correct and well-tested; the only gap is a stale docstring that still promises the non-interactive branch never aborts.

The lockout guard is now correctly shared between both branches, and the new test faithfully covers the missing scenario. The `build_token_cache` docstring's "it never aborts" claim was not updated to reflect the new behavior, which could mislead callers who rely on the documented contract for the non-TTY path.

The `build_token_cache` docstring in `_cache_factory.py` needs updating to remove the "it never aborts" guarantee.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py | Adds `_abort_if_locked_out` helper shared between the interactive and non-interactive branches, correctly closing the lockout bypass. Logic is sound but the `build_token_cache` docstring still states "it never aborts" for the non-TTY path, which is now wrong. |
| tests/test_cache_factory.py | Adds `test_lockout_aborts_without_touching_file_non_interactive` covering the exact scenario that allowed F1 to go unnoticed; mirrors the existing interactive lockout test and correctly verifies exception message, hint emission, and file immutability. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build_token_cache] --> B{passphrase\nmaterial resolved?}
    B -- yes --> C[EncryptedFileTokenCache]
    B -- no --> D{console.isatty?}
    D -- yes --> E[_confirm_plaintext_or_abort]
    D -- no --> F[_abort_if_locked_out]
    E --> F2[_abort_if_locked_out]
    F --> G{cache state\n== encrypted?}
    F2 --> G
    G -- yes --> H[message hint\nraise TokenCacheError]
    G -- no --> I{caller?}
    I -- non-interactive --> J[_warn_plaintext_once\nFileTokenCache]
    I -- interactive --> K{ack_store\nacknowledged?}
    K -- yes --> L[FileTokenCache]
    K -- no --> M[show hint\nconfirm gate]
    M -- confirmed --> N[_offer_to_remember\nFileTokenCache]
    M -- declined --> O[raise TokenCacheError]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[build_token_cache] --> B{passphrase\nmaterial resolved?}
    B -- yes --> C[EncryptedFileTokenCache]
    B -- no --> D{console.isatty?}
    D -- yes --> E[_confirm_plaintext_or_abort]
    D -- no --> F[_abort_if_locked_out]
    E --> F2[_abort_if_locked_out]
    F --> G{cache state\n== encrypted?}
    F2 --> G
    G -- yes --> H[message hint\nraise TokenCacheError]
    G -- no --> I{caller?}
    I -- non-interactive --> J[_warn_plaintext_once\nFileTokenCache]
    I -- interactive --> K{ack_store\nacknowledged?}
    K -- yes --> L[FileTokenCache]
    K -- no --> M[show hint\nconfirm gate]
    M -- confirmed --> N[_offer_to_remember\nFileTokenCache]
    M -- declined --> O[raise TokenCacheError]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py`, line 82-96 ([link](https://github.com/stevenengland/nextlabs_rest_api/blob/3cd09917ac8e3217eeb6e397d92209a797cebc32/src/nextlabs_sdk/_auth/_token_cache/_cache_factory.py#L82-L96)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale "never aborts" guarantee in docstring**

   The docstring on `build_token_cache` still says: *"With no source and no TTY the cache falls back to plaintext … it never aborts."* That was the pre-fix contract; the PR explicitly breaks it by inserting `_abort_if_locked_out` before `_warn_plaintext_once`, so the non-interactive branch now raises `TokenCacheError` whenever the existing cache file is encrypted and no passphrase source resolves. Any caller that read this docstring and relied on the "never aborts" guarantee will be surprised at runtime.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%0ALine%3A%2082-96%0A%0AComment%3A%0A**Stale%20%22never%20aborts%22%20guarantee%20in%20docstring**%0A%0AThe%20docstring%20on%20%60build_token_cache%60%20still%20says%3A%20*%22With%20no%20source%20and%20no%20TTY%20the%20cache%20falls%20back%20to%20plaintext%20%E2%80%A6%20it%20never%20aborts.%22*%20That%20was%20the%20pre-fix%20contract%3B%20the%20PR%20explicitly%20breaks%20it%20by%20inserting%20%60_abort_if_locked_out%60%20before%20%60_warn_plaintext_once%60%2C%20so%20the%20non-interactive%20branch%20now%20raises%20%60TokenCacheError%60%20whenever%20the%20existing%20cache%20file%20is%20encrypted%20and%20no%20passphrase%20source%20resolves.%20Any%20caller%20that%20read%20this%20docstring%20and%20relied%20on%20the%20%22never%20aborts%22%20guarantee%20will%20be%20surprised%20at%20runtime.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=stevenengland%2Fnextlabs_rest_api&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fnextlabs_sdk%2F_auth%2F_token_cache%2F_cache_factory.py%3A82-96%0A**Stale%20%22never%20aborts%22%20guarantee%20in%20docstring**%0A%0AThe%20docstring%20on%20%60build_token_cache%60%20still%20says%3A%20*%22With%20no%20source%20and%20no%20TTY%20the%20cache%20falls%20back%20to%20plaintext%20%E2%80%A6%20it%20never%20aborts.%22*%20That%20was%20the%20pre-fix%20contract%3B%20the%20PR%20explicitly%20breaks%20it%20by%20inserting%20%60_abort_if_locked_out%60%20before%20%60_warn_plaintext_once%60%2C%20so%20the%20non-interactive%20branch%20now%20raises%20%60TokenCacheError%60%20whenever%20the%20existing%20cache%20file%20is%20encrypted%20and%20no%20passphrase%20source%20resolves.%20Any%20caller%20that%20read%20this%20docstring%20and%20relied%20on%20the%20%22never%20aborts%22%20guarantee%20will%20be%20surprised%20at%20runtime.%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): honor lockout guard in non-in..."](https://github.com/stevenengland/nextlabs_rest_api/commit/3cd09917ac8e3217eeb6e397d92209a797cebc32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41038458)</sub>

<!-- /greptile_comment -->