### PR TITLE
fix(search): make scim2-filter-parser CLI-only again

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@
   `RequestTimeoutError`, `TransportError`, and `ApiError` — all
   subclasses of `NextLabsError`.
 - **Pagination helpers** — `SyncPaginator` / `AsyncPaginator` iterate
-  listed endpoints page-by-page or item-by-item.
+  listed endpoints item-by-item, with `first_page()` exposing page
+  metadata.
 - **Optional CLI** — a `nextlabs` command (Typer + Rich) for scripting,
   admin tasks, and quick exploration. Persistent OIDC token cache, four
   output formats (`table` / `wide` / `detail` / `json`), per-call
@@ -64,7 +65,10 @@ pip install "nextlabs-sdk[cli]"     # + nextlabs CLI (Typer, Rich)
 
 If you install the library without the `[cli]` extra, the `nextlabs`
 command is still registered but will print a friendly error pointing at
-`pip install 'nextlabs-sdk[cli]'` and exit with status `1`.
+`pip install 'nextlabs-sdk[cli]'` and exit with status `1`. The extra also
+supplies `scim2-filter-parser`, which the SCIM `--where` policy search
+(`transpile_where`) requires; calling it without the extra raises a
+`SearchExpressionError` pointing at the same install command.
 
 Requires Python **3.11+**.
 
@@ -147,14 +151,15 @@ subject may perform on a resource.
 ### Pagination
 
 `SyncPaginator` / `AsyncPaginator` are returned by every list method.
-Iterate page-by-page (`.pages()`) or item-by-item (default `__iter__`):
+Iterate item-by-item (default `__iter__`, which walks every page), or grab
+the first `PageResult` for its metadata:
 
 ```python
 for tag in client.tags.list(TagType.COMPONENT):       # one item at a time
     ...
 
-for page in client.tags.list(TagType.COMPONENT).pages():
-    print(page.total, len(page.items))                # PageResult metadata
+page = client.tags.list(TagType.COMPONENT).first_page()
+print(page.total_records, len(page.entries))          # PageResult metadata
 ```
 
 ### Error handling

