### PR TITLE
feat(cli): add components history and view-revision commands (#192)

### DIFF
--- a/src/nextlabs_sdk/_cli/_components_cmd.py
+++ b/src/nextlabs_sdk/_cli/_components_cmd.py
@@ -54,6 +54,30 @@ _DEPENDENCY_COLUMNS = (
     ColumnDef("Folder Path", "folder_path"),
 )
 
+_HISTORY_COLUMNS = (
+    ColumnDef("Revision", "revision"),
+    ColumnDef("Action", "action_type"),
+    ColumnDef("Created By", "created_by"),
+    ColumnDef("Modified By", "modified_by"),
+    ColumnDef("Active From", "active_from"),
+    ColumnDef("Active To", "active_to"),
+)
+
+_HISTORY_WIDE_COLUMNS: tuple[ColumnDef, ...] = (
+    _ID_COLUMN,
+    ColumnDef("Submitted By", "submitted_by"),
+    ColumnDef("Submitted Date", "submitted_date"),
+)
+
+_REVISION_COLUMNS = (
+    _ID_COLUMN,
+    ColumnDef("Revision", "revision"),
+    _NAME_COLUMN,
+    ColumnDef("Action", "action_type"),
+    ColumnDef("Created By", "created_by"),
+    ColumnDef("Modified By", "modified_by"),
+)
+
 
 @components_app.command()
 @cli_error_handler
@@ -135,6 +159,39 @@ def find_dependencies(
     client = _client_factory.make_cloudaz_client(cli_ctx)
     deps = client.components.find_dependencies([component_id])
     render(cli_ctx, deps, _DEPENDENCY_COLUMNS, title="Dependencies")
+
+
+@components_app.command()
+@cli_error_handler
+def history(
+    ctx: typer.Context,
+    component_id: Annotated[int, typer.Argument(help="Component ID")],
+) -> None:
+    """List the revision history of a component."""
+    cli_ctx: CliContext = ctx.obj
+    client = _client_factory.make_cloudaz_client(cli_ctx)
+    entries = client.components.list_history(component_id)
+    render(
+        cli_ctx,
+        entries,
+        _HISTORY_COLUMNS,
+        title="Component History",
+        wide_columns=_HISTORY_WIDE_COLUMNS,
+    )
+
+
+@components_app.command(name="view-revision")
+@cli_error_handler
+def view_revision(
+    ctx: typer.Context,
+    revision_id: Annotated[int, typer.Argument(help="Revision ID")],
+    revision: Annotated[int, typer.Argument(help="Revision number")] = 0,
+) -> None:
+    """View a specific revision of a component."""
+    cli_ctx: CliContext = ctx.obj
+    client = _client_factory.make_cloudaz_client(cli_ctx)
+    rev = client.components.get_revision(revision_id, revision)
+    render(cli_ctx, rev, _REVISION_COLUMNS)
 
 
 @components_app.command()

--- a/tests/test_cli_components.py
+++ b/tests/test_cli_components.py
@@ -19,6 +19,8 @@ from nextlabs_sdk.cloudaz import (
 )
 from nextlabs_sdk._cloudaz._component_models import (
     ComponentGroupType,
+    ComponentHistoryEntry,
+    ComponentRevision,
     ComponentStatus,
     DeploymentResult,
 )
@@ -357,3 +359,153 @@ def test_components_find_dependencies(stub: tuple[Any, Any, Any]) -> None:
 
     assert result.exit_code == 0, result.output
     assert "PolA" in result.output
+
+
+def _make_history_entry() -> ComponentHistoryEntry:
+    return ComponentHistoryEntry(
+        id=1,
+        revision=3,
+        name="Host Name",
+        action_type="DEPLOY",
+        created_by="admin",
+        modified_by="editor",
+        active_from=1700000000,
+        active_to=1700003600,
+    )
+
+
+def _make_component_revision() -> ComponentRevision:
+    return ComponentRevision(
+        id=1,
+        revision=3,
+        name="Host Name",
+        action_type="DEPLOY",
+        created_by="admin",
+        modified_by="editor",
+        active_from=1700000000,
+        active_to=1700003600,
+        component_detail=_make_component(),
+    )
+
+
+# --- history (table vs json) ---
+
+
+def test_components_history_table(stub: tuple[Any, Any, Any]) -> None:
+    """Given a component with revision history, when `history` is invoked
+    in table mode, then a titled table shows audit-relevant fields."""
+    _, mock_comp, _ = stub
+    entries = [_make_history_entry()]
+    when(mock_comp).list_history(1).thenReturn(entries)
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "components", "history", "1"])
+
+    assert result.exit_code == 0, result.output
+    output = strip_ansi(result.output)
+    assert "DEPLOY" in output
+    assert "admin" in output
+    assert "editor" in output
+
+
+def test_components_history_json(stub: tuple[Any, Any, Any]) -> None:
+    """Given a component with revision history, when `history --output
+    json` is invoked, then the raw list of history entries is emitted as
+    JSON."""
+    _, mock_comp, _ = stub
+    entries = [_make_history_entry()]
+    when(mock_comp).list_history(1).thenReturn(entries)
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "--output", "json", "components", "history", "1"]
+    )
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, list)
+    assert parsed[0]["revision"] == 3
+    assert parsed[0]["action_type"] == "DEPLOY"
+
+
+# --- view-revision (table vs json) ---
+
+
+def test_components_view_revision_table(stub: tuple[Any, Any, Any]) -> None:
+    """Given a valid revision, when `view-revision` is invoked in table
+    mode, then key identifying fields are rendered as a table."""
+    _, mock_comp, _ = stub
+    when(mock_comp).get_revision(1, 3).thenReturn(_make_component_revision())
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "components", "view-revision", "1", "3"]
+    )
+
+    assert result.exit_code == 0, result.output
+    output = strip_ansi(result.output)
+    assert "DEPLOY" in output
+    assert "admin" in output
+
+
+def test_components_view_revision_json(stub: tuple[Any, Any, Any]) -> None:
+    """Given a valid revision, when `view-revision --output json` is
+    invoked, then the full ComponentRevision including componentDetail is
+    emitted."""
+    _, mock_comp, _ = stub
+    when(mock_comp).get_revision(1, 3).thenReturn(_make_component_revision())
+
+    result = runner.invoke(
+        app,
+        [*_GLOBAL_OPTS, "--output", "json", "components", "view-revision", "1", "3"],
+    )
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["revision"] == 3
+    assert "component_detail" in parsed
+    assert parsed["component_detail"]["name"] == "Host Name"
+
+
+def test_components_view_revision_defaults_revision_to_zero(
+    stub: tuple[Any, Any, Any],
+) -> None:
+    """Given only a revision_id, when `view-revision` is invoked without a
+    revision number, then revision defaults to 0."""
+    _, mock_comp, _ = stub
+    when(mock_comp).get_revision(1, 0).thenReturn(_make_component_revision())
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "components", "view-revision", "1"])
+
+    assert result.exit_code == 0, result.output
+    output = strip_ansi(result.output)
+    assert "admin" in output
+
+
+# --- error handling (history + view-revision) ---
+
+
+def test_components_history_not_found(stub: tuple[Any, Any, Any]) -> None:
+    """Given a non-existent component ID, when `history` is invoked, then
+    the error handler surfaces a non-zero exit code with no traceback."""
+    _, mock_comp, _ = stub
+    when(mock_comp).list_history(999).thenRaise(NotFoundError(message="HTTP 404"))
+
+    result = runner.invoke(app, [*_GLOBAL_OPTS, "components", "history", "999"])
+
+    assert result.exit_code == 1
+    assert "Not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_components_view_revision_not_found(stub: tuple[Any, Any, Any]) -> None:
+    """Given a non-existent revision, when `view-revision` is invoked,
+    then the error handler surfaces a non-zero exit code with no
+    traceback."""
+    _, mock_comp, _ = stub
+    when(mock_comp).get_revision(999, 1).thenRaise(NotFoundError(message="HTTP 404"))
+
+    result = runner.invoke(
+        app, [*_GLOBAL_OPTS, "components", "view-revision", "999", "1"]
+    )
+
+    assert result.exit_code == 1
+    assert "Not found" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
Closes #192

