### PR TITLE
fix(diff): hide noise-subtree changes at any path segment (#293)

### DIFF
--- a/src/nextlabs_sdk/_cli/_diff/_engine.py
+++ b/src/nextlabs_sdk/_cli/_diff/_engine.py
@@ -53,6 +53,15 @@ _CROSS_POLICY_IDENTITY_FIELDS: frozenset[str] = frozenset(
 )
 
 
+def _is_noise_path(path: tuple[str, ...]) -> bool:
+    """Check whether any segment of a change path is a noise field.
+
+    A change beneath a noise field (e.g. ``deploymentRequest.id``) is noise
+    even though its own leaf name (``id``) is not itself a noise field.
+    """
+    return any(segment in _NOISE_FIELDS for segment in path)
+
+
 def canonicalise(payload: Mapping[str, object], *, show_all: bool = False) -> object:
     """Reduce a policy payload to a stable, comparison-ready form.
 
@@ -131,7 +140,7 @@ def diff_payloads(
     noise_changes = []
     visible_changes = []
     for change in changes:
-        if not show_all and change.path and change.path[-1] in _NOISE_FIELDS:
+        if not show_all and _is_noise_path(change.path):
             noise_changes.append(change)
         else:
             visible_changes.append(change)

--- a/tests/test_policy_diff_engine.py
+++ b/tests/test_policy_diff_engine.py
@@ -51,6 +51,37 @@ def test_deployment_noise_excluded_by_default():
     assert result.hidden_noise_count == 3
 
 
+def test_nested_noise_field_hidden_by_default():
+    """Given payloads differing only in a leaf nested under a noise field.
+
+    When diffing without show_all.
+    Then the nested change is hidden and counted as noise, even though the
+    differing leaf itself (``id``) is not a noise field name.
+    """
+    old = {"name": "P", "deploymentRequest": {"id": 1}}
+    new = {"name": "P", "deploymentRequest": {"id": 2}}
+
+    result = diff_payloads(old, new)
+
+    assert result.changes == ()
+    assert result.hidden_noise_count == 1
+
+
+def test_nested_noise_field_visible_with_show_all():
+    """Given the same nested noise-subtree change as the default-mode case.
+
+    When diffing with show_all.
+    Then the nested change is reported instead of hidden.
+    """
+    old = {"name": "P", "deploymentRequest": {"id": 1}}
+    new = {"name": "P", "deploymentRequest": {"id": 2}}
+
+    result = diff_payloads(old, new, show_all=True)
+
+    assert any(c.path == ("deploymentRequest", "id") for c in result.changes)
+    assert result.hidden_noise_count == 0
+
+
 def test_version_change_stays_visible():
     """Given payloads differing only in version.
 


### PR DESCRIPTION
Closes #293

## Summary
- `diff_payloads()` now hides a change anywhere beneath a noise field, not just when the noise field is the change's own leaf name (e.g. `deploymentRequest.id` is suppressed by default, same as a top-level `deploymentTime` change).
- Extracted the membership check into a small `_is_noise_path()` helper so the any-segment rule has one definition.
- Covered by two new tests: default-mode suppression of the nested case, and its visibility under `--show-all`.

## Tests added (red → green)
- `test_nested_noise_field_hidden_by_default`
- `test_nested_noise_field_visible_with_show_all`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where changes nested beneath a noise field (e.g., `deploymentRequest.id`) were not suppressed in `diff_payloads()` because the old check only examined the leaf segment of the change path. The fix extracts a `_is_noise_path()` helper that checks all path segments via `any()`.

- Replaces the leaf-only check `change.path[-1] in _NOISE_FIELDS` with `_is_noise_path(change.path)`, which returns `True` if any path segment is a noise field — correctly suppressing `deploymentRequest.id` and any other nested noise descendants.
- Adds two focused tests covering the default-mode suppression of a nested noise change and its visibility under `show_all=True`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted bug fix with no risk of unintended side effects.

The old leaf-only check `change.path[-1] in _NOISE_FIELDS` left nested noise changes (e.g. `deploymentRequest.id`) visible when they should be hidden. The new helper correctly walks all path segments. The empty-path edge case is handled safely by `any()` returning `False` on an empty tuple, matching the behaviour of the old `change.path and …` guard. Two new tests directly cover the red→green scenario and the `show_all` escape hatch.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_diff/_engine.py | Adds `_is_noise_path()` helper and updates the noise-filtering condition in `diff_payloads()` to check all path segments instead of only the leaf; logic is correct and safe. |
| tests/test_policy_diff_engine.py | Adds two well-structured tests covering the bug scenario (nested noise hidden by default) and its `show_all` counterpart; both assertions are correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[diff_payloads called] --> B[_diff_dicts builds changes list]
    B --> C{For each FieldChange}
    C --> D{show_all=True?}
    D -- Yes --> E[→ visible_changes]
    D -- No --> F[_is_noise_path change.path]
    F --> G{"any(segment in _NOISE_FIELDS\nfor segment in path)?"}
    G -- True\ne.g. deploymentRequest.id --> H[→ noise_changes\nhidden_noise_count++]
    G -- False\ne.g. name, version --> E
    E --> I[DiffResult.changes]
    H --> J[DiffResult.hidden_noise_count]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[diff_payloads called] --> B[_diff_dicts builds changes list]
    B --> C{For each FieldChange}
    C --> D{show_all=True?}
    D -- Yes --> E[→ visible_changes]
    D -- No --> F[_is_noise_path change.path]
    F --> G{"any(segment in _NOISE_FIELDS\nfor segment in path)?"}
    G -- True\ne.g. deploymentRequest.id --> H[→ noise_changes\nhidden_noise_count++]
    G -- False\ne.g. name, version --> E
    E --> I[DiffResult.changes]
    H --> J[DiffResult.hidden_noise_count]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(diff): hide noise-subtree changes at..."](https://github.com/stevenengland/nextlabs_rest_api/commit/134e34ed3337ae711b4f4ba3916f1e4f3e3dc2d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41045300)</sub>

<!-- /greptile_comment -->