--- a/src/nextlabs_sdk/_cloudaz/_search/where.py
+++ b/src/nextlabs_sdk/_cloudaz/_search/where.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import Any, cast
-
-from scim2_filter_parser.ast import AttrExpr, AttrPath, Filter, LogExpr
-from scim2_filter_parser.lexer import SCIMLexer
-from scim2_filter_parser.parser import SCIMParser, SCIMParserError
+from typing import TYPE_CHECKING, Any, cast
 
 from nextlabs_sdk._cloudaz._search.criteria import SearchField, SearchFieldType
 from nextlabs_sdk._cloudaz._search.dates import (
@@ -19,6 +15,14 @@ from nextlabs_sdk._cloudaz._search.payloads import (
     text_payload,
 )
 from nextlabs_sdk.exceptions import SearchExpressionError
+
+if TYPE_CHECKING:
+    from scim2_filter_parser.ast import AttrExpr, Filter, LogExpr
+
+_SCIM_EXTRA_HINT = (
+    "SCIM --where filtering requires the optional 'scim2-filter-parser' "
+    "package. Install it with: pip install 'nextlabs-sdk[cli]'"
+)
 
 _TEXT_ATTR = "text"
 _FROM_DATE = "fromDate"
@@ -77,25 +81,31 @@ def transpile_where(expr: str) -> list[SearchField]:
 
 def _parse(expr: str) -> Filter:
     try:
-        tree = SCIMParser().parse(SCIMLexer().tokenize(expr))
-    except (SCIMParserError, ValueError) as exc:
+        from scim2_filter_parser import ast as scim_ast, lexer, parser
+    except ImportError:
+        raise SearchExpressionError(_SCIM_EXTRA_HINT) from None
+    try:
+        tree = parser.SCIMParser().parse(lexer.SCIMLexer().tokenize(expr))
+    except (parser.SCIMParserError, ValueError) as exc:
         raise SearchExpressionError(
             f"could not parse --where filter: {expr!r}",
         ) from exc
-    return cast(Filter, tree)
+    return cast(scim_ast.Filter, tree)
 
 
 def _transpile_filter(node: Filter) -> list[SearchField]:
+    from scim2_filter_parser import ast as scim_ast
+
     if node.negated:
         raise _cross_field_error()
     inner = node.expr
-    if isinstance(inner, Filter):
+    if isinstance(inner, scim_ast.Filter):
         if inner.namespace is not None:
             return [_nested_field(inner)]
         return _transpile_filter(inner)
-    if isinstance(inner, AttrExpr):
+    if isinstance(inner, scim_ast.AttrExpr):
         return [_scalar_field(inner)]
-    if isinstance(inner, LogExpr):
+    if isinstance(inner, scim_ast.LogExpr):
         return _transpile_log(inner)
     raise SearchExpressionError("unsupported --where expression")
 
@@ -110,9 +120,11 @@ def _transpile_log(node: LogExpr) -> list[SearchField]:
 
 
 def _nested_field(node: Filter) -> SearchField:
-    namespace = cast(AttrPath, node.namespace)
+    from scim2_filter_parser import ast as scim_ast
+
+    namespace = cast(scim_ast.AttrPath, node.namespace)
     base = namespace.attr_name
-    terms = _flatten_or_side(cast(Filter, node.expr))
+    terms = _flatten_or_side(cast(scim_ast.Filter, node.expr))
     sub_names = {term.attr_path.attr_name for term in terms}
     if len(sub_names) != 1:
         raise SearchExpressionError(
@@ -162,14 +174,16 @@ def _flatten_or(node: LogExpr) -> list[AttrExpr]:
 
 
 def _flatten_or_side(node: Filter) -> list[AttrExpr]:
+    from scim2_filter_parser import ast as scim_ast
+
     if node.negated:
         raise _cross_field_error()
     inner = node.expr
-    if isinstance(inner, Filter):
+    if isinstance(inner, scim_ast.Filter):
         return _flatten_or_side(inner)
-    if isinstance(inner, AttrExpr):
+    if isinstance(inner, scim_ast.AttrExpr):
         return [inner]
-    if isinstance(inner, LogExpr) and inner.op.lower() == "or":
+    if isinstance(inner, scim_ast.LogExpr) and inner.op.lower() == "or":
         return _flatten_or(inner)
     raise _cross_field_error()
 

--- a/tests/test_search_optional_scim.py
+++ b/tests/test_search_optional_scim.py
@@ -1,0 +1,67 @@
+"""Library-only import must not require the optional scim2 dependency."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+from nextlabs_sdk.exceptions import SearchExpressionError
+
+_WHERE_MODULE = "nextlabs_sdk._cloudaz._search.where"
+_FIELD_MODULE = "nextlabs_sdk._cloudaz._search.field_expr"
+
+
+def _block_scim2(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "scim2_filter_parser" or name.startswith("scim2_filter_parser."):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    for cached in list(sys.modules):
+        if cached == "scim2_filter_parser" or cached.startswith("scim2_filter_parser."):
+            monkeypatch.delitem(sys.modules, cached, raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_where_module_imports_without_scim2(monkeypatch):
+    # given scim2-filter-parser is not installed
+    _block_scim2(monkeypatch)
+    monkeypatch.delitem(sys.modules, _WHERE_MODULE, raising=False)
+
+    # when the where module is imported
+    module = importlib.import_module(_WHERE_MODULE)
+
+    # then import succeeds and still exposes the public entry point
+    assert hasattr(module, "transpile_where")
+
+
+def test_transpile_where_without_scim2_raises_friendly_error(monkeypatch):
+    # given the where module is loaded while scim2 is unavailable
+    _block_scim2(monkeypatch)
+    monkeypatch.delitem(sys.modules, _WHERE_MODULE, raising=False)
+    module = importlib.import_module(_WHERE_MODULE)
+
+    # when a --where filter is transpiled
+    with pytest.raises(SearchExpressionError) as excinfo:
+        module.transpile_where('name eq "x"')
+
+    # then the error points the user at the optional [cli] extra
+    assert "nextlabs-sdk[cli]" in str(excinfo.value)
+
+
+def test_parse_field_expr_works_without_scim2(monkeypatch):
+    # given scim2-filter-parser is not installed
+    _block_scim2(monkeypatch)
+    monkeypatch.delitem(sys.modules, _FIELD_MODULE, raising=False)
+
+    # when a --field expression is parsed
+    module = importlib.import_module(_FIELD_MODULE)
+    parsed = module.parse_field_expr("status=DRAFT")
+
+    # then it succeeds without the scim2 dependency
+    assert parsed.field == "status"


### PR DESCRIPTION
## Summary

`scim2-filter-parser` is declared only in the optional `[cli]` extra, but
`_cloudaz/_search/where.py` imported it at module scope. Because that module is
reachable from the public package root, a plain `pip install nextlabs-sdk`
(without `[cli]`) failed on `import nextlabs_sdk` with
`ModuleNotFoundError: No module named 'scim2_filter_parser'`.

This defers the parser import to the point of use so the optional dependency
stays CLI-only, as declared.

## Changes

- Move the three `scim2_filter_parser` imports out of module scope into the
  functions that use them (`transpile_where` and the AST walkers); keep the
  type-only names under a `TYPE_CHECKING` guard so annotations and static
  analysis are unchanged.
- When the parser is absent, `transpile_where` raises `SearchExpressionError`
  with a `pip install 'nextlabs-sdk[cli]'` hint instead of a raw
  `ModuleNotFoundError`.
- Add `tests/test_search_optional_scim.py` pinning: import works without the
  parser, `transpile_where` raises the friendly error, and `--field` parsing
  keeps working.
- README: note that the `[cli]` extra supplies `scim2-filter-parser` for
  `--where` search.

## Invariants

- Public API unchanged; `scim2-filter-parser` stays in the `[cli]` extra (no
  dependency-manifest change).
- Behavior is identical when the extra is installed.
- Errors stay within the `NextLabsError` hierarchy.

Closes #305

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `ModuleNotFoundError` that occurred on `import nextlabs_sdk` when `scim2-filter-parser` was absent (i.e., the `[cli]` extra was not installed), by deferring all imports of that package from module scope to their call sites.

- **`where.py`**: The three `scim2_filter_parser` imports are moved into the functions that need them (`_parse`, `_transpile_filter`, `_nested_field`, `_flatten_or_side`). `_parse` now catches `ImportError` and raises a `SearchExpressionError` with an actionable install hint; the remaining helpers rely on module caching after `_parse` succeeds. Type-only names (`AttrExpr`, `Filter`, `LogExpr`) are preserved under a `TYPE_CHECKING` guard so static analysis is unaffected.
- **`tests/test_search_optional_scim.py`**: Three new tests pin the contract: module-level import succeeds without `scim2-filter-parser`, `transpile_where` raises the friendly error when the parser is absent, and `--field` parsing remains unaffected.
- **`README.md`**: Documentation is updated to reflect the deferred-import behaviour and to align the pagination examples with the current `PageResult` API (`first_page()`, `entries`, `total_records`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted deferral of optional imports with no public API surface changes and no dependency-manifest modifications.

The fix is narrow and correct. The only code that changes at runtime is the import location and a new ImportError → SearchExpressionError mapping in _parse. The remaining helpers import scim_ast from the module cache after _parse has already verified availability, so they are unreachable when the extra is absent. Three new tests confirm the contract. The README pagination update was verified against the live _pagination.py API.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nextlabs_sdk/_cloudaz/_search/where.py | Lazy imports of scim2_filter_parser moved into function bodies; ImportError in _parse() mapped to SearchExpressionError with install hint; TYPE_CHECKING guard preserves static analysis coverage. |
| tests/test_search_optional_scim.py | New test file covering module-level import without scim2, friendly error from transpile_where, and field_expr independence — all using builtins.__import__ patching to simulate a missing optional dep. |
| README.md | Documents the scim2-filter-parser CLI-extra requirement; also updates pagination examples to match the current PageResult API (first_page(), entries, total_records). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["transpile_where(expr)"] --> B["_parse(expr)"]
    B --> C{"scim2_filter_parser\navailable?"}
    C -- "No (ImportError)" --> D["raise SearchExpressionError\n(pip install hint)"]
    C -- "Yes" --> E["SCIMParser().parse(...)"]
    E --> F{"Parse\nsucceeds?"}
    F -- "No (SCIMParserError / ValueError)" --> G["raise SearchExpressionError\n(malformed filter)"]
    F -- "Yes" --> H["return Filter AST node"]
    H --> I["_transpile_filter(node)\n(imports scim_ast from cache)"]
    I --> J{"node type?"}
    J -- "Filter (nested)" --> K["_nested_field(node)"]
    J -- "AttrExpr" --> L["_scalar_field(node)"]
    J -- "LogExpr" --> M["_transpile_log(node)"]
    M -- "and" --> N["_transpile_filter x2"]
    M -- "or" --> O["_or_group_field -> _flatten_or -> _flatten_or_side"]
    I --> P["_merge_date_windows(fields)"]
    K --> P
    L --> P
    N --> P
    O --> P
    P --> Q["list[SearchField]"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["transpile_where(expr)"] --> B["_parse(expr)"]
    B --> C{"scim2_filter_parser\navailable?"}
    C -- "No (ImportError)" --> D["raise SearchExpressionError\n(pip install hint)"]
    C -- "Yes" --> E["SCIMParser().parse(...)"]
    E --> F{"Parse\nsucceeds?"}
    F -- "No (SCIMParserError / ValueError)" --> G["raise SearchExpressionError\n(malformed filter)"]
    F -- "Yes" --> H["return Filter AST node"]
    H --> I["_transpile_filter(node)\n(imports scim_ast from cache)"]
    I --> J{"node type?"}
    J -- "Filter (nested)" --> K["_nested_field(node)"]
    J -- "AttrExpr" --> L["_scalar_field(node)"]
    J -- "LogExpr" --> M["_transpile_log(node)"]
    M -- "and" --> N["_transpile_filter x2"]
    M -- "or" --> O["_or_group_field -> _flatten_or -> _flatten_or_side"]
    I --> P["_merge_date_windows(fields)"]
    K --> P
    L --> P
    N --> P
    O --> P
    P --> Q["list[SearchField]"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): defer scim2-filter-parser i..."](https://github.com/stevenengland/nextlabs_rest_api/commit/fcb94eecc22d0a1503c7fc885da4cda9fdd19c7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42665054)</sub>

<!-- /greptile_comment -->