## Summary
- Added `components history <component_id>` and `components view-revision <revision_id> <revision>` to the existing `components_app` Typer group, mirroring the policies slice (#191).
- Tested with `CliRunner` + `mockito`: table and JSON output for both commands, default-revision behavior, and `NotFoundError` surfacing with no raw traceback.
- No new SDK behavior — pure presentation layer reusing `render`/`ColumnDef` and the global `--output` option.

## Tests added (red → green)
- `test_components_history_table`
- `test_components_history_json`
- `test_components_view_revision_table`
- `test_components_view_revision_json`
- `test_components_view_revision_defaults_revision_to_zero`
- `test_components_history_not_found`
- `test_components_view_revision_not_found`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `components history` and `components view-revision` CLI commands to the existing `components_app` Typer group, directly mirroring the previously merged policies slice. No new SDK behaviour is introduced — the commands wire up `client.components.list_history` and `client.components.get_revision` through the shared `render`/`ColumnDef` infrastructure already used by every other command in the group.

- Adds `_HISTORY_COLUMNS`, `_HISTORY_WIDE_COLUMNS`, and `_REVISION_COLUMNS` column definitions, plus the two decorated command functions with correct `cli_error_handler` wrapping and `title`/`wide_columns` args consistent with the rest of the file.
- Adds seven tests covering table output, JSON output, the default-revision-zero behaviour, and `NotFoundError` propagation for both commands, using `mockito` stubs and `CliRunner` as required by the project's testing conventions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the two new commands are a straightforward port of the policies slice with no new SDK behaviour and good test coverage.

The implementation is clean and consistent with the established pattern. The only issue is that `ComponentHistoryEntry` and `ComponentRevision` are imported from an internal module in the test file even though both are exported from the public `nextlabs_sdk.cloudaz` surface — a minor architecture-convention violation that is easy to fix.

tests/test_cli_components.py — the two new imports should be moved to the existing public-surface import block.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cli/_components_cmd.py | Adds `history` and `view-revision` commands with correct column definitions, error handling via `cli_error_handler`, and consistent `render` calls mirroring the policies slice exactly. |
| tests/test_cli_components.py | Seven new tests cover table/JSON output, default-revision behaviour, and `NotFoundError` propagation; `ComponentHistoryEntry`/`ComponentRevision` are imported from an internal module even though both are available on the public `nextlabs_sdk.cloudaz` surface. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant CLI as components_app (Typer)
    participant EH as cli_error_handler
    participant CF as _client_factory
    participant SDK as ComponentService

    User->>CLI: "components history <component_id>"
    CLI->>EH: wrap call
    EH->>CF: make_cloudaz_client(cli_ctx)
    CF-->>EH: client
    EH->>SDK: list_history(component_id)
    SDK-->>EH: List[ComponentHistoryEntry]
    EH->>CLI: render(cli_ctx, entries, _HISTORY_COLUMNS, title, wide_columns)
    CLI-->>User: table or JSON output

    User->>CLI: "components view-revision <revision_id> [revision=0]"
    CLI->>EH: wrap call
    EH->>CF: make_cloudaz_client(cli_ctx)
    CF-->>EH: client
    EH->>SDK: get_revision(revision_id, revision)
    SDK-->>EH: ComponentRevision
    EH->>CLI: render(cli_ctx, rev, _REVISION_COLUMNS)
    CLI-->>User: table or JSON output
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant CLI as components_app (Typer)
    participant EH as cli_error_handler
    participant CF as _client_factory
    participant SDK as ComponentService

    User->>CLI: "components history <component_id>"
    CLI->>EH: wrap call
    EH->>CF: make_cloudaz_client(cli_ctx)
    CF-->>EH: client
    EH->>SDK: list_history(component_id)
    SDK-->>EH: List[ComponentHistoryEntry]
    EH->>CLI: render(cli_ctx, entries, _HISTORY_COLUMNS, title, wide_columns)
    CLI-->>User: table or JSON output

    User->>CLI: "components view-revision <revision_id> [revision=0]"
    CLI->>EH: wrap call
    EH->>CF: make_cloudaz_client(cli_ctx)
    CF-->>EH: client
    EH->>SDK: get_revision(revision_id, revision)
    SDK-->>EH: ComponentRevision
    EH->>CLI: render(cli_ctx, rev, _REVISION_COLUMNS)
    CLI-->>User: table or JSON output
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_cli_components.py`, line 13-26 ([link](https://github.com/stevenengland/nextlabs_rest_api/blob/ec921fec45e19e2db05ecd4abda1e288603c75fe/tests/test_cli_components.py#L13-L26)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `ComponentHistoryEntry` and `ComponentRevision` are imported from the internal `_cloudaz._component_models` module, but both are already re-exported from the public `nextlabs_sdk.cloudaz` surface. CLAUDE.md / AGENTS.md explicitly state "Underscore modules internal — no imports from tests, examples, docs," so these two should move to the existing public import block.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/england-com-de/github/stevenengland/nextlabs_rest_api/-/custom-context?memory=84b9142f-5c02-42c7-9a88-6bc0319bd46d))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Ftest_cli_components.py%0ALine%3A%2013-26%0A%0AComment%3A%0A%60ComponentHistoryEntry%60%20and%20%60ComponentRevision%60%20are%20imported%20from%20the%20internal%20%60_cloudaz._component_models%60%20module%2C%20but%20both%20are%20already%20re-exported%20from%20the%20public%20%60nextlabs_sdk.cloudaz%60%20surface.%20CLAUDE.md%20%2F%20AGENTS.md%20explicitly%20state%20%22Underscore%20modules%20internal%20%E2%80%94%20no%20imports%20from%20tests%2C%20examples%2C%20docs%2C%22%20so%20these%20two%20should%20move%20to%20the%20existing%20public%20import%20block.%0A%0A%60%60%60suggestion%0Afrom%20nextlabs_sdk.cloudaz%20import%20%28%0A%20%20%20%20CloudAzClient%2C%0A%20%20%20%20Component%2C%0A%20%20%20%20ComponentHistoryEntry%2C%0A%20%20%20%20ComponentLite%2C%0A%20%20%20%20ComponentRevision%2C%0A%20%20%20%20ComponentSearchService%2C%0A%20%20%20%20ComponentService%2C%0A%29%0Afrom%20nextlabs_sdk._cloudaz._component_models%20import%20%28%0A%20%20%20%20ComponentGroupType%2C%0A%20%20%20%20ComponentStatus%2C%0A%20%20%20%20DeploymentResult%2C%0A%29%0A%60%60%60%0A%0A**Context%20Used%3A**%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fengland-com-de%2Fgithub%2Fstevenengland%2Fnextlabs_rest_api%2F-%2Fcustom-context%3Fmemory%3D84b9142f-5c02-42c7-9a88-6bc0319bd46d%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=stevenengland%2Fnextlabs_rest_api&pr=295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Ftest_cli_components.py%3A13-26%0A%60ComponentHistoryEntry%60%20and%20%60ComponentRevision%60%20are%20imported%20from%20the%20internal%20%60_cloudaz._component_models%60%20module%2C%20but%20both%20are%20already%20re-exported%20from%20the%20public%20%60nextlabs_sdk.cloudaz%60%20surface.%20CLAUDE.md%20%2F%20AGENTS.md%20explicitly%20state%20%22Underscore%20modules%20internal%20%E2%80%94%20no%20imports%20from%20tests%2C%20examples%2C%20docs%2C%22%20so%20these%20two%20should%20move%20to%20the%20existing%20public%20import%20block.%0A%0A%60%60%60suggestion%0Afrom%20nextlabs_sdk.cloudaz%20import%20%28%0A%20%20%20%20CloudAzClient%2C%0A%20%20%20%20Component%2C%0A%20%20%20%20ComponentHistoryEntry%2C%0A%20%20%20%20ComponentLite%2C%0A%20%20%20%20ComponentRevision%2C%0A%20%20%20%20ComponentSearchService%2C%0A%20%20%20%20ComponentService%2C%0A%29%0Afrom%20nextlabs_sdk._cloudaz._component_models%20import%20%28%0A%20%20%20%20ComponentGroupType%2C%0A%20%20%20%20ComponentStatus%2C%0A%20%20%20%20DeploymentResult%2C%0A%29%0A%60%60%60%0A%0A&repo=stevenengland%2Fnextlabs_rest_api&pr=295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add components history and vi..."](https://github.com/stevenengland/nextlabs_rest_api/commit/ec921fec45e19e2db05ecd4abda1e288603c75fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41048031)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/england-com-de/github/stevenengland/nextlabs_rest_api/-/custom-context?memory=84b9142f-5c02-42c7-9a88-6bc0319bd46d))
- Context used - CLAUDE.md ([source](https://app.greptile.com/england-com-de/github/stevenengland/nextlabs_rest_api/-/custom-context?memory=eb657e36-5b80-4b41-825d-1bf44deafd44))

<!-- /greptile_comment -->